### PR TITLE
fix: Resolve duplicate contract name conflicts in requirements

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -523,8 +523,18 @@ pub async fn generate_default_deployment(
                             _ => {}
                         }
 
+                        // Create unique contract name by appending issuer address
+                        let unique_contract_name = format!("{}-{}", 
+                            contract_id.name,
+                            contract_id.issuer.to_address().replace(".", "-")
+                        );
+                        let unique_contract_id = QualifiedContractIdentifier::new(
+                            default_deployer_address.clone(),
+                            ContractName::try_from(unique_contract_name).unwrap(),
+                        );
+
                         let data = RequirementPublishSpecification {
-                            contract_id: contract_id.clone(),
+                            contract_id: unique_contract_id,
                             remap_sender: default_deployer_address.clone(),
                             source: source.clone(),
                             location: contract_location,
@@ -548,8 +558,18 @@ pub async fn generate_default_deployment(
                             );
                         }
 
+                        // Create unique contract name by appending issuer address
+                        let unique_contract_name = format!("{}-{}", 
+                            contract_id.name,
+                            contract_id.issuer.to_address().replace(".", "-")
+                        );
+                        let unique_contract_id = QualifiedContractIdentifier::new(
+                            remap_sender.clone(),
+                            ContractName::try_from(unique_contract_name).unwrap(),
+                        );
+
                         let data = RequirementPublishSpecification {
-                            contract_id: contract_id.clone(),
+                            contract_id: unique_contract_id,
                             remap_sender,
                             source: source.clone(),
                             location: contract_location,


### PR DESCRIPTION
Problem:
When a project has multiple requirement contracts with the same name (e.g. `nft-trait` from both mainnet and testnet), the second deployment fails because it tries to use the same contract name under the default deployer address.

Solution:
- Append the original issuer's address to the contract name to ensure uniqueness
- Keep using the default deployer address for deployment
- Maintain all existing remapping functionality

Example:
```bash
# Original commands that would fail
clarinet requirements add SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait
clarinet requirements add ST1NXBK3K5YYMD6FD41MVNP3JS1GABZ8TRVX023PT.nft-trait

# Now deploys as:
 default_deployer.nft-trait-SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9
 default_deployer.nft-trait-ST1NXBK3K5YYMD6FD41MVNP3JS1GABZ8TRVX023PT
```

This change ensures that:
1. Each requirement contract has a unique name
2. The original contract identity is preserved in the name
3. All contracts are still deployed under the default deployer
4. The remapping system continues to work as expected

Fixes #948