### PR TITLE
fix: rework format-ignore

### DIFF
--- a/components/clarinet-format/src/formatter/ignored.rs
+++ b/components/clarinet-format/src/formatter/ignored.rs
@@ -1,64 +1,85 @@
 use clarity::vm::representations::PreSymbolicExpression;
 
+fn u32_to_usize(val: u32) -> usize {
+    usize::try_from(val).unwrap()
+}
+
+/// spans use 1-based index, this const is largely only for this comment
+const COLUMN_TO_INDEX_OFFSET: usize = 1;
+
 /// Extract the original source text using its span
-/// This is useful for strings where we don't want to touch the formatting
 pub fn extract_expr_source(expr: &PreSymbolicExpression, source: &str) -> String {
     let span = &expr.span;
-    let start_line = usize::try_from(span.start_line).unwrap();
-    let start_column = usize::try_from(span.start_column).unwrap();
+    extract_source_range(
+        source,
+        span.start_line,
+        span.start_column,
+        span.end_line,
+        span.end_column,
+    )
+}
 
-    if let Some(line) = source.lines().nth(start_line - 1) {
-        let start_col = (start_column).saturating_sub(1);
-        let end_col = usize::try_from(span.end_column).unwrap();
+pub fn extract_source_range(
+    source: &str,
+    start_line: u32,
+    start_column: u32,
+    end_line: u32,
+    end_column: u32,
+) -> String {
+    let start_line = u32_to_usize(start_line);
+    let end_line = u32_to_usize(end_line);
+    let start_column = u32_to_usize(start_column);
+    let end_column = u32_to_usize(end_column);
 
-        if start_col < line.len() && end_col <= line.len() {
-            return line[start_col..end_col].to_string();
+    let lines: Vec<&str> = source.lines().collect();
+    let mut result = String::new();
+
+    for line_idx in start_line..=end_line {
+        if line_idx > lines.len() {
+            break;
+        }
+
+        let line = lines[line_idx - COLUMN_TO_INDEX_OFFSET];
+        let is_first_line = line_idx == start_line;
+        let is_last_line = line_idx == end_line;
+
+        if is_first_line && is_last_line {
+            let start_col = start_column.saturating_sub(COLUMN_TO_INDEX_OFFSET);
+            let end_col = end_column.min(line.len());
+            if start_col < end_col {
+                result.push_str(&line[start_col..end_col]);
+            }
+        } else if is_first_line {
+            let start_col = start_column.saturating_sub(COLUMN_TO_INDEX_OFFSET);
+            if start_col < line.len() {
+                result.push_str(&line[start_col..]);
+            }
+            if !is_last_line {
+                result.push('\n');
+            }
+        } else if is_last_line {
+            let end_col = end_column.min(line.len());
+            if end_col > 0 {
+                result.push_str(&line[..end_col]);
+            }
+        } else {
+            // Middle lines
+            result.push_str(line);
+            result.push('\n');
         }
     }
 
-    String::new()
+    result
 }
 
 pub fn ignored_exprs(exprs: &[PreSymbolicExpression], source: &str) -> String {
     let start = exprs.first().unwrap().span();
     let end = exprs.last().unwrap().span();
-
-    let start_line = usize::try_from(start.start_line).unwrap();
-    let end_line = usize::try_from(end.end_line).unwrap();
-
-    let mut result = String::new();
-    let mut is_first = true;
-
-    for (idx, line) in source
-        .lines()
-        .skip(start_line - 1)
-        .take(end_line - start_line + 1)
-        .enumerate()
-    {
-        if !is_first {
-            result.push('\n');
-        }
-
-        if idx == 0 {
-            // First line (the one with the opening parenthesis)
-            if let Some(paren_pos) = line.find('(') {
-                result.push_str(&line[paren_pos..]);
-            }
-        } else if idx == end_line - start_line {
-            // Last line - up to and including end column
-            let end_column = usize::try_from(end.end_column).unwrap();
-            if end_column <= line.len() {
-                result.push_str(&line[..end_column]);
-            } else {
-                result.push_str(line);
-            }
-        } else {
-            // Middle lines - complete line
-            result.push_str(line);
-        }
-
-        is_first = false;
-    }
-
-    result
+    extract_source_range(
+        source,
+        start.start_line,
+        start.start_column,
+        end.end_line,
+        end.end_column,
+    )
 }


### PR DESCRIPTION
closes #2105 

This is a somewhat heavy rework of format-ignore to cache ignored exprs within the main loop. I'm not sure it ever worked since we were only checking at the top level above function signatures.
