### PR TITLE
fix: Highlight binding name instead of expression in `unused_binding` lint

### DIFF
--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
 
 use clarity::vm::types::{BlockInfoProperty, FunctionType, TypeSignatureExt};
-use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, TypedVar};
+use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, LetBinding, TypedVar};
 use clarity_repl::clarity::analysis::ContractAnalysis;
 use clarity_repl::clarity::docs::{
     make_api_reference, make_define_reference, make_keyword_reference,
@@ -335,12 +335,13 @@ impl<'a> ASTVisitor<'a> for ContractDefinedData {
     fn visit_let(
         &mut self,
         expr: &'a SymbolicExpression,
-        bindings: &HashMap<&'a ClarityName, &'a SymbolicExpression>,
+        bindings: &HashMap<&'a ClarityName, LetBinding<'a>>,
         _body: &'a [SymbolicExpression],
     ) -> bool {
         if is_position_within_span(&self.position, &expr.span, 0) {
-            for (name, value) in bindings {
-                self.locals.push((name.to_string(), value.to_string()));
+            for (name, binding) in bindings {
+                self.locals
+                    .push((name.to_string(), binding.value.to_string()));
             }
         }
         true

--- a/components/clarity-lsp/src/common/requests/document_symbols.rs
+++ b/components/clarity-lsp/src/common/requests/document_symbols.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use clarity::vm::ClarityVersion;
-use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor};
+use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, LetBinding};
 use clarity_repl::clarity::representations::Span;
 use clarity_repl::clarity::{ClarityName, SymbolicExpression, SymbolicExpressionType};
 use ls_types::{DocumentSymbol, SymbolKind};
@@ -338,19 +338,19 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_let(
         &mut self,
         expr: &'a SymbolicExpression,
-        bindings: &HashMap<&'a ClarityName, &'a SymbolicExpression>,
+        bindings: &HashMap<&'a ClarityName, LetBinding<'a>>,
         body: &'a [SymbolicExpression],
     ) -> bool {
         let mut children: Vec<DocumentSymbol> = Vec::new();
 
         let mut bindings_children: Vec<DocumentSymbol> = Vec::new();
-        for (name, expr) in bindings.iter() {
+        for (name, binding) in bindings.iter() {
             bindings_children.push(build_symbol(
                 name.as_str(),
                 None,
                 ClaritySymbolKind::LET_BINDING,
-                &expr.span,
-                self.children_map.remove(&expr.id),
+                &binding.value.span,
+                self.children_map.remove(&binding.value.id),
             ))
         }
         if !bindings_children.is_empty() {


### PR DESCRIPTION
### Description

Fixes: #2214

Highlight binding name instead of expression in `unused_binding` lint. This was caused by the desired information not being available in `ASTVisitor::traverse_let()`, so that has been fixed to include a `Span` for the binding name also

#### Breaking change?

No

### Example

Sample output from `clarinet check`:

```
warning: `let` binding `check1` is never used
--> /home/jbencin/git/stx-labs/stacks-wormhole-ntt/contracts/ntt-manager-v1.clar:238:10
  (let ((check1 (try! (check-enabled)))
         ^~~~~~
Remove this expression or suffix binding with '_' if this is intentional
```