### PR TITLE
feat: Add lint groups to enable/disable multiple lints

### DIFF
--- a/components/clarity-repl/src/analysis/linter.rs
+++ b/components/clarity-repl/src/analysis/linter.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use clarity_types::diagnostic::Level as ClarityDiagnosticLevel;
@@ -8,7 +9,10 @@ use strum::{EnumString, VariantArray};
 
 use crate::analysis::annotation::Annotation;
 
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Hash, VariantArray, EnumString)]
+/// Represents a single linter pass
+#[derive(
+    Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, Hash, VariantArray, EnumString,
+)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 #[serde(rename_all = "snake_case", try_from = "String")]
 #[strum(serialize_all = "snake_case")]
@@ -29,8 +33,65 @@ impl TryFrom<String> for LintName {
     }
 }
 
+/// Represents a set of linter passes
+#[derive(
+    Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, Hash, VariantArray, EnumString,
+)]
+#[cfg_attr(feature = "json_schema", derive(JsonSchema))]
+#[serde(rename_all = "snake_case", try_from = "String")]
+#[strum(serialize_all = "snake_case")]
+pub enum LintGroup {
+    All,
+    Recommended,
+    Unused,
+    Perf,
+    Style,
+    Safety,
+    Misc,
+}
+
+impl LintGroup {
+    pub fn insert_into<T: Copy>(&self, map: &mut HashMap<LintName, T>, value: T) {
+        use LintGroup::*;
+
+        match self {
+            All => {
+                for lint in LintName::VARIANTS {
+                    map.insert(*lint, value);
+                }
+            }
+            Recommended => {
+                Unused.insert_into(map, value);
+                Perf.insert_into(map, value);
+                Safety.insert_into(map, value);
+            }
+            Unused => {
+                map.insert(LintName::UnusedConst, value);
+                map.insert(LintName::UnusedDataVar, value);
+                map.insert(LintName::UnusedMap, value);
+                map.insert(LintName::UnusedPrivateFn, value);
+            }
+            Perf => {
+                map.insert(LintName::Noop, value);
+            }
+            Style => {}
+            Safety => {}
+            Misc => {}
+        }
+    }
+}
+
+/// `strum` can automatically derive `TryFrom<&str>`, but we need a wrapper to work with `String`s
+impl TryFrom<String> for LintGroup {
+    type Error = strum::ParseError;
+
+    fn try_from(s: String) -> Result<LintGroup, Self::Error> {
+        LintGroup::try_from(s.as_str())
+    }
+}
+
 /// Map user intput to `clarity_types::diagnostic::Level` or ignore
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "json_schema", derive(JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum LintLevel {


### PR DESCRIPTION
### Description

Add `repl.analysis.lint_groups` config section and `LintGroup` enum to allow multiple lints to be enabled/disabled at once. The current groups are:

 - `all`
 - `recommended`
 - `unused`
 - `perf`
 - `style`
 - `safety`
 - `misc`

Note that not all of these groups have lints available yet

These groups can be recursively defined. For example, `recommended` is defined as `unused`, `perf`, and `safety`

I made this a separate config item from `repl.analysis.lints` so we can guarantee ordering: All lint groups are processed first, and can be overridden by individual lints

#### Breaking change?

No

### Example

```toml
# Enable all lints except `unused_const`

[repl.analysis.lint_groups]
all = true

[repl.analysis.lints]
unused_const = false
```

### Checklist

- [ ] Tests added in this PR (if applicable)

