### PR TITLE
Use `PreSymbolicExpressions` when parsing source for conditional deployment

### DIFF
--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1097,7 +1097,7 @@ impl DeploymentSpecification {
                                     } else {
                                         Epoch::Latest
                                     };
-                                    let source = remove_env_simnet(spec.clarity_version, epoch, &contract_id, spec.source.clone())?;
+                                    let source = remove_env_simnet(epoch, spec.source.clone())?;
                                     contracts.insert(contract_id, (source, spec.location.clone()));
                                     TransactionSpecification::ContractPublish(spec)
                                 }

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -42,6 +42,17 @@ impl PartialEq<StacksEpochId> for Epoch {
     }
 }
 
+impl PartialOrd<StacksEpochId> for Epoch {
+    fn partial_cmp(&self, other: &StacksEpochId) -> Option<std::cmp::Ordering> {
+        let myself = match self {
+            Epoch::Specific(epoch) => epoch,
+            Epoch::Latest => &DEFAULT_EPOCH,
+        };
+
+        StacksEpochId::partial_cmp(myself, other)
+    }
+}
+
 impl Serialize for Epoch {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
### Description

The previous change to allow conditional deployment did a full `AST` parse into `SymbolicExpressions`, which unfortunately did not work well with annotations when the `AST` was reordered due to intra-contract dependencies.  This change instead uses only the first pass of the `AST` parser into `PresymbolicExpressions`, which means that nothing is reordered so the annotations will be tied to the correct expressions.

#### Breaking change?

None

### Example

The unit test has been updated to include intra-contract dependencies, and it still ties the annotation to the correct top level function.

---

### Checklist

- [x] Tests added in this PR (if applicable)

