### PR TITLE
fix: correct typo in contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ specification when writing commit messages.
 **Note:** These conventions are helpful for any commit message, but all PR end up being merged with
 "squash and merge", giving an other chance to refine the commit messages.
 
-To start contributing, fork this repo and open a new branc:
+To start contributing, fork this repo and open a new branch:
 
 1. Fork this repo and clone the fork locally.
 1. Create a new branch


### PR DESCRIPTION
### Description

<!-- Describe the bug this PR fixes or the feature it adds. Link to any related issues and PRs -->

Fixed a typo in the Contributing section of the README where "branc" was misspelled. Changed it to the correct spelling "branch" for clarity.

**File changed:** [README.md](cci:7://file:///F:/Github%20contributation/stacks.js/README.md:0:0-0:0) (line 105)

```diff
- To start contributing, fork this repo and open a new branc:
+ To start contributing, fork this repo and open a new branch: