### PR TITLE
updated links from hiro docs to stacks docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ code with confidence.
 
 ### Documentation
 
-- [Clarinet CLI](https://docs.hiro.so/stacks/clarinet)
-- [Clarinet JS SDK and testing framework](https://docs.hiro.so/stacks/clarinet-js-sdk)
+- [Clarinet CLI](https://docs.stacks.co/clarinet)
+- [Clarinet JS SDK and testing framework](https://docs.stacks.co/clarinet/testing-with-clarinet-sdk)
 
 ---
 
@@ -33,7 +33,7 @@ brew install clarinet
 ```
 
 > To check out more installation methods, click
-> [here](https://docs.hiro.so/stacks/clarinet#installation)
+> [here](https://docs.stacks.co/clarinet/overview#installation)
 
 ```bash
 # Create a new project

--- a/components/clarinet-cli/examples/counter/tests/counter.test.ts
+++ b/components/clarinet-cli/examples/counter/tests/counter.test.ts
@@ -7,7 +7,7 @@ const address1 = accounts.get("wallet_1")!;
 const address2 = accounts.get("wallet_2")!;
 
 /*
-  The test below is an example. Learn more in the documentation: https://docs.hiro.so/stacks/clarinet-js-sdk
+  The test below is an example. Learn more in the documentation: https://docs.stacks.co/clarinet/testing-with-clarinet-sdk
 */
 
 it("Ensure that counter can be incremented multiples times per block, across multiple blocks", () => {

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1858,7 +1858,7 @@ fn display_post_check_hint() {
         "{}",
         yellow!("    Run all run tests in the ./tests folder.\n")
     );
-    println!("{}", yellow!("Find more information on testing with Clarinet here: https://docs.hiro.so/stacks/clarinet-js-sdk"));
+    println!("{}", yellow!("Find more information on testing with Clarinet here: https://docs.stacks.co/clarinet/testing-with-clarinet-sdk"));
     display_hint_footer();
 }
 
@@ -1888,7 +1888,7 @@ fn display_contract_new_hint(project_name: Option<&str>) {
         yellow!("    Check contract syntax for all files in ./contracts.\n")
     );
 
-    println!("{}", yellow!("Find more information on writing contracts with Clarinet here: https://docs.hiro.so/clarinet/how-to-guides/how-to-set-up-local-development-environment#developing-a-clarity-smart-contract"));
+    println!("{}", yellow!("Find more information on writing contracts with Clarinet here: https://docs.stacks.co/clarinet"));
     display_hint_footer();
 }
 
@@ -1918,7 +1918,7 @@ fn display_deploy_hint() {
     );
     println!(
         "{}",
-        yellow!("Find more information on the devnet here: https://docs.hiro.so/clarinet/guides/how-to-run-integration-environment")
+        yellow!("Find more information on the devnet here: https://docs.stacks.co/clarinet/local-blockchain-development")
     );
     display_hint_footer();
 }

--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -170,7 +170,7 @@ impl GetChangesForNewContract {
 
             /*
             The test below is an example. To learn more, read the testing documentation here:
-            https://docs.hiro.so/stacks/clarinet-js-sdk
+            https://docs.stacks.co/clarinet/testing-with-clarinet-sdk
             */
 
             describe("example tests", () => {

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -890,7 +890,7 @@ rpcport={bitcoin_node_rpc_port}
             panic!("unable to get Docker client");
         };
         let res = docker.list_containers(options).await;
-        let url = "https://docs.hiro.so/tools/clarinet/local-blockchain-development#common-issues";
+        let url = "https://docs.stacks.co/clarinet/local-blockchain-development#common-issues";
         let containers = res.map_err(|e| {
             formatdoc!(
                 "


### PR DESCRIPTION
Updated all of the links of the now outdated Clarinet sections of the Hiro docs to its corresponding sections in the Stacks docs.