### PR TITLE
fix: New CI failure in Clippy 1.93

### DIFF
--- a/components/clarity-repl/src/repl/hooks/perf.rs
+++ b/components/clarity-repl/src/repl/hooks/perf.rs
@@ -366,17 +366,11 @@ impl EvalHook for PerfHook {
                 }
 
                 for (call_stack, cost) in &self.collected_data {
-                    let final_call_stack =
-                        if overhead_runtime > 0 && self.contract_identifier.is_some() {
-                            format!(
-                                "{};{}",
-                                self.contract_identifier.as_ref().unwrap(),
-                                call_stack
-                            )
-                        } else {
-                            call_stack.clone()
-                        };
-                    writeln!(writer, "{} {}", final_call_stack, cost)
+                    let final_call_stack = match &self.contract_identifier {
+                        Some(id) if overhead_runtime > 0 => format!("{id};{call_stack}"),
+                        _ => call_stack.clone(),
+                    };
+                    writeln!(writer, "{final_call_stack} {cost}")
                         .expect("Failed to write to perf output");
                 }
             }


### PR DESCRIPTION
> [!WARNING]
> This needs to be merged ASAP because it's causing most CI jobs to fail  

### Description

Now that our CI is using the Rust 1.93 toolchain, Clippy is failing on this unnecessary use of `is_some()`. I agree that this is ugly and inefficient code, so I rewrote it to use `match` instead

#### Breaking change?

No

### Example

Here is the error message Clippy was giving:

```
error: called `unwrap` on `self.contract_identifier` after checking its variant with `is_some`
   --> components/clarity-repl/src/repl/hooks/perf.rs:373:33
    |
370 |                         if overhead_runtime > 0 && self.contract_identifier.is_some() {
    |                                                    ---------------------------------- the check is happening here
...
373 |                                 self.contract_identifier.as_ref().unwrap(),
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try using `match`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#unnecessary_unwrap
    = note: `-D clippy::unnecessary-unwrap` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_unwrap)]`
```

