### PR TITLE
refactor(linter): Factor some common logic out of unit tests

### DIFF
--- a/components/clarity-repl/src/analysis/lints/noop.rs
+++ b/components/clarity-repl/src/analysis/lints/noop.rs
@@ -254,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_noop_annotation() {
+    fn allow_with_annotation() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-public (test-func)

--- a/components/clarity-repl/src/analysis/lints/unused_const.rs
+++ b/components/clarity-repl/src/analysis/lints/unused_const.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn const_used() {
+    fn used() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-constant MINUTES_PER_HOUR u60)
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn const_used_before_declaration() {
+    fn used_before_declaration() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-read-only (hours-to-minutes (hours uint))
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn const_not_used() {
+    fn not_used() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-constant MINUTES_PER_HOUR u60)
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_with_comment() {
+    fn allow_with_annotation() {
         #[rustfmt::skip]
         let snippet = indoc!("
             ;; #[allow(unused_const)]

--- a/components/clarity-repl/src/analysis/lints/unused_data_var.rs
+++ b/components/clarity-repl/src/analysis/lints/unused_data_var.rs
@@ -246,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn data_var_used() {
+    fn used() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-data-var counter uint u0)
@@ -261,7 +261,7 @@ mod tests {
     }
 
     #[test]
-    fn data_var_not_set() {
+    fn not_set() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-data-var counter uint u0)
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn data_var_not_read() {
+    fn not_read() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-data-var counter uint u0)
@@ -303,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn data_var_not_used() {
+    fn not_used() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-data-var counter uint u0)
@@ -324,7 +324,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_with_comment() {
+    fn allow_with_annotation() {
         #[rustfmt::skip]
         let snippet = indoc!("
             ;; #[allow(unused_data_var)]

--- a/components/clarity-repl/src/analysis/lints/unused_map.rs
+++ b/components/clarity-repl/src/analysis/lints/unused_map.rs
@@ -309,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn map_used_by_insert() {
+    fn used_by_insert() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-map consumed-messages (buff 32) bool)
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn map_used_by_set_and_get() {
+    fn used_by_set_and_get() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-map admins principal bool)
@@ -344,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn map_not_set() {
+    fn not_set() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-map admins principal bool)
@@ -365,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    fn map_not_read() {
+    fn not_read() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-map admins principal bool)
@@ -386,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn map_not_used() {
+    fn not_used() {
         #[rustfmt::skip]
         let snippet = indoc!("
             (define-map admins principal bool)
@@ -407,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_with_comment() {
+    fn allow_with_annotation() {
         #[rustfmt::skip]
         let snippet = indoc!("
             ;; #[allow(unused_map)]

--- a/components/clarity-repl/src/analysis/lints/unused_private_fn.rs
+++ b/components/clarity-repl/src/analysis/lints/unused_private_fn.rs
@@ -338,7 +338,7 @@ mod tests {
     }
 
     #[test]
-    fn allow_with_comment() {
+    fn allow_with_annotation() {
         #[rustfmt::skip]
         let snippet = indoc!("
             ;; #[allow(unused_private_fn)]


### PR DESCRIPTION
### Description

This PR factors some common code out of lint unit  tests to make them smaller, creating a single `run_snippet()` function which handles all configuration and then runs each code snippet

#### Breaking change?

No

