### PR TITLE
feat: implement console commands for accessing contract state data

### DIFF
--- a/components/clarinet-cli/tests/console.rs
+++ b/components/clarinet-cli/tests/console.rs
@@ -77,3 +77,291 @@ fn can_init_console_with_mxs() {
     assert_eq!(output[1], "false");
     assert_eq!(output[2], "true");
 }
+
+#[test]
+fn test_get_constant_command() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &["::get_constant counter MISSING_CONSTANT"],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain error message for missing constant
+    assert!(output_text.contains("not found") || output_text.contains("MISSING_CONSTANT"));
+    assert!(output_text.contains("Constant:") && output_text.contains("MISSING_CONSTANT"));
+    assert!(output_text.contains("contract:") && output_text.contains("counter"));
+}
+
+#[test]
+fn test_get_constant_command_found() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &["::get_constant counter MAX_COUNT"],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain the constant value
+    assert!(output_text.contains("Contract:"));
+    assert!(output_text.contains("counter"));
+    assert!(output_text.contains("Constant:"));
+    assert!(output_text.contains("MAX_COUNT"));
+    assert!(output_text.contains("Value:"));
+    assert!(output_text.contains("u100"));
+}
+
+#[test]
+fn test_get_data_var_command() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &["::get_data_var counter count"],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain the data variable value
+    assert!(output_text.contains("Contract:"));
+    assert!(output_text.contains("counter"));
+    assert!(output_text.contains("Data var:"));
+    assert!(output_text.contains("count"));
+    assert!(output_text.contains("Value:"));
+    assert!(output_text.contains("u0")); // Initial value should be u0
+}
+
+#[test]
+fn test_get_map_val_command_not_found() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &["::get_map_val counter test-map u1"],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain not found message for empty map
+    assert!(output_text.contains("Map entry not found") || output_text.contains("not found"));
+    assert!(output_text.contains("test-map"));
+    assert!(output_text.contains("u1"));
+}
+
+#[test]
+fn test_get_map_val_command_found() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &[
+            "(contract-call? .counter set-map-entry u1 u42)",
+            "::get_map_val counter test-map u1",
+        ],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain the map value
+    assert!(output_text.contains("Contract:"));
+    assert!(output_text.contains("counter"));
+    assert!(output_text.contains("Map:"));
+    assert!(output_text.contains("test-map"));
+    assert!(output_text.contains("Key:"));
+    assert!(output_text.contains("u1"));
+    assert!(output_text.contains("Value:"));
+    assert!(output_text.contains("some u42"));
+}
+
+#[test]
+fn test_get_constant_command_invalid_args() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &[
+            "::get_constant counter", // Missing constant argument
+        ],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain usage error message
+    assert!(output_text.contains("Usage:") || output_text.contains("get_constant"));
+}
+
+#[test]
+fn test_get_constant_command_invalid_contract() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &["::get_constant non_existent_contract SOME_CONSTANT"],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain contract not found error message
+    assert!(output_text.contains("Contract not found:") || output_text.contains("not found"));
+    assert!(output_text.contains("non_existent_contract"));
+}
+
+#[test]
+fn test_get_data_var_command_invalid_args() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &[
+            "::get_data_var counter", // Missing variable argument
+        ],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain usage error message
+    assert!(output_text.contains("Usage:") || output_text.contains("get_data_var"));
+}
+
+#[test]
+fn test_get_data_var_command_not_found() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &["::get_data_var counter non_existent_var"],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain data variable not found error message
+    assert!(output_text.contains("Data var:") && output_text.contains("not found"));
+    assert!(output_text.contains("non_existent_var"));
+}
+
+#[test]
+fn test_get_map_val_command_invalid_args() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &[
+            "::get_map_val counter test-map", // Missing key argument
+        ],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain usage error message
+    assert!(output_text.contains("Usage:") || output_text.contains("get_map_val"));
+}
+
+#[test]
+fn test_get_map_val_command_invalid_contract() {
+    let output = run_console_command(
+        &[
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ],
+        &["::get_map_val non_existent_contract test-map u1"],
+    );
+
+    assert!(!output.is_empty());
+    let output_text = output.join(" ");
+
+    // Should contain contract related error
+    assert!(output_text.contains("contract") || output_text.contains("Contract"));
+    assert!(output_text.contains("non_existent_contract"));
+}
+
+#[test]
+fn test_get_map_val_command_invalid_key_expression() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_clarinet"))
+        .args(["console"])
+        .args([
+            "-m",
+            &format!(
+                "{}/tests/fixtures/mxs/Clarinet.toml",
+                env!("CARGO_MANIFEST_DIR")
+            ),
+        ])
+        .current_dir(&temp_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to start console");
+
+    let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+    stdin
+        .write_all(b"::get_map_val counter test-map invalid-key-expression-xyz\n")
+        .expect("Failed to write to stdin");
+
+    let output = child.wait_with_output().expect("Failed to read stdout");
+
+    // We expect this to fail due to invalid expression, but we're testing that it doesn't crash the console
+    let stdout_str = String::from_utf8_lossy(&output.stdout);
+    let stderr_str = String::from_utf8_lossy(&output.stderr);
+    let combined_output = format!("{} {}", stdout_str, stderr_str);
+
+    // The command might fail, but we should get some output rather than a hard crash
+    assert!(!combined_output.is_empty());
+}

