### PR TITLE
chore: release 3.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,67 @@
+#### [3.14.0](https://github.com/stx-labs/clarinet/compare/v3.13.1...v3.14.0) 2026-02-12
+
+##### New Features
+
+- Add `unnecessary_public` lint (#2190) (4db92079)
+- Add `error_const` lint (#2186) (3af16427)
+- Improve deployment plan transaction structure (#2175) (81cb8ffe)
+- Add hex string support to toBeBuff matcher (#2176) (63b0041e)
+
+##### Performance Improvements
+
+- Improve Linux performance by using `jemalloc` instead of default allocator (#2149) (fb198d84)
+
+##### Refactors
+
+- Remove a few clone() in orchestrator.rs (#2193) (7eaa919b)
+- Remove forced epoch dead code (#2183) (cf5f55b2)
+- Remove epoch parameter since its no longer necessary (#2180) (76fc0269)
+
+##### Bug Fixes
+
+- Formatter: commented-out function params (#2191) (86f1188a)
+- `deploy_contract` respects cost tracking (#2158) (8e40fe48)
+- Preserve user settings, key ordering, and comments when editing `Clarinet.toml` (#2167) (c1df374c)
+- `encode_error` failure in certain environments (#2192) (552642cf)
+
+##### Chores
+
+- Upgrade stacks docker images (#2171) (210d88f4)
+- Remove generated completions files (#2153) (382f9ebc)
+
+##### Documentation Changes
+
+- Updated links from hiro docs to stacks docs (#2160) (3d62752c)
+
 #### [3.13.1](https://github.com/stx-labs/clarinet/compare/v3.12.0...v3.13.0) 2026-01-16
 
 ##### Bug Fixes
 
-*  Allow multiple lints inside a single `#[allow(...)]` annotation (#2145) (436a939b)
+- Allow multiple lints inside a single `#[allow(...)]` annotation (#2145) (436a939b)
 
 #### [3.13.0](https://github.com/stx-labs/clarinet/compare/v3.12.0...v3.13.0) 2026-01-15
 
 ##### New Features
 
-* **linter:**
-  * Add `unused_binding` lint (#2134) (7ab80d56)
-  * Add `case_const` lint (#2132) (3afd5274)
-  * Add `unused_trait` lint (#2121) (438722e3)
-  * Allow `LintGroup::Unused` lints to ignore identifiers using naming convention (#2138) (46db1fc1)
-  * Enable lints by default (#2141) (a3e4bb8c)
+- **linter:**
+  - Add `unused_binding` lint (#2134) (7ab80d56)
+  - Add `case_const` lint (#2132) (3afd5274)
+  - Add `unused_trait` lint (#2121) (438722e3)
+  - Allow `LintGroup::Unused` lints to ignore identifiers using naming convention (#2138) (46db1fc1)
+  - Enable lints by default (#2141) (a3e4bb8c)
 
 ##### Refactors
 
-* **linter:**  Create struct `AnalysisCache` to share data structures between passes (#2131) (59d43a6e)
-* Add `Session::new_without_boot_contracts()` to avoid loading them in unit tests (#2123) (59ad4435)
+- **linter:** Create struct `AnalysisCache` to share data structures between passes (#2131) (59d43a6e)
+- Add `Session::new_without_boot_contracts()` to avoid loading them in unit tests (#2123) (59ad4435)
 
 ##### Chores
 
-* Update `clarity-repl` to Rust Edition 2021 (#2139) (8dfa44ee)
-* Upgrade default stacks-node docker image (#2137) (dce12e80)
-* Upgrade clarity-vm (#2136) (e34782f9)
-* Upgrade clarity (#2113) (64e5fe1c)
-* Bump `qs` from 6.14.0 to 6.14.1 in /components/clarity-vscode (#2130) (0fb286a0)
+- Update `clarity-repl` to Rust Edition 2021 (#2139) (8dfa44ee)
+- Upgrade default stacks-node docker image (#2137) (dce12e80)
+- Upgrade clarity-vm (#2136) (e34782f9)
+- Upgrade clarity (#2113) (64e5fe1c)
+- Bump `qs` from 6.14.0 to 6.14.1 in /components/clarity-vscode (#2130) (0fb286a0)
 
 # [3.12.0](https://github.com/stx-labs/clarinet/compare/v3.11.0...v3.12.0) (2025-12-18)
 
@@ -34,7 +69,7 @@
 
 - Suggest using encrypted mnemonics in testnet and mainnet TOML files (#2118) (ec5cd306)
 - Generate deployment plan in sdk (#2109) (32269474)
-- **linter:**  Add `unused_token` lint (#2091) (3ac821da)
+- **linter:** Add `unused_token` lint (#2091) (3ac821da)
 - Change encrypted mnemonic output to be pasteable into TOML without editing (#2107) (9b37fe58)
 - Always enable call_checker (#2117)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "bs58",
  "clap",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "bitcoin",
  "clarinet-utils",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "clarinet-deployments",
  "clarinet-files",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-codec"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "clarity",
  "serde",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.13.1"
+version = "3.14.0"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 default-members = ["components/clarinet-cli"]
 
 [workspace.package]
-version = "3.13.1"
+version = "3.14.0"
 
 [workspace.dependencies]
 clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "68c67034326bfcc4565d74e659c8c6144f5adebf", package = "clarity", default-features = false }

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",
@@ -28,7 +28,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@stacks/clarinet-sdk-wasm-browser": "3.13.1",
+    "@stacks/clarinet-sdk-wasm-browser": "3.14.0",
     "@stacks/transactions": "^7.0.6"
   }
 }

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",
@@ -58,7 +58,7 @@
   "license": "GPL-3.0",
   "readme": "./README.md",
   "dependencies": {
-    "@stacks/clarinet-sdk-wasm": "3.13.1",
+    "@stacks/clarinet-sdk-wasm": "3.14.0",
     "@stacks/transactions": "^7.0.6",
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",

--- a/components/clarity-vscode/package-lock.json
+++ b/components/clarity-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clarity-stacks",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clarity-stacks",
-      "version": "3.13.1",
+      "version": "3.14.0",
       "license": "GPL-3.0-only",
       "workspaces": [
         "client",
@@ -1643,6 +1643,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -2129,6 +2130,7 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3102,6 +3104,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3611,6 +3614,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4749,6 +4753,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6536,6 +6541,7 @@
       "resolved": "https://registry.npmjs.org/koa/-/koa-3.1.1.tgz",
       "integrity": "sha512-KDDuvpfqSK0ZKEO2gCPedNjl5wYpfj+HNiuVRlbhd1A88S3M0ySkdf2V/EJ4NWt5dwh5PXCdcenrKK2IQJAxsg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^1.3.8",
         "content-disposition": "~0.5.4",
@@ -8668,6 +8674,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9644,6 +9651,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9845,6 +9853,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10135,6 +10144,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10184,6 +10194,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "private": true,
   "workspaces": [
     "client",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,20 +25,20 @@
     },
     "components/clarinet-sdk-wasm/pkg-browser": {
       "name": "@stacks/clarinet-sdk-wasm-browser",
-      "version": "3.13.1",
+      "version": "3.14.0",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk-wasm/pkg-node": {
       "name": "@stacks/clarinet-sdk-wasm",
-      "version": "3.13.1",
+      "version": "3.14.0",
       "license": "GPL-3.0"
     },
     "components/clarinet-sdk/browser": {
       "name": "@stacks/clarinet-sdk-browser",
-      "version": "3.13.1",
+      "version": "3.14.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@stacks/clarinet-sdk-wasm-browser": "3.13.1",
+        "@stacks/clarinet-sdk-wasm-browser": "3.14.0",
         "@stacks/transactions": "^7.0.6"
       }
     },
@@ -48,10 +48,10 @@
     },
     "components/clarinet-sdk/node": {
       "name": "@stacks/clarinet-sdk",
-      "version": "3.13.1",
+      "version": "3.14.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "@stacks/clarinet-sdk-wasm": "3.13.1",
+        "@stacks/clarinet-sdk-wasm": "3.14.0",
         "@stacks/transactions": "^7.0.6",
         "kolorist": "^1.8.0",
         "prompts": "^2.4.2",


### PR DESCRIPTION
##### New Features

- Add `unnecessary_public` lint (#2190) (4db92079)
- Add `error_const` lint (#2186) (3af16427)
- Improve deployment plan transaction structure (#2175) (81cb8ffe)
- Add hex string support to toBeBuff matcher (#2176) (63b0041e)

##### Performance Improvements

- Improve Linux performance by using `jemalloc` instead of default allocator (#2149) (fb198d84)

##### Refactors

- Remove a few clone() in orchestrator.rs (#2193) (7eaa919b)
- Remove forced epoch dead code (#2183) (cf5f55b2)
- Remove epoch parameter since its no longer necessary (#2180) (76fc0269)

##### Bug Fixes

- Formatter: commented-out function params (#2191) (86f1188a)
- `deploy_contract` respects cost tracking (#2158) (8e40fe48)
- Preserve user settings, key ordering, and comments when editing `Clarinet.toml` (#2167) (c1df374c)
- `encode_error` failure in certain environments (#2192) (552642cf)

##### Chores

- Upgrade stacks docker images (#2171) (210d88f4)
- Remove generated completions files (#2153) (382f9ebc)

##### Documentation Changes

- Updated links from hiro docs to stacks docs (#2160) (3d62752c)
