### PR TITLE
Fix "`default-features` is ignored for clarity-types..." warning

### DIFF
--- a/components/clarity-lsp/Cargo.toml
+++ b/components/clarity-lsp/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 clarity = { workspace = true, default-features = false, features = ["developer-mode"] }
-clarity-types = { workspace = true, default-features = false, features = ["developer-mode"] }
+clarity-types = { workspace = true, features = ["developer-mode"] }
 lsp-types = "0.97.0"
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -17,7 +17,7 @@ clarinet-deployments = { path = "../clarinet-deployments" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 clarity = { workspace = true, default-features = false, features = ["wasm-web", "developer-mode"] }
-clarity-types = { workspace = true, default-features = false, features = ["wasm-web", "developer-mode"] }
+clarity-types = { workspace = true, features = ["wasm-web", "developer-mode"] }
 console_error_panic_hook = { version = "0.1" }
 js-sys = { workspace = true }
 serde-wasm-bindgen = { workspace = true }

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -36,7 +36,7 @@ strum = { workspace = true, features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clarity = { workspace = true, default-features = false, features = ["rusqlite", "developer-mode", "devtools"] }
-clarity-types = { workspace = true, default-features = false, features = ["developer-mode"] }
+clarity-types = { workspace = true, features = ["developer-mode"] }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 pox-locking = { workspace = true, default-features = true }
 
@@ -57,7 +57,7 @@ memchr = { version = "2.4.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 clarity = { workspace = true, default-features = false, features = ["developer-mode", "devtools", "wasm-web"] }
-clarity-types = { workspace = true, default-features = false, features = ["developer-mode", "wasm-web"] }
+clarity-types = { workspace = true, features = ["developer-mode", "wasm-web"] }
 pox-locking = { workspace = true, default-features = false }
 
 comfy-table = { version = "=7.1.4", default-features = false }


### PR DESCRIPTION
### Description

Fix the following compiler warnings:

```
warning: /home/jbencin/git/stx-labs/clarinet/components/clarity-repl/Cargo.toml: `default-features` is ignored for clarity-types, since `default-features` was not specified for `workspace.dependencies.clarity-types`, this could become a hard error in the future
warning: /home/jbencin/git/stx-labs/clarinet/components/clarity-repl/Cargo.toml: `default-features` is ignored for clarity-types, since `default-features` was not specified for `workspace.dependencies.clarity-types`, this could become a hard error in the future
warning: /home/jbencin/git/stx-labs/clarinet/components/clarity-lsp/Cargo.toml: `default-features` is ignored for clarity-types, since `default-features` was not specified for `workspace.dependencies.clarity-types`, this could become a hard error in the future
warning: /home/jbencin/git/stx-labs/clarinet/components/clarity-lsp/Cargo.toml: `default-features` is ignored for clarity-types, since `default-features` was not specified for `workspace.dependencies.clarity-types`, this could become a hard error in the future
```