### PR TITLE
ci: set vscode env

### DIFF
--- a/.github/workflows/release-vscode.yaml
+++ b/.github/workflows/release-vscode.yaml
@@ -14,6 +14,8 @@ jobs:
   build-publish:
     name: Build and Publish
     runs-on: ubuntu-latest
+    environment: release-vscode-extension
+
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
### Description

Use the newly set `release-vscode-extension` to get the vsce and ovsx tokens