### PR TITLE
ci: update github token in docker image release job

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.TOKEN }}
+          password: ${{ github.token }}
 
       - name: Download release asset
         env:


### PR DESCRIPTION
Use `github.token` for consistency with `github.TOKEN` with #2056 