--- a/components/clarinet-cli/tests/fixtures/mxs/counter.clar
+++ b/components/clarinet-cli/tests/fixtures/mxs/counter.clar
@@ -1,5 +1,13 @@
 (define-data-var count uint u0)
 
+(define-constant MAX_COUNT u100)
+
+(define-map test-map uint uint)
+
 (define-public (increment)
   (ok (var-set count (+ (var-get count) u1)))
+)
+
+(define-public (set-map-entry (key uint) (value uint))
+  (ok (map-set test-map key value))
 )

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -284,6 +284,9 @@ impl Session {
             cmd if cmd.starts_with("::set_epoch") => self.set_epoch(cmd),
             cmd if cmd.starts_with("::encode") => self.encode(cmd),
             cmd if cmd.starts_with("::decode") => self.decode(cmd),
+            cmd if cmd.starts_with("::get_constant") => self.get_constant(cmd),
+            cmd if cmd.starts_with("::get_data_var") => self.get_data_var(cmd),
+            cmd if cmd.starts_with("::get_map_val") => self.get_map_val(cmd),
 
             _ => "Invalid command. Try `::help`".yellow().to_string(),
         }
@@ -927,6 +930,18 @@ impl Session {
             "{}",
             "::decode <bytes>\t\t\tDecode a Clarity Value bytes representation".yellow()
         ));
+        output.push(format!(
+            "{}",
+            "::get_constant <contract> <constant>\tGet constant value from a contract".yellow()
+        ));
+        output.push(format!(
+            "{}",
+            "::get_data_var <contract> <var>\t\tGet data variable value from a contract".yellow()
+        ));
+        output.push(format!(
+            "{}",
+            "::get_map_val <contract> <map> <key>\tGet map value from a contract".yellow()
+        ));
 
         output.join("\n")
     }
@@ -1148,6 +1163,249 @@ impl Session {
         };
 
         format!("{}", value_to_string(&value).green())
