### PR TITLE
chore: rename npm packages and vscode extension

### DIFF
--- a/.github/workflows/release-vscode.yaml
+++ b/.github/workflows/release-vscode.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup Rust
@@ -36,11 +36,11 @@ jobs:
         run: npm ci
 
       - name: Build vsix
-        run: npx vsce package --out clarity-lsp.vsix
+        run: npx vsce package --out clarity.vsix
 
       - name: Publish to VSCode Marketplace
         continue-on-error: true
-        run: npx vsce publish --packagePath clarity-lsp.vsix --pat ${{ secrets.VSCE_TOKEN }}
+        run: npx vsce publish --packagePath clarity.vsix --pat ${{ secrets.VSCE_TOKEN }}
 
       - name: Publish to Open VSX
-        run: npx ovsx publish --packagePath clarity-lsp.vsix --pat ${{ secrets.OVSX_TOKEN }}
+        run: npx ovsx publish --packagePath clarity.vsix --pat ${{ secrets.OVSX_TOKEN }}

--- a/components/clarinet-sdk-wasm/Cargo.toml
+++ b/components/clarinet-sdk-wasm/Cargo.toml
@@ -3,8 +3,8 @@ name = "clarinet-sdk-wasm"
 version.workspace = true
 edition = "2021"
 license = "GPL-3.0"
-repository = "https://github.com/hirosystems/clarinet"
-description = "The core lib that powers @hirosystems/clarinet-sdk"
+repository = "https://github.com/stx-labs/clarinet"
+description = "The core lib that powers @stacks/clarinet-sdk"
 
 [lib]
 crate-type = ["cdylib"]

--- a/components/clarinet-sdk-wasm/README.md
+++ b/components/clarinet-sdk-wasm/README.md
@@ -1,9 +1,9 @@
 # Clarity SDK WASM
 
