### PR TITLE
fix: start api container when ready

### DIFF
--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1560,12 +1560,11 @@ db_path = "stacks-signer-{signer_id}.sqlite"
             .await
             .map_err(|e| formatted_docker_error("unable to start stacks-api container", e))?;
 
-        let devnet_config = match &self.network_config {
-            Some(ref network_config) => match network_config.devnet {
-                Some(ref devnet_config) => devnet_config,
-                _ => return Ok(()),
-            },
-            _ => return Ok(()),
+        let Some(network_config) = &self.network_config else {
+            return Ok(());
+        };
+        let Some(devnet_config) = &network_config.devnet else {
+            return Ok(());
         };
 
         // Check if we need to import events


### PR DESCRIPTION
### Description

Addressing a old todo that I found.
Instead of waiting an arbitrary 8 seconds, start the container when it's actually ready.
Making it faster when it takes less than 8secs, and more robust in the events it might take more

(On my M4 Pro, it's about 5 seconds faster)

We may want to review other wait timing in the orchestrator to get the boot up a bit faster

Added a small refactor on the double `match` above