+    }
+
+    pub fn get_constant(&mut self, cmd: &str) -> String {
+        let args: Vec<_> = cmd.split_whitespace().skip(1).collect();
+
+        if args.len() != 2 {
+            return format!("{}", "Usage: ::get_constant <contract> <constant>".red());
+        }
+
+        let contract_name = args[0];
+        let constant_name = args[1];
+
+        let default_deployer = match self.settings.initial_deployer.as_ref() {
+            Some(account) => account.address.clone(),
+            None => self.get_tx_sender(),
+        };
+
+        let contract_id = match Self::desugar_contract_id(&default_deployer, contract_name) {
+            Ok(id) => id,
+            Err(e) => return format!("{} {}", "Invalid contract identifier:".red(), e),
+        };
+
+        let contract = match self.contracts.get(&contract_id) {
+            Some(contract) => contract,
+            None => return format!("{} {}", "Contract not found:".red(), contract_id),
+        };
+
+        // Search for constant in the contract's AST
+        for function_definition in &contract.ast.expressions {
+            if let Some(expr) = function_definition.match_list() {
+                if expr.len() >= 3 {
+                    if let Some(name_expr) = expr.get(1) {
+                        if let Some(name) = name_expr.match_atom() {
+                            if name.as_str() == constant_name && expr.len() >= 3 {
+                                let expr_str = format!("{}", expr[2]);
+                                return format!(
+                                    "{} {}\n{} {}\n{} {}",
+                                    "Contract:".yellow(),
+                                    contract_id.to_string().green(),
+                                    "Constant:".yellow(),
+                                    name.green(),
+                                    "Value:".yellow(),
+                                    expr_str.green()
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        format!(
+            "{} {} {} {}",
+            "Constant:".red(),
+            constant_name.red(),
+            "not found in contract:".red(),
+            contract_id.to_string().red()
+        )
+    }
+
+    pub fn get_data_var(&mut self, cmd: &str) -> String {
+        let args: Vec<_> = cmd.split_whitespace().skip(1).collect();
+
+        if args.len() != 2 {
+            return format!("{}", "Usage: ::get_data_var <contract> <var>".red());
+        }
+
+        let contract_name = args[0];
+        let var_name = args[1];
+
+        let default_deployer = match self.settings.initial_deployer.as_ref() {
+            Some(account) => account.address.clone(),
+            None => self.get_tx_sender(),
+        };
+
+        let contract_id = match Self::desugar_contract_id(&default_deployer, contract_name) {
+            Ok(id) => id,
+            Err(e) => return format!("{} {}", "Invalid contract identifier:".red(), e),
+        };
+
+        match self.interpreter.get_data_var(&contract_id, var_name) {
+            Some(value_hex) => {
+                // Convert hex string back to Clarity Value for display
+                let value_bytes = match decode_hex(&value_hex) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        return format!(
+                            "{} {} {} {}",
+                            "Failed to decode value:".red(),
+                            e.to_string().red(),
+                            "from contract:".red(),
+                            contract_id.to_string().red()
+                        )
+                    }
+                };
+
+                let value = match Value::consensus_deserialize(&mut &value_bytes[..]) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        return format!(
+                            "{} {} {} {}",
+                            "Failed to deserialize value:".red(),
+                            e.to_string().red(),
+                            "from contract:".red(),
+                            contract_id.to_string().red()
+                        )
+                    }
+                };
+
+                format!(
+                    "{} {}\n{} {}\n{} {}",
+                    "Contract:".yellow(),
+                    contract_id.to_string().green(),
+                    "Data var:".yellow(),
+                    var_name.green(),
+                    "Value:".yellow(),
+                    value_to_string(&value).green()
+                )
+            }
+            None => {
+                format!(
+                    "{} {} {} {}",
+                    "Data var:".red(),
+                    var_name.red(),
+                    "not found in contract:".red(),
+                    contract_id.to_string().red()
+                )
+            }
+        }
+    }
+
+    pub fn get_map_val(&mut self, cmd: &str) -> String {
+        let args: Vec<_> = cmd.split_whitespace().skip(1).collect();
+
+        if args.len() < 3 {
+            return format!("{}", "Usage: ::get_map_val <contract> <map> <key>".red());
+        }
+
+        let contract_name = args[0];
+        let map_name = args[1];
+        let key_expr = args[2..].join(" ");
+
+        let default_deployer = match self.settings.initial_deployer.as_ref() {
+            Some(account) => account.address.clone(),
+            None => self.get_tx_sender(),
+        };
+
+        let contract_id = match Self::desugar_contract_id(&default_deployer, contract_name) {
+            Ok(id) => id,
+            Err(e) => return format!("{} {}", "Invalid contract identifier:".red(), e),
+        };
+
+        // Parse the key expression to get a Clarity Value
+        let key_value = self.eval_clarity_string(&key_expr);
+
+        // Extract the actual Value from the SymbolicExpression
+        let key_value = match key_value.match_atom_value() {
+            Some(value) => value.clone(),
+            None => {
+                // For complex expressions, we need to evaluate them differently
+                let result = match self.eval_with_hooks(format!("({})", key_expr), None, false) {
+                    Ok(result) => match &result.result {
+                        EvaluationResult::Snippet(snippet_result) => snippet_result.result.clone(),
+                        _ => {
+                            return format!(
+                                "{} {} {} {}",
+                                "Unable to evaluate key expression:".red(),
+                                key_expr.red(),
+                                "for contract:".red(),
+                                contract_id.to_string().red()
+                            )
+                        }
+                    },
+                    Err(_) => {
+                        return format!(
+                            "{} {} {} {}",
+                            "Unable to evaluate key expression:".red(),
+                            key_expr.red(),
+                            "for contract:".red(),
+                            contract_id.to_string().red()
+                        )
+                    }
+                };
+                result
+            }
+        };
+
+        match self
+            .interpreter
+            .get_map_entry(&contract_id, map_name, &key_value)
+        {
+            Some(value_hex) => {
+                // Convert hex string back to Clarity Value for display
+                let value_bytes = match decode_hex(&value_hex) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        return format!(
+                            "{} {} {} {}",
+                            "Failed to decode value:".red(),
+                            e.to_string().red(),
+                            "from contract:".red(),
+                            contract_id.to_string().red()
+                        )
+                    }
+                };
+
+                let value = match Value::consensus_deserialize(&mut &value_bytes[..]) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        return format!(
+                            "{} {} {} {}",
+                            "Failed to deserialize value:".red(),
+                            e.to_string().red(),
+                            "from contract:".red(),
+                            contract_id.to_string().red()
+                        )
+                    }
+                };
+
+                format!(
+                    "{} {}\n{} {}\n{} {}\n{} {}",
+                    "Contract:".yellow(),
+                    contract_id.to_string().green(),
+                    "Map:".yellow(),
+                    map_name.green(),
+                    "Key:".yellow(),
+                    key_expr.green(),
+                    "Value:".yellow(),
+                    value_to_string(&value).green()
+                )
+            }
+            None => {
+                format!(
+                    "{} {} {} {} {} {}",
+                    "Map entry not found for key:".red(),
+                    key_expr.red(),
+                    "in map:".red(),
+                    map_name.red(),
+                    "of contract:".red(),
+                    contract_id.to_string().red()
+                )
+            }
+        }
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
Resolves #1722

## Summary
Implements three new REPL commands for inspecting contract data during development:
- `::get_constant <contract> <constant>` - Get constant value from a contract
- `::get_data_var <contract> <var>` - Get data variable value from a contract  
- `::get_map_val <contract> <map> <key>` - Get map value from a contract

## Implementation Details
- Added command handlers in `components/clarity-repl/src/repl/session.rs`
- Added help documentation for the new commands
- Added comprehensive tests in `components/clarinet-cli/tests/console.rs`

## Test Plan
- [x] All existing tests pass
- [x] Added unit tests for all three new commands
- [x] Commands work with both valid and invalid contract identifiers
- [x] Error handling works correctly for missing contracts/data
- [x] Help documentation displays properly

REPL demo of interaction with `fixtures/mxs/counter.clar` contract:

<img width="1552" height="917" alt="Screenshot 2025-11-05 at 18 07 15" src="https://github.com/user-attachments/assets/458e5f6a-e411-4472-8ecb-93f696783d41" />
<img width="1552" height="561" alt="Screenshot 2025-11-05 at 18 07 24" src="https://github.com/user-attachments/assets/1fe8920c-0360-40a2-a085-875593276bdd" />