### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Clarinet
 
+[![CI](https://github.com/stx-labs/clarinet/actions/workflows/ci.yaml/badge.svg)](https://github.com/stx-labs/clarinet/actions/workflows/ci.yaml)
+[![Release](https://img.shields.io/github/v/release/stx-labs/clarinet)](https://github.com/stx-labs/clarinet/releases/latest)
+[![npm](https://img.shields.io/npm/v/@stacks/clarinet-sdk)](https://www.npmjs.com/package/@stacks/clarinet-sdk)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/stackslabs.clarity-stacks?label=VSCode)](https://marketplace.visualstudio.com/items?itemName=stackslabs.clarity-stacks)
+
 Clarinet is the fastest way to build, test, and deploy smart contracts on the Stacks blockchain. It
 gives you a local devnet, REPL, testing framework, and debugging tools to ship high-quality Clarity
 code with confidence.


### PR DESCRIPTION
### Description

I asked Claude to review our `README.md` and here is what it said:

```
  Incorrect Items

  1. Line 116: Wrong path for cargo config — The README says cargo tst is "declared in ./cargo/config" but the actual file is .cargo/config.toml. Missing the leading dot and the .toml extension.
  2. Line 119–126: examples directory does not exist — The README instructs contributors to run functional tests in the examples directory, but no examples/ directory exists in the repo. This entire section is stale/outdated and will confuse contributors.
  3. Line 136: Copy-paste error in SDK description — "the TS wrapper around it: ./components/clarinet-sdk-wasm" should be ./components/clarinet-sdk. Both the Rust lib and the TS wrapper are listed as the same path.
  4. Line 146: Broken Code of Conduct link — The link ../../../.github/blob/main/CODE_OF_CONDUCT.md is a relative path that resolves to three directories above the repo root, which doesn't exist on disk. This was likely intended to be a GitHub URL to a .github organization-level repo (e.g., https://github.com/stx-labs/.github/blob/main/CODE_OF_CONDUCT.md), not a relative file path.

  Needs Clarification / Could Be Better

  5. Lines 89–93: Pinned prerequisite versions are very specific — Listing Rust >=1.89.0, Node >=v24.4.1, and NPM >=11.5.2 as minimums is unusually precise for a "minimum" requirement. The rust-toolchain file just says channel = "stable". These versions will age quickly and may confuse people who have slightly older stable versions that work fine. Consider either saying "latest stable" or documenting actual tested minimums.
  6. Line 32: brew install clarinet — This may or may not be the current installation method. I couldn't verify it's in Homebrew. If it's been removed or is only available via a tap, this quickstart will fail immediately for new users.
  7. Lines 7–17: Inconsistent bullet formatting — The first three features use bold text with no colon, while the fourth ("VSCode extension") uses a colon and different phrasing style. The fourth also lacks a verb ("helps writing" vs. the imperative style of the others).
  8. Line 100: Grammar — "giving an other chance" should be "giving another chance".
  9. Line 142: Capitalization — Readme.md should be README.md to match the actual file name.

  Missing Items

  10. No mention of the VSCode extension in Contributing — There's a "Contributing to the CLI" section and a "Contributing to the JS SDK" section, but no "Contributing to the VSCode Extension" section, despite the extension being listed as a feature at the top.
  11. No license information — The package.json says GPL-3.0 but the README doesn't mention the license anywhere. Most open-source READOs include a License section.
  12. No badges — Many projects include CI status, latest version, and license badges at the top. Not essential, but common for discoverability and trust.
  13. No link to the VSCode extension marketplace listing — The VSCode extension is called out as a feature but there's no link to install it from the marketplace.
  14. Section heading levels are inconsistent — "Contributing" and "Quickstart" are ### (h3), "Community" is ## (h2), and "Code of Conduct" is ### (h3). There's no ## or # parent for the ### sections, which is semantically odd.
```

I fixed 1-3, 7-9, and 11-14. I couldn't find the proper link to fix 4, the rest didn't seem that important