### PR TITLE
fix: trick cost tracking into using deployed costs contracts

### DIFF
--- a/components/clarity-repl/src/repl/boot/mod.rs
+++ b/components/clarity-repl/src/repl/boot/mod.rs
@@ -216,6 +216,10 @@ pub fn get_boot_contracts_data_with_overrides(
             continue;
         }
 
+        eprintln!(
+            "Loading custom boot contract override '{}' from '{}'",
+            contract_name, file_path
+        );
         let custom_source = match load_custom_boot_contract(file_path) {
             Ok(source) => source,
             Err(e) => {
@@ -223,6 +227,8 @@ pub fn get_boot_contracts_data_with_overrides(
                 continue;
             }
         };
+
+        eprintln!("Loaded custom boot contract '{}'", contract_name,);
 
         // Use standard epoch/version mapping for known boot contracts
         let (epoch, clarity_version) =

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -665,10 +665,13 @@ impl ClarityBackingStore for ClarityDatastore {
     fn get_metadata_manual(
         &mut self,
         _at_height: u32,
-        _contract: &QualifiedContractIdentifier,
-        _key: &str,
+        contract: &QualifiedContractIdentifier,
+        key: &str,
     ) -> Result<Option<String>> {
-        panic!("Datastore cannot get_metadata_manual")
+        Ok(self
+            .metadata
+            .get(&(contract.to_string(), key.to_string()))
+            .cloned())
     }
 
     fn get_cc_special_cases_handler(&self) -> Option<clarity::vm::database::SpecialCaseHandler> {

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -355,7 +355,7 @@ impl ClarityInterpreter {
             .map_err(|e| e.to_string())?;
         conn.commit().map_err(|e| e.to_string())?;
         let cost_tracker = if cost_track {
-            LimitedCostTracker::new(
+            LimitedCostTracker::new_mid_block(
                 is_mainnet,
                 chain_id,
                 BLOCK_LIMIT_MAINNET.clone(),


### PR DESCRIPTION
By default the costs are computed via [compiled cost function references](https://github.com/stacks-network/stacks-core/blob/master/clarity/src/vm/costs/mod.rs#L1158-L1173) so in order to actually use the custom boot contracts for costs, we need to trick clarity. We do this by hijacking the state_summary and adding our references to cost functions from the dummy contract we deploy if overrides are present.

This successfully alters the result of `::get_costs` in the repl, but the tests seemingly need an extra step similar to this as well..

