### PR TITLE
Add Entra ID auth for VSCode Extensions 

### DIFF
--- a/.github/workflows/release-vscode.yaml
+++ b/.github/workflows/release-vscode.yaml
@@ -3,8 +3,7 @@
 
 name: Publish VSCode Extension
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
### Description

This PR change the login phase for the VSCode Extensions to Azure OIDC.

### Example

Improvements on the security side removing the use of a PAT.

---

### Checklist

- [ ] We are still able to publish the extension

