### PR TITLE
chore: fix homebrew cmd

### DIFF
--- a/.github/workflows/pkg-version-bump.yaml
+++ b/.github/workflows/pkg-version-bump.yaml
@@ -33,7 +33,7 @@ jobs:
           brew bump-formula-pr \
             --no-browse \
             --no-audit \
-            --url https://github.com/${{ github.repository }}/archive/${TAG}.tar.gz \
+            --tag "${TAG}"
             ${{ github.event.repository.name }}
 
   winget:


### PR DESCRIPTION
Clone the git repo (and submodules) and build from source instead of downloading the tar.gz file to build from source.

Do not run this until https://github.com/Homebrew/homebrew-core/pull/87534 is merged.

Closes https://github.com/hirosystems/clarinet/issues/140