### PR TITLE
chore: upgrade clarity-vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -126,7 +126,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -935,7 +935,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1260,7 +1260,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1407,7 +1407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1442,7 +1442,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if 1.0.4",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2217,7 +2217,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2668,7 +2668,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3298,7 +3298,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3311,7 +3311,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3915,6 +3915,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -4170,7 +4171,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4179,7 +4180,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4829,7 +4830,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/components/clarinet-cli/src/deployments/mod.rs
+++ b/components/clarinet-cli/src/deployments/mod.rs
@@ -22,8 +22,7 @@ pub fn generate_default_deployment(
     network: &StacksNetwork,
     _no_batch: bool,
 ) -> Result<(DeploymentSpecification, DeploymentGenerationArtifacts), String> {
-    let future =
-        clarinet_deployments::generate_default_deployment(manifest, network, false, None, None);
+    let future = clarinet_deployments::generate_default_deployment(manifest, network, false, None);
     hiro_system_kit::nestable_block_on(future)
 }
 

--- a/components/clarinet-deployments/tests/genesis_accounts_funding.rs
+++ b/components/clarinet-deployments/tests/genesis_accounts_funding.rs
@@ -50,7 +50,7 @@ fn fund_geneis_account_with_stx() {
         }],
     };
     let deployment = build_test_deployement_plan(vec![], Some(genesis));
-    update_session_with_deployment_plan(&mut session, &deployment, None, None);
+    update_session_with_deployment_plan(&mut session, &deployment, None);
 
     let assets_maps = session.get_assets_maps();
     assert!(assets_maps.len() == 1);
@@ -72,7 +72,7 @@ fn does_not_fund_sbtc_without_sbtc_contract() {
         }],
     };
     let deployment = build_test_deployement_plan(vec![], Some(genesis));
-    update_session_with_deployment_plan(&mut session, &deployment, None, None);
+    update_session_with_deployment_plan(&mut session, &deployment, None);
 
     let assets_maps = session.get_assets_maps();
     assert!(assets_maps.len() == 1);
@@ -124,7 +124,7 @@ fn can_fund_initial_sbtc_balance() {
         }],
     };
     let deployment = build_test_deployement_plan(vec![batch], Some(genesis));
-    update_session_with_deployment_plan(&mut session, &deployment, None, None);
+    update_session_with_deployment_plan(&mut session, &deployment, None);
 
     let assets_maps = session.get_assets_maps();
     assert!(assets_maps.len() == 2);

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -422,12 +422,8 @@ impl SDK {
             session.enable_coverage_hook();
         }
         session.enable_logger_hook();
-        let executed_contracts = update_session_with_deployment_plan(
-            &mut session,
-            &deployment,
-            Some(&artifacts.asts),
-            Some(DEFAULT_EPOCH),
-        );
+        let executed_contracts =
+            update_session_with_deployment_plan(&mut session, &deployment, Some(&artifacts.asts));
 
         let mut accounts = HashMap::new();
         if let Some(ref spec) = deployment.genesis {
@@ -506,7 +502,6 @@ impl SDK {
             &StacksNetwork::Simnet,
             false,
             Some(&*self.file_accessor),
-            Some(StacksEpochId::Epoch21),
         )
         .await?;
 

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -652,22 +652,13 @@ pub async fn build_state(
         }
     };
 
-    let (deployment, mut artifacts) = generate_default_deployment(
-        &manifest,
-        &StacksNetwork::Simnet,
-        false,
-        file_accessor,
-        Some(StacksEpochId::Epoch21),
-    )
-    .await?;
+    let (deployment, mut artifacts) =
+        generate_default_deployment(&manifest, &StacksNetwork::Simnet, false, file_accessor)
+            .await?;
 
     let mut session = initiate_session_from_manifest(&manifest);
-    let contracts = update_session_with_deployment_plan(
-        &mut session,
-        &deployment,
-        Some(&artifacts.asts),
-        Some(StacksEpochId::Epoch21),
-    );
+    let contracts =
+        update_session_with_deployment_plan(&mut session, &deployment, Some(&artifacts.asts));
     for (contract_id, mut result) in contracts.into_iter() {
         let Some((_, contract_location)) = deployment.contracts.get(&contract_id) else {
             continue;

--- a/components/clarity-vscode/client/package.json
+++ b/components/clarity-vscode/client/package.json
@@ -19,7 +19,7 @@
     "@types/webpack-env": "^1.18.8"
   },
   "dependencies": {
-    "@vscode/test-web": "0.0.77",
+    "@vscode/test-web": "0.0.78",
     "chai": "^6.0.1",
     "mocha": "^11.2.2",
     "vscode-languageclient": "^9.0.1"

--- a/components/clarity-vscode/package-lock.json
+++ b/components/clarity-vscode/package-lock.json
@@ -20,19 +20,19 @@
         "@swc/core": "^1.7.40",
         "@typescript-eslint/eslint-plugin": "^8.11.0",
         "@typescript-eslint/parser": "^8.11.0",
-        "@vscode/test-web": "0.0.77",
+        "@vscode/test-web": "0.0.78",
         "@vscode/vsce": "^3.2.2",
         "@wasm-tool/wasm-pack-plugin": "^1.6.0",
         "concurrently": "^9.1.2",
         "copy-webpack-plugin": "^13.0.0",
         "eslint": "^9.13.0",
-        "ovsx": "^0.10.2",
+        "ovsx": "^0.10.8",
         "path-browserify": "^1.0.1",
         "regenerator-runtime": "^0.14.0",
         "rimraf": "^6.0.1",
         "swc-loader": "^0.2.3",
         "typescript": "^5.0.2",
-        "webpack": "^5.76.0",
+        "webpack": "^5.104.1",
         "webpack-cli": "^6.0.1"
       },
       "engines": {
@@ -44,7 +44,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@vscode/test-web": "0.0.77",
+        "@vscode/test-web": "0.0.78",
         "chai": "^6.0.1",
         "mocha": "^11.2.2",
         "vscode-languageclient": "^9.0.1"
@@ -652,9 +652,9 @@
       }
     },
     "node_modules/@koa/router": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@koa/router/-/router-15.1.0.tgz",
