### PR TITLE
ci: prevent silent error on vsce publish

### DIFF
--- a/.github/workflows/release-vscode.yaml
+++ b/.github/workflows/release-vscode.yaml
@@ -40,7 +40,6 @@ jobs:
         run: npx vsce package --out clarity.vsix
 
       - name: Publish to VSCode Marketplace
-        continue-on-error: true
         run: npx vsce publish --packagePath clarity.vsix --pat ${{ secrets.VSCE_TOKEN }}
 
       - name: Publish to Open VSX


### PR DESCRIPTION
### Description

With `continue-on-error: true`, the goal was to still try to publish on ovsx even though the job fails on vsce for some reason.
This is actually too risky because it marks the jobs as successful and silence any vsce error (eg: this job https://github.com/stx-labs/clarinet/actions/runs/21073640805).
So it's better to just stop the job and fail