### PR TITLE
chore: fix transaction spec contract publish

### DIFF
--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1380,7 +1380,7 @@ impl TransactionPlanSpecification {
                                     ClarityVersion::Clarity1 => Some(1),
                                     ClarityVersion::Clarity2 => Some(2),
                                     ClarityVersion::Clarity3 => Some(3),
-                                    ClarityVersion::Clarity4 => Some(3),
+                                    ClarityVersion::Clarity4 => Some(4),
                                 },
                             },
                         )


### PR DESCRIPTION
### Description

Fix bug introduced in #2013 (the PR, not the year)

Clarity version 3 -> 4