-      "integrity": "sha512-0zCmuapmgBHrfVSFjBfCdgnkBnXwRGcG5qHnxVs8ZoTNEJiwSSspgJ5+2NugiqLJS/S0d96KMeNntLqTNWaioQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-15.2.0.tgz",
+      "integrity": "sha512-7YUhq4W83cybfNa4E7JqJpWzoCTSvbnFltkvRaUaUX1ybFzlUoLNY1SqT8XmIAO6nGbFrev+FvJHw4mL+4WhuQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -2371,13 +2371,13 @@
       }
     },
     "node_modules/@vscode/test-web": {
-      "version": "0.0.77",
-      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.77.tgz",
-      "integrity": "sha512-jeHvZn2crMdX6ICX7vZYeDx6DLxyW07b9EU3cV8zT+coEVQpf4C8zIN6uEBV67xFOUmOi4C1bzFZF5oUkDD7+w==",
+      "version": "0.0.78",
+      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.78.tgz",
+      "integrity": "sha512-gj+Y6fT3vhUu2nAJhY+yxj27QU04it7oZdqDwO5uLWi8yzD8B7ZAWby52ODePJrRPMUndNIvleQZr7v3BowkSA==",
       "license": "MIT",
       "dependencies": {
         "@koa/cors": "^5.0.0",
-        "@koa/router": "^15.0.0",
+        "@koa/router": "^15.2.0",
         "@playwright/browser-chromium": "^1.57.0",
         "gunzip-maybe": "^1.4.2",
         "http-proxy-agent": "^7.0.2",
@@ -7538,9 +7538,9 @@
       }
     },
     "node_modules/ovsx": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.10.7.tgz",
-      "integrity": "sha512-UjBQlB5xSDD+biAylCZ8Q/k3An9K3y9FYa+hT/HTbJkzOQP+gaNHX20CaOo4lrYT1iJXdiePH9zS2uvCXdDNDA==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.10.8.tgz",
+      "integrity": "sha512-Vf6ZQi2l4ENUUdO8eZhduQVcxYjhLt3LT2OL1ah+4XOZjJakanjhDr563wmcqZJZgbK/Tn09RAMkhblrp0lt/g==",
       "dev": true,
       "license": "EPL-2.0",
       "dependencies": {
@@ -10139,9 +10139,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.104.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.0.tgz",
-      "integrity": "sha512-5DeICTX8BVgNp6afSPYXAFjskIgWGlygQH58bcozPOXgo2r/6xx39Y1+cULZ3gTxUYQP88jmwLj2anu4Xaq84g==",
+      "version": "5.104.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
+      "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -248,19 +248,19 @@
     "@swc/core": "^1.7.40",
     "@typescript-eslint/eslint-plugin": "^8.11.0",
     "@typescript-eslint/parser": "^8.11.0",
-    "@vscode/test-web": "0.0.77",
+    "@vscode/test-web": "0.0.78",
     "@vscode/vsce": "^3.2.2",
     "@wasm-tool/wasm-pack-plugin": "^1.6.0",
     "concurrently": "^9.1.2",
     "copy-webpack-plugin": "^13.0.0",
     "eslint": "^9.13.0",
-    "ovsx": "^0.10.2",
+    "ovsx": "^0.10.8",
     "path-browserify": "^1.0.1",
     "regenerator-runtime": "^0.14.0",
     "rimraf": "^6.0.1",
     "swc-loader": "^0.2.3",
     "typescript": "^5.0.2",
-    "webpack": "^5.76.0",
+    "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1"
   }
 }


### PR DESCRIPTION
### Description

- Upgrade clarity-vm
  - Thanks to https://github.com/stacks-network/stacks-core/pull/6764, we don't need to forces the epoch to 2.1 to use parser v2. It will always use parser v2
  - fix #1833 
  

- Upgrade the vscode npm dependencies; i was struggling to get the integration tests running reliably locally, this was fixed with the vscode-test-web upgrade
