### PR TITLE
perf: Remove unnecesary `clone()`s and `to_string()`s

### DIFF
--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -176,7 +176,7 @@ pub async fn process_notification(
                         contract_location.clone(),
                         clarity_version,
                         issuer,
-                        contract_source.as_str(),
+                        contract_source,
                     )
                 })?;
             }
@@ -591,7 +591,7 @@ mod range_formatting_tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    fn create_test_editor_state(source: &str) -> EditorStateInput {
+    fn create_test_editor_state(source: String) -> EditorStateInput {
         let mut editor_state = EditorState::new();
 
         let contract_location = FileLocation::FileSystem {
@@ -612,7 +612,7 @@ mod range_formatting_tests {
     fn test_range_formatting_comments() {
         let source = "(ok true)\n\n(define-public (foo)\n  ;; this is a comment\n   (ok   true)\n)";
 
-        let editor_state_input = create_test_editor_state(source);
+        let editor_state_input = create_test_editor_state(source.to_owned());
 
         let params = DocumentRangeFormattingParams {
             text_document: TextDocumentIdentifier {

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -555,7 +555,7 @@ pub fn get_definitions(
 }
 
 pub fn get_public_function_definitions(
-    expressions: &Vec<SymbolicExpression>,
+    expressions: &[SymbolicExpression],
 ) -> HashMap<ClarityName, Range> {
     let mut definitions = HashMap::new();
 

--- a/components/clarity-lsp/src/common/requests/signature_help.rs
+++ b/components/clarity-lsp/src/common/requests/signature_help.rs
@@ -90,7 +90,7 @@ mod definitions_visitor_tests {
     use super::get_signatures;
 
     fn get_source_signature(
-        source: &str,
+        source: String,
         position: &Position,
     ) -> Option<Vec<lsp_types::SignatureInformation>> {
         let contract = &ActiveContractData::new(Clarity2, Epoch21, None, source);
@@ -100,7 +100,7 @@ mod definitions_visitor_tests {
     #[test]
     fn get_simple_signature() {
         let signatures = get_source_signature(
-            "(var-set counter )",
+            "(var-set counter )".to_owned(),
             &Position {
                 line: 1,
                 character: 18,
@@ -150,9 +150,9 @@ mod definitions_visitor_tests {
                 continue;
             }
 
-            let src = format!("({} )", &method);
+            let src = format!("({method} )");
             let signatures = get_source_signature(
-                src.as_str(),
+                src,
                 &Position {
                     line: 1,
                     character: 2,


### PR DESCRIPTION
### Description

Remove a few unnecessary instances where the entire contract source code or `SymbolicExpression`s were being unnecessarily cloned by `ActiveContractData` functions. Specifically:

- Remove `.to_string()` in `ActiveContractData::new()` (pass in a `String` instead)
- Reorder field initializtion in `ActiveContractData::new()` so that we don't clone `ast.expressions`
- Don't clone the source in `update_clarity_version()`
- Use `.clone_into()` in `update_sources()` to re-use existing memory allocations

Hopefully this will make the LSP feel a bit snappier