### PR TITLE
fix: tracer stack handling

### DIFF
--- a/components/clarinet-sdk/node/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/node/tests/simnet-usage.test.ts
@@ -303,9 +303,9 @@ describe("simnet can call contracts function", () => {
 
     expect(consoleSpy).toHaveBeenCalledTimes(2);
     expect(consoleSpy).toHaveBeenCalledWith(`├── ( sub-a n m )  stacks-trace-test:17:3
-│ ↳ args: u3 u4
-├── ( sub-b n m )  stacks-trace-test:11:3
 │   │ ↳ args: u3 u4
+│   ├── ( sub-b n m )  stacks-trace-test:11:3
+│   │   │ ↳ args: u3 u4
 Error: Runtime error while interpreting ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.stacks-trace-test`);
 
     expect(consoleSpy).toHaveBeenCalledWith(`\nError occured in stacks-trace-test:5:7

--- a/components/clarity-repl/src/repl/hooks/tracer.rs
+++ b/components/clarity-repl/src/repl/hooks/tracer.rs
@@ -31,7 +31,6 @@ impl std::fmt::Display for TracerErrorOutput {
     }
 }
 
-#[derive(Default)]
 pub struct TracerHook {
     pub output: Vec<String>,
     pub error: Option<TracerErrorOutput>,
@@ -39,6 +38,19 @@ pub struct TracerHook {
     pending_call_string: Vec<String>,
     pending_args: Vec<Vec<u64>>,
     nb_of_emitted_events: usize,
+}
+
+impl Default for TracerHook {
+    fn default() -> Self {
+        Self {
+            output: Vec::new(),
+            error: None,
+            stack: vec![u64::MAX],
+            pending_call_string: Vec::new(),
+            pending_args: Vec::new(),
+            nb_of_emitted_events: 0,
+        }
+    }
 }
 
 impl TracerHook {
@@ -97,8 +109,11 @@ impl EvalHook for TracerHook {
                                 };
                                 lines.push(format!(
                                     "{}│ {}",
-                                    "│   "
-                                        .repeat(self.stack.len() - self.pending_call_string.len()),
+                                    "│   ".repeat(
+                                        self.stack
+                                            .len()
+                                            .saturating_sub(self.pending_call_string.len())
+                                    ),
                                     purple!("↳ callee: {callee}"),
                                 ));
                             }
@@ -120,8 +135,11 @@ impl EvalHook for TracerHook {
                             } else {
                                 self.add_to_output(format!(
                                     "{}{}",
-                                    "│   "
-                                        .repeat(self.stack.len() - self.pending_call_string.len()),
+                                    "│   ".repeat(
+                                        self.stack
+                                            .len()
+                                            .saturating_sub(self.pending_call_string.len())
+                                    ),
                                     call
                                 ));
                             }
@@ -133,11 +151,10 @@ impl EvalHook for TracerHook {
                     let mut call = format!(
                         "{}├── {}  {}\n",
                         "│   ".repeat(
-                            (self
-                                .stack
+                            self.stack
                                 .len()
-                                .saturating_sub(self.pending_call_string.len()))
-                            .saturating_sub(1)
+                                .saturating_sub(self.pending_call_string.len())
+                                .saturating_sub(1)
                         ),
                         expr,
                         black!(
@@ -166,7 +183,11 @@ impl EvalHook for TracerHook {
                     } else {
                         self.add_to_output(format!(
                             "{}{}",
-                            "│   ".repeat(self.stack.len() - self.pending_call_string.len()),
+                            "│   ".repeat(
+                                self.stack
+                                    .len()
+                                    .saturating_sub(self.pending_call_string.len())
+                            ),
                             call
                         ));
                     }
@@ -206,7 +227,10 @@ impl EvalHook for TracerHook {
                 self.add_to_output(format!(
                     "{}│ {}",
                     "│   ".repeat(
-                        (self.stack.len() - self.pending_call_string.len()).saturating_sub(1),
+                        self.stack
+                            .len()
+                            .saturating_sub(self.pending_call_string.len())
+                            .saturating_sub(1),
                     ),
                     black!("✸ {event_message}"),
                 ));
@@ -220,7 +244,10 @@ impl EvalHook for TracerHook {
                     self.add_to_output(format!(
                         "{}└── {}",
                         "│   ".repeat(
-                            (self.stack.len() - self.pending_call_string.len()).saturating_sub(1)
+                            self.stack
+                                .len()
+                                .saturating_sub(self.pending_call_string.len())
+                                .saturating_sub(1)
                         ),
                         blue!("{value}")
                     ));


### PR DESCRIPTION
### Description

Fix regression introduced in in #1974, [here](https://github.com/hirosystems/clarinet/pull/1974/files#diff-31ef549d4e9e23da21cf19cde211df68187111beb89f254f496b2eb9439645d1L24). The tracer's stacks has to be `vec![u64::MAX]`.

Alos now using `.saturating_sub()` everywhere for onssitency and safety
