### PR TITLE
ci: fix windows release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,6 +156,8 @@ jobs:
 
   dist_clarinet:
     name: Build Clarinet Distributions
+    needs:
+      - get_release_info
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write


### PR DESCRIPTION
### Description

Fix CI following #2114, the condition `needs.get_release_info.outputs.tag != ''` was failing because of the missing `needs` step
