### PR TITLE
fix: shim InterpreterResult for future stacks-core

### DIFF
--- a/components/clarity-repl/src/repl/remote_data/context.rs
+++ b/components/clarity-repl/src/repl/remote_data/context.rs
@@ -1,10 +1,12 @@
 use clarity::types::StacksEpochId;
 use clarity::vm::callables::{DefineType, DefinedFunction};
 use clarity::vm::costs::LimitedCostTracker;
-use clarity::vm::errors::{CheckErrors, InterpreterResult as Result, SyntaxBindingErrorType};
+use clarity::vm::errors::{CheckErrors, SyntaxBindingErrorType};
 use clarity::vm::functions::define::DefineFunctionsParsed;
 use clarity::vm::types::parse_name_type_pairs;
 use clarity::vm::{ClarityName, ContractContext, SymbolicExpression};
+
+use crate::utils::InterpreterResult as Result;
 
 fn handle_function(
     epoch_id: &StacksEpochId,

--- a/components/clarity-repl/src/repl/remote_data/mod.rs
+++ b/components/clarity-repl/src/repl/remote_data/mod.rs
@@ -2,12 +2,12 @@ use clarity::types::chainstate::{
     BlockHeaderHash, BurnchainHeaderHash, ConsensusHash, SortitionId, StacksBlockId, VRFSeed,
 };
 use clarity::types::StacksEpochId;
-use clarity::vm::errors::InterpreterResult;
 use clarity_types::types::QualifiedContractIdentifier;
 use serde::de::{DeserializeOwned, Error as SerdeError};
 use serde::{Deserialize, Deserializer};
 
 use crate::repl::settings::ApiUrl;
+use crate::utils::InterpreterResult;
 
 pub mod context;
 pub mod fs;

--- a/components/clarity-repl/src/utils.rs
+++ b/components/clarity-repl/src/utils.rs
@@ -1,6 +1,13 @@
 use ::clarity::vm::events::{FTEventType, NFTEventType, STXEventType, StacksTransactionEvent};
+use clarity::vm::errors::Error as VmExecutionError;
 
 use crate::repl::clarity_values::value_to_string;
+
+// this was removed from stacks-core (https://github.com/stacks-network/stacks-core/commit/3ba954dd0b231adc1f6406f5ef8b4ec22e5768cb#diff-236aa49dfd8ede88d351e87f5df9ee9918a246a8e6a4a48136190385853503feL210)
+// We're adding it back to avoid a huge diff for changing all our uses of InterpreterResult
+// what used to be Error is now called VmExecutionError (https://github.com/stacks-network/stacks-core/commit/3ba954dd0b231adc1f6406f5ef8b4ec22e5768cb#diff-236aa49dfd8ede88d351e87f5df9ee9918a246a8e6a4a48136190385853503feR52-R78)
+// and has slightly different types. When we update to the newer stacks-core we'll have to change this.
+pub type InterpreterResult<R> = Result<R, VmExecutionError>;
 
 pub fn serialize_event(event: &StacksTransactionEvent) -> serde_json::Value {
     match event {


### PR DESCRIPTION
`InterpreterResult` alias was removed from stacks-core [here](https://github.com/stacks-network/stacks-core/commit/3ba954dd0b231adc1f6406f5ef8b4ec22e5768cb#diff-236aa49dfd8ede88d351e87f5df9ee9918a246a8e6a4a48136190385853503feR52-R78) so when we bump the version it would break. This shims it back in for clarinet

