### PR TITLE
Fix: update clarinet to parse new tenure extends

### DIFF
--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -38,8 +38,6 @@ const CLARITY_STORAGE_BLOCK_TIME_KEY: &str = "_stx-data::clarity_storage::block_
 const SECONDS_BETWEEN_BURN_BLOCKS: u64 = 600;
 const SECONDS_BETWEEN_STACKS_BLOCKS: u64 = 10;
 
-type Result<T> = std::result::Result<T, VmExecutionError>;
-
 fn epoch_to_peer_version(epoch: StacksEpochId) -> u8 {
     use clarity::consts::*;
     match epoch {

--- a/components/clarity-repl/src/repl/remote_data/mod.rs
+++ b/components/clarity-repl/src/repl/remote_data/mod.rs
@@ -37,8 +37,6 @@ pub const TESTNET_31_START_HEIGHT: u32 = 814;
 pub const TESTNET_32_START_HEIGHT: u32 = 3_140_887;
 pub const TESTNET_33_START_HEIGHT: u32 = 3_640_102;
 
-type InterpreterResult<T> = std::result::Result<T, VmExecutionError>;
-
 pub fn epoch_for_height(is_mainnet: bool, height: u32) -> StacksEpochId {
     if is_mainnet {
         epoch_for_mainnet_height(height)


### PR DESCRIPTION
### Description

This lets Clarinet parse the new tenure extend variants.

It also updated a couple of imports which was necessary for getting the CLI to compile with the latest from `stacks-core:develop`.

One note on this patch is that it seems like clarinet's build would benefit from using specific git hashes rather than `develop` for the stacks-core dependencies -- otherwise a working build could fail when stacks-core gets updated (which seems to happen somewhat regularly?). I see an ~2 year old issue that is related to this (https://github.com/stx-labs/clarinet/issues/1346), so I'll comment there.