### PR TITLE
fix: `repl::session::tests::encode_error` failure in certain environments

### DIFF
--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1573,7 +1573,10 @@ mod tests {
         let result = session.encode("::encode { foo false }");
         assert_eq!(
             result,
-            "encode:1:7: error: expected ':' after key in tuple\n{ foo false }\n      ^~~~~\nencoding failed"
+            format!(
+                "encode:1:7: {} expected ':' after key in tuple\n{{ foo false }}\n      ^~~~~\nencoding failed",
+                "error:".red().bold()
+            )
         );
 
         let result = session.encode("::encode (foo 1)");


### PR DESCRIPTION
### Description

The unit test `repl::session::tests::encode_error` failure in certain environments. If there are ANSI color codes in the output of `session.encode()` it sill fail, since it's being tested against a `&str` without any color codes.

The fix is to color the "error:" text using our coloring functions, so it will match the output of `session.encode()` (colored in interactive terminals, no color in other environments)

It works for me locally (on Linux, in Konsole and VSCode's terminal). If it passes in CI it should be okay, but if anyone wants to test on a Mac that would be nice
