### PR TITLE
fix: Add suggestion to suffix item with '_' to some `unused_*` lints

### DIFF
--- a/components/clarity-repl/src/analysis/lints/unused_binding.rs
+++ b/components/clarity-repl/src/analysis/lints/unused_binding.rs
@@ -71,7 +71,10 @@ impl<'a, 'b> UnusedBinding<'a, 'b> {
         };
         (
             msg,
-            Some("Remove this expression or suffix binding with '_' if this is intentional".to_string()),
+            Some(
+                "Remove this expression or suffix binding with '_' if this is intentional"
+                    .to_string(),
+            ),
         )
     }
 

--- a/components/clarity-repl/src/analysis/lints/unused_private_fn.rs
+++ b/components/clarity-repl/src/analysis/lints/unused_private_fn.rs
@@ -102,7 +102,10 @@ impl<'a> UnusedPrivateFn<'a> {
     fn make_diagnostic_strings(name: &ClarityName) -> (String, Option<String>) {
         (
             format!("private function `{name}` is never used"),
-            Some("Remove this expression or suffix function name with '_' if this is intentional".to_string()),
+            Some(
+                "Remove this expression or suffix function name with '_' if this is intentional"
+                    .to_string(),
+            ),
         )
     }
 


### PR DESCRIPTION
### Description

Add suggestion to suffix item with '_' to some `unused_*` lints

For some unused items, it may be desirable to keep them around, in particular:
- `unused_private_fn`: May be for unit testing
- `unused_binding`: May be side-effects from the assignment

We should provide this hint for users since it may be a common practice