### PR TITLE
feat: upgrade clarinet-sdk templates

### DIFF
--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -500,8 +500,8 @@ btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"
     "@stacks/transactions": "^6.9.0",
     "chokidar-cli": "^3.0.0",
     "typescript": "^5.2.2",
-    "vite": "^4.4.9",
-    "vitest": "^0.34.4",
+    "vite": "^5.0.6",
+    "vitest": "^1.0.1",
     "vitest-environment-clarinet": "^1.0.0"
   }}
 }}

--- a/components/clarinet-sdk/templates/package.json
+++ b/components/clarinet-sdk/templates/package.json
@@ -15,8 +15,8 @@
     "@stacks/transactions": "^6.9.0",
     "chokidar-cli": "^3.0.0",
     "typescript": "^5.2.2",
-    "vite": "^4.4.9",
-    "vitest": "^0.34.4",
+    "vite": "^5.0.6",
+    "vitest": "^1.0.1",
     "vitest-environment-clarinet": "^1.0.0"
   }
 }


### PR DESCRIPTION
Upgrade clarinet project templates to use vite 5 and vitest 1