-This component exposes Clarinet features to a JS interface through wasm-bindgen.
-It's built with wasm-pack.  
-It powers [@hirosystems/clarinet-sdk](https://npmjs.com/package/@hirosystems/clarinet-sdk) and
-[@hirosystems/clarinet-sdk-browser](https://npmjs.com/package/@hirosystems/clarinet-sdk-browser).
+This component exposes Clarinet features to a JS interface through wasm-bindgen. It's built with
+wasm-pack.  
+It powers [@stacks/clarinet-sdk](https://npmjs.com/package/@stacks/clarinet-sdk) and
+[@stacks/clarinet-sdk-browser](https://npmjs.com/package/@stacks/clarinet-sdk-browser).
 
 ## Contributing
 
@@ -11,25 +11,26 @@ It powers [@hirosystems/clarinet-sdk](https://npmjs.com/package/@hirosystems/cla
 
 Install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/).
 
-In the root directory of Clarinet, run the following command to build the packages for Node.js and the browser.
-Under the hood, it will run `wasm-pack build` twice, once for each target.
+In the root directory of Clarinet, run the following command to build the packages for Node.js and
+the browser. Under the hood, it will run `wasm-pack build` twice, once for each target.
 
 ```sh
 npm run build:sdk-wasm
 ```
 
-Alternatively, it's also possible to build the packages separately. It should only be done for development purpose.
+Alternatively, it's also possible to build the packages separately. It should only be done for
+development purpose.
 
 **Build for node**
 
 ```sh
-wasm-pack build --release --scope hirosystems --out-dir pkg-node --target nodejs
+wasm-pack build --release --scope stacks --out-dir pkg-node --target nodejs
 ```
 
 **Build for the browser**
 
 ```sh
-wasm-pack build --release --scope hirosystems --out-dir pkg-browser --target web
+wasm-pack build --release --scope stacks --out-dir pkg-browser --target web
 ```
 
 ### Release
@@ -43,7 +44,7 @@ npm run build:sdk-wasm
 ```
 
 Once built, the packages can be released by running the following command. Note that by default we
-release with the beta tag. 
+release with the beta tag.
 
 ```sh
 npm run publish:sdk-wasm

--- a/components/clarinet-sdk-wasm/build.mjs
+++ b/components/clarinet-sdk-wasm/build.mjs
@@ -21,7 +21,7 @@ async function build_wasm_sdk() {
       "build",
       "--release",
       "--scope",
-      "hirosystems",
+      "stacks",
       "--out-dir",
       "pkg-node",
       "--target",
@@ -31,7 +31,7 @@ async function build_wasm_sdk() {
       "build",
       "--release",
       "--scope",
-      "hirosystems",
+      "stacks",
       "--out-dir",
       "pkg-browser",
       "--target",
@@ -96,8 +96,8 @@ async function updatePackageName() {
 
   const fileData = await fs.readFile(filePath, "utf-8");
   const updatedData = fileData.replace(
-    '"name": "@hirosystems/clarinet-sdk-wasm"',
-    '"name": "@hirosystems/clarinet-sdk-wasm-browser"',
+    '"name": "@stacks/clarinet-sdk-wasm"',
+    '"name": "@stacks/clarinet-sdk-wasm-browser"',
   );
   await fs.writeFile(filePath, updatedData, "utf-8");
   console.log("✅ pkg-browser/package.json name updated");

--- a/components/clarinet-sdk/README.md
+++ b/components/clarinet-sdk/README.md
@@ -1,13 +1,13 @@
 # Clarinet SDK Workspace
 
 This workspace regroups
-`@hirosystems/clarinet-sdk` for node.js and `@hirosystems/clarinet-sdk-browser` for web browsers.  
-They respectively rely on `@hirosystems/clarinet-sdk-wasm` and `@hirosystems/clarinet-sdk-browser-wasm`.
+`@stacks/clarinet-sdk` for node.js and `@stacks/clarinet-sdk-browser` for web browsers.  
+They respectively rely on `@stacks/clarinet-sdk-wasm` and `@stacks/clarinet-sdk-browser-wasm`.
 
 Because of the way the wasm packages are build, with wasm-pack, it made sense to have two different
 packages for Node.js and the browsers, but it has some caveats. Especially, some of the code is
-duplicated in `./browser/src/sdkProxy.ts` and `./node/src/sdkProxy.ts`. In the future, we hope to 
-be able to simplify this build, it would require some breaking changes so it could be part of 
+duplicated in `./browser/src/sdkProxy.ts` and `./node/src/sdkProxy.ts`. In the future, we hope to
+be able to simplify this build, it would require some breaking changes so it could be part of
 Clarinet 3.x.
 
 ## Contributing
@@ -17,7 +17,7 @@ The clarinet-sdk requires a few steps to be built and tested locally.
 Clone the clarinet repo and `cd` into it:
 
 ```sh
-git clone git@github.com:hirosystems/clarinet.git
+git clone git@github.com:stacks/clarinet.git
 cd clarinet
 ```
 

--- a/components/clarinet-sdk/browser/README.md
+++ b/components/clarinet-sdk/browser/README.md
@@ -2,12 +2,12 @@
 
 The Clarinet SDK can be used to interact with the simnet from web browsers.
 
-If you want to use the Clarinet SDK in Node.js, try [@hirosystems/clarinet-sdk](https://www.npmjs.com/package/@hirosystems/clarinet-sdk).
+If you want to use the Clarinet SDK in Node.js, try [@stacks/clarinet-sdk](https://www.npmjs.com/package/@stacks/clarinet-sdk).
 
-Find the API references of the SDK in [our documentation](https://docs.hiro.so/stacks/clarinet-js-sdk).  
-Learn more about unit testing Clarity smart contracts in [this guide](https://docs.hiro.so/stacks/clarinet-js-sdk).
+Find the API references of the SDK in [our documentation](https://docs.stacks.co/reference/clarinet-js-sdk/overview).
 
 You can use this SDK to:
+
 - Interact with a clarinet project as you would with the Clarinet CLI
 - Call public, read-only, and private functions from smart contracts
 - Get clarity maps or data-var values
@@ -17,7 +17,7 @@ You can use this SDK to:
 ## Installation
 
 ```sh
-npm install @hirosystems/clarinet-sdk-browser
+npm install @stacks/clarinet-sdk-browser
 ```
 
 ### Usage
@@ -25,16 +25,17 @@ npm install @hirosystems/clarinet-sdk-browser
 There are two ways to use the sdk in the browser:
 
 - With an empty clarinet session:
+
 ```js
 const simnet = await initSimnet();
 await simnet.initEmptySession();
-simnet.runSnippet("(+ 1 2)")
+simnet.runSnippet("(+ 1 2)");
 ```
 
 - With a clarinet project (ie: with a Clarinet.toml)
-💡 It requires to use a virtual file system. More documentation and examples soon.
+  💡 It requires to use a virtual file system. More documentation and examples soon.
+
 ```js
 const simnet = await initSimnet();
-await simnet.initSession("/project", "Clarinet.toml")
+await simnet.initSession("/project", "Clarinet.toml");
 ```
-

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@hirosystems/clarinet-sdk-browser",
+  "name": "@stacks/clarinet-sdk-browser",
   "version": "3.8.1",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
-  "homepage": "https://www.hiro.so/clarinet",
+  "homepage": "https://stackslabs.com/clarinet",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hirosystems/clarinet.git"
+    "url": "git+https://github.com/stx-labs/clarinet.git"
   },
   "files": [
     "dist"
@@ -24,11 +24,11 @@
     "clarinet",
     "tests"
   ],
-  "author": "hirosystems",
+  "author": "stacks-labs",
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm-browser": "3.8.1",
+    "@stacks/clarinet-sdk-wasm-browser": "3.8.1",
     "@stacks/transactions": "^7.0.6"
   }
 }

--- a/components/clarinet-sdk/browser/src/index.ts
+++ b/components/clarinet-sdk/browser/src/index.ts
@@ -1,4 +1,4 @@
-import init, { SDK } from "@hirosystems/clarinet-sdk-wasm-browser";
+import init, { SDK } from "@stacks/clarinet-sdk-wasm-browser";
 
 import { Simnet, getSessionProxy } from "./sdkProxy.js";
 import { defaultVfs } from "./defaultVfs.js";

--- a/components/clarinet-sdk/browser/src/sdkProxy.ts
+++ b/components/clarinet-sdk/browser/src/sdkProxy.ts
@@ -6,7 +6,7 @@ import {
   ContractOptions,
   type SDK,
   type TransactionRes,
-} from "@hirosystems/clarinet-sdk-wasm-browser";
+} from "@stacks/clarinet-sdk-wasm-browser";
 
 import {
   parseEvents,

--- a/components/clarinet-sdk/common/package.json
+++ b/components/clarinet-sdk/common/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@hirosystems/clarinet-sdk-common",
+  "name": "@stacks/clarinet-sdk-common",
   "description": "Common helpers used in the Clarinet SDK for the node.js and the browser version",
   "private": true,
-  "author": "hirosystems",
+  "author": "stacks-labs",
   "license": "GPL-3.0"
 }

--- a/components/clarinet-sdk/node/README.md
+++ b/components/clarinet-sdk/node/README.md
@@ -2,10 +2,9 @@
 
 The Clarinet SDK allows to interact with the simnet in Node.js.
 
-If you want to use the Clarinet SDK in web browsers, try [@hirosystems/clarinet-sdk-browser](https://www.npmjs.com/package/@hirosystems/clarinet-sdk-browser).
+If you want to use the Clarinet SDK in web browsers, try [@stacks/clarinet-sdk-browser](https://www.npmjs.com/package/@stacks/clarinet-sdk-browser).
 
-Find the API references of the SDK in [our documentation](https://docs.hiro.so/stacks/clarinet-js-sdk).
-Learn more about unit testing Clarity smart contracts in [this guide](https://docs.hiro.so/stacks/clarinet-js-sdk).
+Find the API references of the SDK in [our documentation](https://docs.stacks.co/reference/clarinet-js-sdk/overview).
 
 You can use this SDK to:
 
@@ -18,13 +17,13 @@ You can use this SDK to:
 ## Installation
 
 ```sh
-npm install @hirosystems/clarinet-sdk
+npm install @stacks/clarinet-sdk
 ```
 
 ## Usage
 
 ```ts
-import { initSimnet } from "@hirosystems/clarinet-sdk";
+import { initSimnet } from "@stacks/clarinet-sdk";
 import { Cl } from "@stacks/transactions";
 
 async function main() {
@@ -73,7 +72,7 @@ npm install
 npm test
 ```
 
-Visit the [clarity starter project](https://github.com/hirosystems/clarity-starter) to see the testing framework in action.
+Visit the [clarity starter project](https://github.com/stx-labs/clarity-starter) to see the testing framework in action.
 
 ### Type checking
 
@@ -87,6 +86,6 @@ Note: If you want to write your test in JavaScript but still have a certain leve
     "checkJs": true,
     "strict": true
   },
-  "include": ["node_modules/@hirosystems/clarinet-sdk/vitest-helpers/src", "unit-tests"]
+  "include": ["node_modules/@stacks/clarinet-sdk/vitest-helpers/src", "unit-tests"]
 }
 ```

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@hirosystems/clarinet-sdk",
+  "name": "@stacks/clarinet-sdk",
   "version": "3.8.1",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
-  "homepage": "https://www.hiro.so/clarinet",
+  "homepage": "https://stackslabs.com/clarinet",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hirosystems/clarinet.git"
+    "url": "git+https://github.com/stx-labs/clarinet.git"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -54,11 +54,11 @@
     "clarinet",
     "tests"
   ],
-  "author": "hirosystems",
+  "author": "stacks-labs",
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@hirosystems/clarinet-sdk-wasm": "3.8.1",
+    "@stacks/clarinet-sdk-wasm": "3.8.1",
     "@stacks/transactions": "^7.0.6",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",

--- a/components/clarinet-sdk/node/src/index.ts
+++ b/components/clarinet-sdk/node/src/index.ts
@@ -1,4 +1,4 @@
-import { SDKOptions } from "@hirosystems/clarinet-sdk-wasm";
+import { SDKOptions } from "@stacks/clarinet-sdk-wasm";
 
 export {
   tx,
@@ -14,7 +14,7 @@ import { Simnet, getSessionProxy } from "./sdkProxy.js";
 
 export { type Simnet } from "./sdkProxy.js";
 
-const wasmModule = import("@hirosystems/clarinet-sdk-wasm");
+const wasmModule = import("@stacks/clarinet-sdk-wasm");
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
 // @ts-ignore

--- a/components/clarinet-sdk/node/src/sdkProxy.ts
+++ b/components/clarinet-sdk/node/src/sdkProxy.ts
@@ -6,7 +6,7 @@ import {
   ContractOptions,
   type SDK,
   type TransactionRes,
-} from "@hirosystems/clarinet-sdk-wasm";
+} from "@stacks/clarinet-sdk-wasm";
 
 import {
   parseEvents,

--- a/components/clarinet-sdk/node/src/vitest/index.ts
+++ b/components/clarinet-sdk/node/src/vitest/index.ts
@@ -44,7 +44,7 @@ export function getClarinetVitestsArgv() {
 
 // ensure vitest helpers can be imported even in workspace setup
 // import.meta.resolve return an url like "file:///absolute/path/to/clarinet-sdk/dist/esm/index.js"
-const sdkURL = import.meta.resolve("@hirosystems/clarinet-sdk");
+const sdkURL = import.meta.resolve("@stacks/clarinet-sdk");
 const sdkPath = url.fileURLToPath(sdkURL);
 const sdkDir = path.dirname(sdkPath);
 

--- a/components/clarinet-sdk/node/vitest-helpers/README.md
+++ b/components/clarinet-sdk/node/vitest-helpers/README.md
@@ -3,8 +3,7 @@
 This directory contains the setup files used in the `vitest.config.js` of a Clarinet project.
 
 This mean that these file are not directly part of the clarinet-sdk code and not compiled.
-Instead, they are directly loaded by `vitest.config.js`, following the path exposed in `@hirosystems/clarinet-sdk/vitest`
-
+Instead, they are directly loaded by `vitest.config.js`, following the path exposed in `@stacks/clarinet-sdk/vitest`
 
 ### Contributing
 

--- a/components/clarity-vscode/README.md
+++ b/components/clarity-vscode/README.md
@@ -4,11 +4,11 @@ Clarity is a **decidable** Smart Contract language that optimizes for predictabi
 
 This VS Code extension brings essential features to write safe and clean Clarity code: auto-completion, documentation, go-to definition, linting, safety checks, debugger and more.
 
-![screenshot](https://raw.githubusercontent.com/hirosystems/clarinet/develop/components/clarity-vscode/docs/images/screenshot.png)
+![screenshot](https://raw.githubusercontent.com/stx-labs/clarinet/refs/heads/main/components/clarity-vscode/docs/images/screenshot.png)
 
 ## Clarity for Visual Studio Installation
 
-You can install the latest release of the extension directly from VS Code or from the [marketplace](https://marketplace.visualstudio.com/items?itemName=hirosystems.clarity-lsp).
+You can install the latest release of the extension directly from VS Code or from the [marketplace](https://marketplace.visualstudio.com/items?itemName=stackslabs.clarity-lsp).
 
 ## Features
 
@@ -16,38 +16,38 @@ You can install the latest release of the extension directly from VS Code or fro
 
 Access all of Clarity documentation right in your editor by hovering functions and keywords.
 
-![documentation screenshot](https://raw.githubusercontent.com/hirosystems/clarinet/develop/components/clarity-vscode/docs/images/documentation.png)
+![documentation screenshot](https://raw.githubusercontent.com/stx-labs/clarinet/refs/heads/main/components/clarity-vscode/docs/images/documentation.png)
 
 ### Auto Complete Functions
 
 This feature enables you to start typing a function name, and then have the editor automatically suggest auto-completion with the documentation related to the suggestion.  
 When you select a function, the extension adds the necessary parentheses around it and puts placeholders in the arguments of the function.
 
-![autocomplete gif](https://raw.githubusercontent.com/hirosystems/clarinet/develop/components/clarity-vscode/docs/images/autocomplete.gif)
+![autocomplete gif](https://raw.githubusercontent.com/stx-labs/clarinet/refs/heads/main/components/clarity-vscode/docs/images/autocomplete.gif)
 
 ### Go-to definition
 
 Easily find functions, constants and variables declarations in the same contract or in contract calls.
 
-![go-to definition screenshot](https://raw.githubusercontent.com/hirosystems/clarinet/develop/components/clarity-vscode/docs/images/go-to-definition.png)
+![go-to definition screenshot](https://raw.githubusercontent.com/stx-labs/clarinet/refs/heads/main/components/clarity-vscode/docs/images/go-to-definition.png)
 
 ### Resolve contract-call targeting local contracts
 
 The extension auto-completes local contract calls as well.
 
-![multiple error support](https://raw.githubusercontent.com/hirosystems/clarinet/develop/components/clarity-vscode/docs/images/multicontract.gif)
+![multiple error support](https://raw.githubusercontent.com/stx-labs/clarinet/refs/heads/main/components/clarity-vscode/docs/images/multicontract.gif)
 
 ### Check Contract on Save and Display Errors Inline
 
 When a contract is opened or saved, the extension will notify you if errors are found (syntax, unknown keyword, etc), or warnings (such as unsafe code). This helps you to ensure that you write safe and clean code.
 
-![display errors gif](https://raw.githubusercontent.com/hirosystems/clarinet/develop/components/clarity-vscode/docs/images/errors.gif)
+![display errors gif](https://raw.githubusercontent.com/stx-labs/clarinet/refs/heads/main/components/clarity-vscode/docs/images/errors.gif)
 
 ### Debugger
 
 The debugging feature allows you to run Clarity code, line-by-line, so you can better understand what happens when it runs.
 
-**Note: This feature currently only runs on the desktop and requires a local [installation of Clarinet](https://github.com/hirosystems/clarinet#installation).**
+**Note: This feature currently only runs on the desktop and requires a local [installation of Clarinet](https://github.com/stx-labs/clarinet).**
 
 For more information on how debugging works, and how you can debug smart contracts, please see the [How to Debug Your Smart Contracts With Clarinet](https://www.hiro.so/blog/how-to-debug-your-smart-contracts-with-clarinet) blog post.
 
@@ -61,13 +61,13 @@ When a contract implements a trait (such as the NFT of FT trait – SIPs 009 and
 
 ### Handle Requirements
 
-If your Clarity project relies on specific requirements (eg: SIPs 009 or 010) for [interacting with contracts on mainnet](https://github.com/hirosystems/clarinet#interacting-with-contracts-deployed-on-mainnet), the extension will automatically detect and cached the required contracts.
+If your Clarity project relies on specific requirements (eg: SIPs 009 or 010) for interacting with contracts on mainnet, the extension will automatically detect and cached the required contracts.
 
 ---
 
 ## Contributing to this Extension
 
-Hiro welcomes feedback, comments and suggestions to improve this extension over time. 
+Stacks Labs welcomes feedback, comments and suggestions to improve this extension over time.
 
 ### Run the extension locally
 
@@ -79,6 +79,7 @@ From the `./components/clarity-vscode`, run `npm install` to install the depende
 
 The LSP has two main parts: the client and the server.
 These two parts will run in different environments:
+
 - VSCode Web (Web Worker)
 - VSCode Desktop (Node.js)
 

--- a/components/clarity-vscode/client/package.json
+++ b/components/clarity-vscode/client/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@hirosystems/clarity-vs-code-web-client",
+  "name": "@stacks/clarity-vs-code-web-client",
   "description": "VSCode client",
-  "author": "Hugo <hugo@hiro.so>",
+  "author": "Stacks Labs",
   "license": "MIT",
   "version": "0.0.1",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/vscode-extension-samples"
+    "url": "https://github.com/stx-labs/clarinet"
   },
   "engines": {
     "vscode": "^1.52.0"

--- a/components/clarity-vscode/client/src/common.ts
+++ b/components/clarity-vscode/client/src/common.ts
@@ -125,7 +125,7 @@ export async function initClient(
     if (config.misc[surveyConfig] && now >= surveyStart && now <= surveyEnd) {
       window
         .showInformationMessage(
-          "Help us improve Hiro products by telling us about your experience in a short 10 minute survey.",
+          "Help us improve Clarinet by telling us about your experience in a short 10 minute survey.",
           { title: "Take the survey", action: "open-survey" },
           { title: "No thanks", action: "hide" },
         )

--- a/components/clarity-vscode/package-lock.json
+++ b/components/clarity-vscode/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "clarity-lsp",
+  "name": "clarity-stacks",
   "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clarity-lsp",
+      "name": "clarity-stacks",
       "version": "3.8.1",
       "license": "GPL-3.0-only",
       "workspaces": [
@@ -40,7 +40,7 @@
       }
     },
     "client": {
-      "name": "@hirosystems/clarity-vs-code-web-client",
+      "name": "@stacks/clarity-vs-code-web-client",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -463,14 +463,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@hirosystems/clarity-lsp-server": {
-      "resolved": "server",
-      "link": true
-    },
-    "node_modules/@hirosystems/clarity-vs-code-web-client": {
-      "resolved": "client",
-      "link": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1552,6 +1544,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@stacks/clarity-lsp-server": {
+      "resolved": "server",
+      "link": true
+    },
+    "node_modules/@stacks/clarity-vs-code-web-client": {
+      "resolved": "client",
+      "link": true
     },
     "node_modules/@swc/cli": {
       "version": "0.7.8",
@@ -10633,7 +10633,7 @@
       }
     },
     "server": {
-      "name": "@hirosystems/clarity-lsp-server",
+      "name": "@stacks/clarity-lsp-server",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "clarity-lsp",
-  "displayName": "Clarity",
+  "name": "clarity-stacks",
+  "displayName": "Clarity - Stacks Labs",
   "description": "Syntax highlighting, code completion, documentation, and debugging for Clarity smart contracts. Build decentralized applications on Stacks.",
-  "author": "Hiro Systems",
-  "publisher": "hirosystems",
+  "author": "Stacks Labs",
+  "publisher": "stackslabs",
   "icon": "assets/images/clarity-logo.png",
-  "homepage": "https://github.com/hirosystems/clarinet",
-  "bugs": "https://github.com/hirosystems/clarinet/issues",
+  "homepage": "https://github.com/stx-labs/clarinet",
+  "bugs": "https://github.com/stx-labs/clarinet/issues",
   "license": "GPL-3.0-only",
   "version": "3.8.1",
   "private": true,
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/hirosystems/clarinet/"
+    "url": "https://github.com/stx-labs/clarinet"
   },
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",
@@ -35,7 +35,9 @@
   "categories": [
     "Programming Languages",
     "Linters",
-    "Debuggers"
+    "Debuggers",
+    "Formatters",
+    "Testing"
   ],
   "keywords": [
     "clarity",
@@ -49,7 +51,7 @@
     "color": "#242424",
     "theme": "dark"
   },
-  "qna": "https://docs.hiro.so/",
+  "qna": "https://github.com/stx-labs/clarinet/issues",
   "engines": {
     "vscode": "^1.64.0"
   },
@@ -131,7 +133,7 @@
           "clarity-lsp.misc.showDevSurveyQ2-23-1": {
             "type": "boolean",
             "default": false,
-            "description": "Show link to https://survey.hiro.so"
+            "description": "n/a"
           }
         }
       }

--- a/components/clarity-vscode/server/package.json
+++ b/components/clarity-vscode/server/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@hirosystems/clarity-lsp-server",
+  "name": "@stacks/clarity-lsp-server",
   "description": "Example implementation of a language server in a web extension.",
   "version": "1.0.0",
-  "author": "Hugo <hugo@hiro.so>",
+  "author": "Stacks Labs",
   "license": "MIT",
   "engines": {
     "node": "*"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/vscode-extension-samples"
+    "url": "hhttps://github.com/stx-labs/clarinet"
   },
   "dependencies": {
     "node-fetch": "^3.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@hirosystems/clarinet-sdk-workspace",
+  "name": "@stacks/clarinet-sdk-workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@hirosystems/clarinet-sdk-workspace",
+      "name": "@stacks/clarinet-sdk-workspace",
       "license": "GPL-3.0",
       "workspaces": [
         "components/clarinet-sdk-wasm/pkg-node",
@@ -24,34 +24,34 @@
       }
     },
     "components/clarinet-sdk-wasm/pkg-browser": {
-      "name": "@hirosystems/clarinet-sdk-wasm-browser",
+      "name": "@stacks/clarinet-sdk-wasm-browser",
       "version": "3.8.1",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk-wasm/pkg-node": {
-      "name": "@hirosystems/clarinet-sdk-wasm",
+      "name": "@stacks/clarinet-sdk-wasm",
       "version": "3.8.1",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk/browser": {
-      "name": "@hirosystems/clarinet-sdk-browser",
+      "name": "@stacks/clarinet-sdk-browser",
       "version": "3.8.1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm-browser": "3.8.1",
+        "@stacks/clarinet-sdk-wasm-browser": "3.8.1",
         "@stacks/transactions": "^7.0.6"
       }
     },
     "components/clarinet-sdk/common": {
-      "name": "@hirosystems/clarinet-sdk-common",
+      "name": "@stacks/clarinet-sdk-common",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk/node": {
-      "name": "@hirosystems/clarinet-sdk",
+      "name": "@stacks/clarinet-sdk",
       "version": "3.8.1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@hirosystems/clarinet-sdk-wasm": "3.8.1",
+        "@stacks/clarinet-sdk-wasm": "3.8.1",
         "@stacks/transactions": "^7.0.6",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",
@@ -509,26 +509,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@hirosystems/clarinet-sdk": {
-      "resolved": "components/clarinet-sdk/node",
-      "link": true
-    },
-    "node_modules/@hirosystems/clarinet-sdk-browser": {
-      "resolved": "components/clarinet-sdk/browser",
-      "link": true
-    },
-    "node_modules/@hirosystems/clarinet-sdk-common": {
-      "resolved": "components/clarinet-sdk/common",
-      "link": true
-    },
-    "node_modules/@hirosystems/clarinet-sdk-wasm": {
-      "resolved": "components/clarinet-sdk-wasm/pkg-node",
-      "link": true
-    },
-    "node_modules/@hirosystems/clarinet-sdk-wasm-browser": {
-      "resolved": "components/clarinet-sdk-wasm/pkg-browser",
-      "link": true
-    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -968,6 +948,26 @@
         "@noble/hashes": "~1.1.1",
         "@scure/base": "~1.1.0"
       }
+    },
+    "node_modules/@stacks/clarinet-sdk": {
+      "resolved": "components/clarinet-sdk/node",
+      "link": true
+    },
+    "node_modules/@stacks/clarinet-sdk-browser": {
+      "resolved": "components/clarinet-sdk/browser",
+      "link": true
+    },
+    "node_modules/@stacks/clarinet-sdk-common": {
+      "resolved": "components/clarinet-sdk/common",
+      "link": true
+    },
+    "node_modules/@stacks/clarinet-sdk-wasm": {
+      "resolved": "components/clarinet-sdk-wasm/pkg-node",
+      "link": true
+    },
+    "node_modules/@stacks/clarinet-sdk-wasm-browser": {
+      "resolved": "components/clarinet-sdk-wasm/pkg-browser",
+      "link": true
     },
     "node_modules/@stacks/common": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@hirosystems/clarinet-sdk-workspace",
+  "name": "@stacks/clarinet-sdk-workspace",
   "private": true,
   "description": "Workspace hosting the Clarinet SDK for Node.js and Browser",
-  "author": "hirosystems",
+  "author": "stacks-labs",
   "license": "GPL-3.0",
   "workspaces": [
     "components/clarinet-sdk-wasm/pkg-node",


### PR DESCRIPTION
Merge before #2026 

### Description

Rename all occurrences of "hirosystems" related names and IDs to Stacks Labs ones.

- NPM
  - `@hirosystems/clarinet-sdk` -> `@stacks/clarinet-sdk`
  - `@hirosystems/clarinet-sdk-wasm` -> `@stacks/clarinet-sdk-wasm`
  - `@hirosystems/clarinet-sdk-browser` -> `@stacks/clarinet-sdk-browser`
  - `@hirosystems/clarinet-sdk-wasm-browser` -> `@stacks/clarinet-sdk-wasm-browser`
- VSCode
  - the name must be unique regardless of the publisher
  - `hirosystems.clarity-lsp` -> `stacks-labs.clarity-stacks`

--- 

These new packages have already been published as 3.8.1 versions with exactly the same code as the Hirosystem ones.
- https://www.npmjs.com/package/@stacks/clarinet-sdk
- https://marketplace.visualstudio.com/items?itemName=StacksLabs.clarity-stacks