### PR TITLE
feat: allow ignoring specific vscode warning pop-ups

### DIFF
--- a/components/clarity-lsp/src/vscode_bridge.rs
+++ b/components/clarity-lsp/src/vscode_bridge.rs
@@ -14,7 +14,7 @@ use ls_types::request::{
 };
 use ls_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, MessageType, PublishDiagnosticsParams,
+    DidSaveTextDocumentParams, PublishDiagnosticsParams,
 };
 use serde::Serialize;
 use serde_wasm_bindgen::{from_value as decode_from_js, to_value as encode_to_js, Serializer};
@@ -162,12 +162,8 @@ impl LspVscodeBridge {
                 if err.starts_with("No Clarinet.toml is associated to the contract") {
                     let _ = send_notification.call2(
                         &JsValue::NULL,
-                        &encode_to_js(&ls_types::notification::ShowMessage::METHOD).unwrap(),
-                        &encode_to_js(&ls_types::ShowMessageParams {
-                            typ: MessageType::WARNING,
-                            message: String::from(&err),
-                        })
-                        .unwrap(),
+                        &encode_to_js("clarity/noManifestWarning").unwrap(),
+                        &encode_to_js(&err).unwrap(),
                     );
                 }
                 return Err(JsValue::from(err));

--- a/components/clarity-vscode/client/src/common.ts
+++ b/components/clarity-vscode/client/src/common.ts
@@ -8,6 +8,51 @@ import type { InsightsData, LanguageClient } from "./types";
 
 const { window, workspace } = vscode;
 
+const SUPPRESSED_WARNINGS_KEY = "clarityLsp.suppressedWarnings";
+
+function isWarningSuppressed(context: ExtensionContext, id: string): boolean {
+  const suppressed = context.globalState.get<string[]>(
+    SUPPRESSED_WARNINGS_KEY,
+    [],
+  );
+  return suppressed.includes(id);
+}
+
+async function suppressWarning(
+  context: ExtensionContext,
+  id: string,
+): Promise<void> {
+  const suppressed = context.globalState.get<string[]>(
+    SUPPRESSED_WARNINGS_KEY,
+    [],
+  );
+  if (!suppressed.includes(id)) {
+    await context.globalState.update(SUPPRESSED_WARNINGS_KEY, [
+      ...suppressed,
+      id,
+    ]);
+  }
+}
+
+async function showWarningOnce(
+  context: ExtensionContext,
+  id: string,
+  message: string,
+): Promise<void> {
+  if (isWarningSuppressed(context, id)) {
+    return;
+  }
+
+  const result = await vscode.window.showWarningMessage(
+    message,
+    "Don't show again",
+  );
+
+  if (result === "Don't show again") {
+    await suppressWarning(context, id);
+  }
+}
+
 function isValidInsight(data: InsightsData): data is InsightsData {
   return !!data && !!data.fnName && !!data.fnType && Array.isArray(data.fnArgs);
 }
@@ -113,6 +158,17 @@ export async function initClient(
       console.warn(err);
     }
   }
+
+  client.onNotification(
+    "clarity/noManifestWarning",
+    async (message: string) => {
+      await showWarningOnce(
+        context,
+        "clarity-lsp.no-clarinet-toml-associated",
+        message,
+      );
+    },
+  );
 
   initVFS(client);
   try {


### PR DESCRIPTION
- closes #2155 

Allows ignoring the "No Clarinet.toml" warning in vscode

<img width="481" height="108" alt="Screenshot 2026-02-10 at 8 59 16 AM" src="https://github.com/user-attachments/assets/083d15ca-e0b1-43bf-a7b8-e3e644763d5e" />

https://github.com/user-attachments/assets/b81adb63-6f80-4b9e-b55b-bb51f63a390d


