### PR TITLE
fix: service status update indexing

### DIFF
--- a/components/stacks-network/src/ui/app.rs
+++ b/components/stacks-network/src/ui/app.rs
@@ -74,12 +74,22 @@ impl<'a> App<'a> {
     }
 
     pub fn display_service_status_update(&mut self, service_update: ServiceStatusData) {
-        let insertion_index = service_update.order;
-        if insertion_index == self.services.items.len() {
-            self.services.items.push(service_update)
+        let existing_index = self
+            .services
+            .items
+            .iter()
+            .position(|s| s.name == service_update.name);
+
+        if let Some(index) = existing_index {
+            self.services.items[index] = service_update;
         } else {
-            self.services.items.remove(insertion_index);
-            self.services.items.insert(insertion_index, service_update)
+            let insertion_index = self
+                .services
+                .items
+                .iter()
+                .position(|s| s.order > service_update.order)
+                .unwrap_or(self.services.items.len());
+            self.services.items.insert(insertion_index, service_update);
         }
     }
 


### PR DESCRIPTION
- closes #2061 

Note: The `services.items` is currently a `StatefulList` where I think it would be better as a HashMap or similar (i'm assuming it uses this for a good reason and it would take some digging to figure out if HashMap is possible here)

