### PR TITLE
chore: migrate to ls-types instead of lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,7 +847,7 @@ dependencies = [
  "clarity-types",
  "console_error_panic_hook",
  "js-sys",
- "lsp-types",
+ "ls-types",
  "regex",
  "serde",
  "serde-wasm-bindgen",
@@ -1529,11 +1535,12 @@ dependencies = [
 
 [[package]]
 name = "fluent-uri"
-version = "0.1.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
 dependencies = [
- "bitflags 1.3.2",
+ "borrow-or-share",
+ "ref-cast",
 ]
 
 [[package]]
@@ -2517,16 +2524,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lsp-types"
-version = "0.97.0"
+name = "ls-types"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+checksum = "7a7deb98ef9daaa7500324351a5bab7c80c644cfb86b4be0c4433b582af93510"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.10.0",
  "fluent-uri",
+ "percent-encoding",
  "serde",
  "serde_json",
- "serde_repr",
 ]
 
 [[package]]
@@ -4550,17 +4557,16 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-lsp-server"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f3f8ec0dcfdda4d908bad2882fe0f89cf2b606e78d16491323e918dfa95765"
+checksum = "2f0e711655c89181a6bc6a2cc348131fcd9680085f5b06b6af13427a393a6e72"
 dependencies = [
  "bytes",
  "dashmap",
  "futures",
  "httparse",
- "lsp-types",
+ "ls-types",
  "memchr",
- "percent-encoding",
  "serde",
  "serde_json",
  "tokio",

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -48,7 +48,7 @@ libc = "0.2"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { version = "4.4.4" }
-tower-lsp-server = { version = "0.22.0" }
+tower-lsp-server = { version = "0.23.0" }
 segment = { version = "0.2.4", optional = true }
 mac_address = { version = "1.1.8", optional = true }
 

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -7,7 +7,7 @@ use clarity_repl::clarity::vm::diagnostic::{
     Diagnostic as ClarityDiagnostic, Level as ClarityLevel,
 };
 use crossbeam_channel::unbounded;
-use tower_lsp_server::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use tower_lsp_server::ls_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use tower_lsp_server::{LspService, Server};
 
 use self::native_bridge::LspNativeBridge;
@@ -50,7 +50,7 @@ async fn do_run_lsp() -> Result<(), String> {
 
 pub fn clarity_diagnostics_to_tower_lsp_type(
     diagnostics: &[ClarityDiagnostic],
-) -> Vec<tower_lsp_server::lsp_types::Diagnostic> {
+) -> Vec<tower_lsp_server::ls_types::Diagnostic> {
     diagnostics
         .iter()
         .map(clarity_diagnostic_to_tower_lsp_type)
@@ -59,7 +59,7 @@ pub fn clarity_diagnostics_to_tower_lsp_type(
 
 pub fn clarity_diagnostic_to_tower_lsp_type(
     diagnostic: &ClarityDiagnostic,
-) -> tower_lsp_server::lsp_types::Diagnostic {
+) -> tower_lsp_server::ls_types::Diagnostic {
     let range = match diagnostic.spans.len() {
         0 => Range::default(),
         _ => Range {

--- a/components/clarinet-cli/src/lsp/native_bridge.rs
+++ b/components/clarinet-cli/src/lsp/native_bridge.rs
@@ -5,19 +5,17 @@ use clarity_lsp::backend::{
     process_mutating_request, process_notification, process_request, EditorStateInput,
     LspNotification, LspNotificationResponse, LspRequest, LspRequestResponse,
 };
-use clarity_lsp::lsp_types::{
-    DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams, GotoDefinitionResponse,
-    SignatureHelp, SignatureHelpParams,
-};
 use clarity_lsp::state::EditorState;
 use crossbeam_channel::{Receiver as MultiplexableReceiver, Select, Sender as MultiplexableSender};
 use serde_json::Value;
 use tower_lsp_server::jsonrpc::{Error, ErrorCode, Result};
-use tower_lsp_server::lsp_types::{
+use tower_lsp_server::ls_types::{
     CompletionParams, CompletionResponse, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams,
-    DocumentRangeFormattingParams, ExecuteCommandParams, Hover, HoverParams, InitializeParams,
-    InitializeResult, InitializedParams, MessageType, TextEdit,
+    DocumentRangeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
+    ExecuteCommandParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+    InitializeParams, InitializeResult, InitializedParams, MessageType, SignatureHelp,
+    SignatureHelpParams, TextEdit,
 };
 use tower_lsp_server::{Client, LanguageServer};
 

--- a/components/clarity-lsp/Cargo.toml
+++ b/components/clarity-lsp/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 clarity = { workspace = true, default-features = false, features = ["developer-mode"] }
 clarity-types = { workspace = true, features = ["developer-mode"] }
-lsp-types = "0.97.0"
+ls-types = "0.0.2"
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -4,16 +4,15 @@ use clarinet_files::{FileAccessor, FileLocation, ProjectManifest};
 use clarity_repl::clarity::diagnostic::Diagnostic;
 use clarity_repl::repl::boot::get_boot_contract_epoch_and_clarity_version;
 use clarity_repl::repl::ContractDeployer;
-use lsp_types::{
+use ls_types::{
     CompletionItem, CompletionParams, DocumentFormattingParams, DocumentRangeFormattingParams,
     DocumentSymbol, DocumentSymbolParams, GotoDefinitionParams, Hover, HoverParams,
-    InitializeParams, InitializeResult, Location, ServerInfo, SignatureHelp, SignatureHelpParams,
-    TextEdit,
+    InitializeParams, InitializeResult, Location, MessageType, ServerInfo, SignatureHelp,
+    SignatureHelpParams, TextEdit,
 };
 use serde::{Deserialize, Serialize};
 
 use super::requests::capabilities::{get_capabilities, InitializationOptions};
-use crate::lsp_types::MessageType;
 use crate::state::{build_state, EditorState, ProtocolState};
 use crate::utils::get_contract_location;
 
@@ -395,8 +394,8 @@ pub fn process_request(
                 .and_then(|value| {
                     // FormattingProperty can be boolean, number, or string
                     match value {
-                        lsp_types::FormattingProperty::Number(num) => Some(*num as usize),
-                        lsp_types::FormattingProperty::String(s) => s.parse::<usize>().ok(),
+                        ls_types::FormattingProperty::Number(num) => Some(*num as usize),
+                        ls_types::FormattingProperty::String(s) => s.parse::<usize>().ok(),
                         _ => None,
                     }
                 })
@@ -412,13 +411,13 @@ pub fn process_request(
 
             let formatter = clarinet_format::formatter::ClarityFormatter::new(formatting_options);
             let formatted_result = formatter.format_file(source);
-            let text_edit = lsp_types::TextEdit {
-                range: lsp_types::Range {
-                    start: lsp_types::Position {
+            let text_edit = ls_types::TextEdit {
+                range: ls_types::Range {
+                    start: ls_types::Position {
                         line: 0,
                         character: 0,
                     },
-                    end: lsp_types::Position {
+                    end: ls_types::Position {
                         line: source.lines().count() as u32,
                         character: 0,
                     },
@@ -451,8 +450,8 @@ pub fn process_request(
                 .and_then(|value| {
                     // FormattingProperty can be boolean, number, or string
                     match value {
-                        lsp_types::FormattingProperty::Number(num) => Some(*num as usize),
-                        lsp_types::FormattingProperty::String(s) => s.parse::<usize>().ok(),
+                        ls_types::FormattingProperty::Number(num) => Some(*num as usize),
+                        ls_types::FormattingProperty::String(s) => s.parse::<usize>().ok(),
                         _ => None,
                     }
                 })
@@ -554,7 +553,7 @@ pub fn process_request(
                 }
             };
 
-            let text_edit = lsp_types::TextEdit {
+            let text_edit = ls_types::TextEdit {
                 range: param.range,
                 new_text: formatted_result,
             };
@@ -620,7 +619,7 @@ mod lsp_tests {
 
     use clarinet_files::FileLocation;
     use clarity_repl::clarity::ClarityVersion;
-    use lsp_types::{
+    use ls_types::{
         DocumentRangeFormattingParams, FormattingOptions, Position, Range, TextDocumentIdentifier,
         WorkDoneProgressParams,
     };
@@ -699,8 +698,8 @@ mod lsp_tests {
         let contract_location = FileLocation::FileSystem { path: path.clone() };
 
         let params = GotoDefinitionParams {
-            text_document_position_params: lsp_types::TextDocumentPositionParams {
-                text_document: lsp_types::TextDocumentIdentifier {
+            text_document_position_params: ls_types::TextDocumentPositionParams {
+                text_document: ls_types::TextDocumentIdentifier {
                     uri: contract_location.to_url_string().unwrap().parse().unwrap(),
                 },
                 // Position inside the 'N' constant
@@ -712,7 +711,7 @@ mod lsp_tests {
             work_done_progress_params: WorkDoneProgressParams {
                 work_done_token: None,
             },
-            partial_result_params: lsp_types::PartialResultParams {
+            partial_result_params: ls_types::PartialResultParams {
                 partial_result_token: None,
             },
         };
@@ -724,7 +723,7 @@ mod lsp_tests {
             panic!("Expected a Definition response, got: {response:?}");
         };
 
-        assert_eq!(location.uri.scheme().unwrap().as_str(), "file");
+        assert_eq!(location.uri.scheme().as_str(), "file");
         let response_json = json!(response);
         assert!(response_json
             .get("Definition")

--- a/components/clarity-lsp/src/common/requests/capabilities.rs
+++ b/components/clarity-lsp/src/common/requests/capabilities.rs
@@ -1,4 +1,4 @@
-use lsp_types::{
+use ls_types::{
     CompletionOptions, HoverProviderCapability, ServerCapabilities, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
     TextDocumentSyncSaveOptions,
@@ -53,19 +53,19 @@ pub fn get_capabilities(initialization_options: &InitializationOptions) -> Serve
             false => None,
         },
         document_symbol_provider: match initialization_options.document_symbols {
-            true => Some(lsp_types::OneOf::Left(true)),
+            true => Some(ls_types::OneOf::Left(true)),
             false => None,
         },
         document_formatting_provider: match initialization_options.formatting {
-            true => Some(lsp_types::OneOf::Left(true)),
+            true => Some(ls_types::OneOf::Left(true)),
             false => None,
         },
         document_range_formatting_provider: match initialization_options.formatting {
-            true => Some(lsp_types::OneOf::Left(true)),
+            true => Some(ls_types::OneOf::Left(true)),
             false => None,
         },
         definition_provider: match initialization_options.go_to_definition {
-            true => Some(lsp_types::OneOf::Left(true)),
+            true => Some(ls_types::OneOf::Left(true)),
             false => None,
         },
         signature_help_provider: match initialization_options.signature_help {

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -14,7 +14,7 @@ use clarity_repl::clarity::variables::NativeVariables;
 use clarity_repl::clarity::{ClarityName, ClarityVersion, SymbolicExpression};
 use clarity_repl::repl::DEFAULT_EPOCH;
 use clarity_types::types::TypeSignature;
-use lsp_types::{
+use ls_types::{
     CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
     Position,
 };
@@ -538,7 +538,7 @@ pub fn build_default_native_keywords_list(version: ClarityVersion) -> Vec<Comple
         NativeFunctions::BitwiseXor,
     ];
 
-    let command = lsp_types::Command {
+    let command = ls_types::Command {
         title: "triggerParameterHints".into(),
         command: "editor.action.triggerParameterHints".into(),
         arguments: None,
@@ -828,7 +828,7 @@ mod get_contract_global_data_tests {
     use clarity_repl::clarity::ast::build_ast;
     use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
     use clarity_repl::clarity::{ClarityVersion, StacksEpochId};
-    use lsp_types::Position;
+    use ls_types::Position;
 
     use super::ContractDefinedData;
 
@@ -881,7 +881,7 @@ mod get_contract_local_data_tests {
     use clarity_repl::clarity::ast::build_ast;
     use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
     use clarity_repl::clarity::{ClarityVersion, StacksEpochId};
-    use lsp_types::Position;
+    use ls_types::Position;
 
     use super::ContractDefinedData;
 
@@ -936,7 +936,7 @@ mod populate_snippet_with_options_tests {
     use clarity_repl::clarity::ast::build_ast;
     use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
     use clarity_repl::clarity::{ClarityVersion, StacksEpochId};
-    use lsp_types::Position;
+    use ls_types::Position;
 
     use super::ContractDefinedData;
 

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -7,7 +7,7 @@ use clarity_repl::clarity::vm::types::{
     QualifiedContractIdentifier, StandardPrincipalData, TraitIdentifier,
 };
 use clarity_repl::clarity::{ClarityName, SymbolicExpression};
-use lsp_types::Range;
+use ls_types::Range;
 
 use super::helpers::span_to_range;
 #[cfg(target_arch = "wasm32")]
@@ -669,7 +669,7 @@ mod definitions_visitor_tests {
     use clarity_repl::clarity::ast::build_ast;
     use clarity_repl::clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
     use clarity_repl::clarity::{ClarityVersion, StacksEpochId, SymbolicExpression};
-    use lsp_types::{Position, Range};
+    use ls_types::{Position, Range};
 
     use super::{DefinitionLocation, Definitions};
 

--- a/components/clarity-lsp/src/common/requests/document_symbols.rs
+++ b/components/clarity-lsp/src/common/requests/document_symbols.rs
@@ -4,7 +4,7 @@ use clarity::vm::ClarityVersion;
 use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor};
 use clarity_repl::clarity::representations::Span;
 use clarity_repl::clarity::{ClarityName, SymbolicExpression, SymbolicExpressionType};
-use lsp_types::{DocumentSymbol, SymbolKind};
+use ls_types::{DocumentSymbol, SymbolKind};
 use serde::{Deserialize, Serialize};
 
 use super::helpers::span_to_range;
@@ -492,7 +492,7 @@ mod tests {
     use clarity_repl::clarity::representations::Span;
     use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
     use clarity_repl::clarity::{ClarityVersion, StacksEpochId, SymbolicExpression};
-    use lsp_types::{DocumentSymbol, SymbolKind};
+    use ls_types::{DocumentSymbol, SymbolKind};
 
     use super::ASTSymbols;
     use crate::common::requests::document_symbols::{build_symbol, ClaritySymbolKind};

--- a/components/clarity-lsp/src/common/requests/helpers.rs
+++ b/components/clarity-lsp/src/common/requests/helpers.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use clarity_repl::clarity::representations::Span;
 use clarity_repl::clarity::{ClarityName, SymbolicExpression, SymbolicExpressionType};
-use lsp_types::{Position, Range};
+use ls_types::{Position, Range};
 
 pub fn span_to_range(span: &Span) -> Range {
     if span == &Span::zero() {

--- a/components/clarity-lsp/src/common/requests/hover.rs
+++ b/components/clarity-lsp/src/common/requests/hover.rs
@@ -1,5 +1,5 @@
 use clarity_repl::clarity::SymbolicExpression;
-use lsp_types::Position;
+use ls_types::Position;
 
 use super::api_ref::API_REF;
 use super::helpers::get_expression_name_at_position;

--- a/components/clarity-lsp/src/common/requests/signature_help.rs
+++ b/components/clarity-lsp/src/common/requests/signature_help.rs
@@ -1,5 +1,5 @@
 use clarity_repl::clarity::docs::FunctionAPI;
-use lsp_types::{ParameterInformation, ParameterLabel, Position, SignatureInformation};
+use ls_types::{ParameterInformation, ParameterLabel, Position, SignatureInformation};
 
 use super::api_ref::API_REF;
 use super::helpers::get_function_at_position;
@@ -84,8 +84,8 @@ mod definitions_visitor_tests {
     use clarity_repl::clarity::functions::NativeFunctions;
     use clarity_repl::clarity::ClarityVersion::Clarity2;
     use clarity_repl::clarity::StacksEpochId::Epoch21;
-    use lsp_types::ParameterLabel::Simple;
-    use lsp_types::{ParameterInformation, Position, SignatureInformation};
+    use ls_types::ParameterLabel::Simple;
+    use ls_types::{ParameterInformation, Position, SignatureInformation};
 
     use super::get_signatures;
     use crate::state::ActiveContractData;
@@ -93,7 +93,7 @@ mod definitions_visitor_tests {
     fn get_source_signature(
         source: String,
         position: &Position,
-    ) -> Option<Vec<lsp_types::SignatureInformation>> {
+    ) -> Option<Vec<ls_types::SignatureInformation>> {
         let contract = &ActiveContractData::new(Clarity2, Epoch21, None, source);
         get_signatures(contract, position)
     }

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -16,7 +16,7 @@ use clarity_repl::clarity::vm::types::{QualifiedContractIdentifier, StandardPrin
 use clarity_repl::clarity::vm::EvaluationResult;
 use clarity_repl::clarity::{ClarityName, ClarityVersion, StacksEpochId, SymbolicExpression};
 use clarity_repl::repl::{ContractDeployer, DEFAULT_CLARITY_VERSION};
-use lsp_types::{
+use ls_types::{
     CompletionItem, DocumentSymbol, Hover, Location, MessageType, Position, Range, SignatureHelp,
 };
 
@@ -300,7 +300,7 @@ impl EditorState {
         &self,
         contract_location: &FileLocation,
         position: &Position,
-    ) -> Vec<lsp_types::CompletionItem> {
+    ) -> Vec<ls_types::CompletionItem> {
         let Some(active_contract) = self.active_contracts.get(contract_location) else {
             return vec![];
         };
@@ -357,7 +357,7 @@ impl EditorState {
         &self,
         contract_location: &FileLocation,
         position: &Position,
-    ) -> Option<lsp_types::Location> {
+    ) -> Option<ls_types::Location> {
         let contract = self.active_contracts.get(contract_location)?;
         let position = Position {
             line: position.line + 1,
@@ -422,7 +422,7 @@ impl EditorState {
     pub fn get_hover_data(
         &self,
         contract_location: &FileLocation,
-        position: &lsp_types::Position,
+        position: &ls_types::Position,
     ) -> Option<Hover> {
         let contract = self.active_contracts.get(contract_location)?;
         let position = Position {
@@ -433,8 +433,8 @@ impl EditorState {
             get_expression_documentation(&position, contract.expressions.as_ref()?)?;
 
         Some(Hover {
-            contents: lsp_types::HoverContents::Markup(lsp_types::MarkupContent {
-                kind: lsp_types::MarkupKind::Markdown,
+            contents: ls_types::HoverContents::Markup(ls_types::MarkupContent {
+                kind: ls_types::MarkupKind::Markdown,
                 value: documentation,
             }),
             range: None,
@@ -444,7 +444,7 @@ impl EditorState {
     pub fn get_signature_help(
         &self,
         contract_location: &FileLocation,
-        position: &lsp_types::Position,
+        position: &ls_types::Position,
         active_signature: Option<u32>,
     ) -> Option<SignatureHelp> {
         let contract = self.active_contracts.get(contract_location)?;

--- a/components/clarity-lsp/src/lib.rs
+++ b/components/clarity-lsp/src/lib.rs
@@ -4,4 +4,3 @@ pub mod utils;
 pub mod vscode_bridge;
 
 pub use common::{backend, state};
-pub use lsp_types;

--- a/components/clarity-lsp/src/utils/mod.rs
+++ b/components/clarity-lsp/src/utils/mod.rs
@@ -2,7 +2,7 @@ use clarinet_files::FileLocation;
 use clarity_repl::clarity::vm::diagnostic::{
     Diagnostic as ClarityDiagnostic, Level as ClarityLevel,
 };
-use lsp_types::{Diagnostic as LspDiagnostic, DiagnosticSeverity, Position, Range, Uri};
+use ls_types::{Diagnostic as LspDiagnostic, DiagnosticSeverity, Position, Range, Uri};
 
 #[allow(unused_macros)]
 #[cfg(target_arch = "wasm32")]

--- a/components/clarity-lsp/src/vscode_bridge.rs
+++ b/components/clarity-lsp/src/vscode_bridge.rs
@@ -4,15 +4,15 @@ use std::sync::{Arc, RwLock};
 
 use clarinet_files::{FileAccessor, WASMFileSystemAccessor};
 use js_sys::{Function as JsFunction, Promise};
-use lsp_types::notification::{
+use ls_types::notification::{
     DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, DidSaveTextDocument,
     Initialized, Notification,
 };
-use lsp_types::request::{
+use ls_types::request::{
     Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest, Initialize,
     RangeFormatting, Request, SignatureHelpRequest,
 };
-use lsp_types::{
+use ls_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     DidSaveTextDocumentParams, MessageType, PublishDiagnosticsParams,
 };
@@ -162,8 +162,8 @@ impl LspVscodeBridge {
                 if err.starts_with("No Clarinet.toml is associated to the contract") {
                     let _ = send_notification.call2(
                         &JsValue::NULL,
-                        &encode_to_js(&lsp_types::notification::ShowMessage::METHOD).unwrap(),
-                        &encode_to_js(&lsp_types::ShowMessageParams {
+                        &encode_to_js(&ls_types::notification::ShowMessage::METHOD).unwrap(),
+                        &encode_to_js(&ls_types::ShowMessageParams {
                             typ: MessageType::WARNING,
                             message: String::from(&err),
                         })


### PR DESCRIPTION
### Description

- upgrade tower-lsp-types
- use ls-types: a maintained fork of lsp-types

context: https://github.com/tower-lsp-community/tower-lsp-server/blob/main/CHANGELOG.md#0230---2025-12-07