### PR TITLE
chore: Remove unused dependencies in `clarinet-cli` and `clarity-repl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,6 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 name = "clarinet-cli"
 version = "3.14.0"
 dependencies = [
- "bs58",
  "clap",
  "clap_complete",
  "clarinet-deployments",
@@ -684,19 +683,14 @@ dependencies = [
  "colored",
  "crossbeam-channel",
  "crossterm",
- "ctrlc",
  "hiro-system-kit",
  "indoc",
- "libc",
  "mac_address",
- "nix 0.30.1",
- "rand 0.8.5",
  "ratatui",
  "rpassword",
  "segment",
  "serde",
  "serde_json",
- "signal-hook 0.4.3",
  "similar",
  "stacks-network",
  "tempfile",
@@ -705,7 +699,6 @@ dependencies = [
  "toml",
  "toml_edit",
  "tower-lsp-server",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -889,7 +882,6 @@ dependencies = [
  "rustyline",
  "schemars 1.2.1",
  "serde",
- "serde-wasm-bindgen",
  "serde_derive",
  "serde_json",
  "sha2 0.10.9",

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -16,20 +16,16 @@ categories = [
 ]
 
 [dependencies]
-bs58 = { workspace = true }
 colored = { workspace = true }
 crossbeam-channel = "0.5.6"
 crossterm = { workspace = true }
-ctrlc = "3.1.9"
 indoc = { workspace = true }
-rand = { workspace = true }
 ratatui = { workspace = true }
 rpassword = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 similar = "2.1.0"
 tokio = { workspace = true }
-toml = { workspace = true }
 toml_edit = { workspace = true }
 
 clarity-repl = { package = "clarity-repl", path = "../clarity-repl" }
@@ -41,11 +37,6 @@ clarinet-utils = { path = "../clarinet-utils" }
 hiro-system-kit = { path = "../hiro-system-kit" }
 stacks-network = { path = "../stacks-network" }
 
-[target.'cfg(unix)'.dependencies]
-nix = "0.30.1"
-signal-hook = { workspace = true, features = ["iterator"] }
-libc = "0.2"
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { version = "4.4.4" }
@@ -53,28 +44,13 @@ tower-lsp-server = { version = "0.23.0" }
 segment = { version = "0.2.4", optional = true }
 mac_address = { version = "1.1.8", optional = true }
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = [
-    "knownfolders",
-    "mswsock",
-    "objbase",
-    "shlobj",
-    "tlhelp32",
-    "winbase",
-    "winerror",
-    "winsock2",
-    "std",
-    "handleapi",
-    "ws2ipdef",
-    "ws2tcpip",
-] }
-
 # Must match condition in bin.rs EXACTLY
 [target.'cfg(not(any(target_env = "msvc", target_os = "macos")))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+toml = { workspace = true }
 
 [package.metadata.winres]
 OriginalFilename = "clarinet.exe"

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -64,7 +64,6 @@ pox-locking = { workspace = true, default-features = false }
 comfy-table = { version = "=7.2.2", default-features = false }
 js-sys = { version = "0.3" }
 hiro-system-kit = { path = "../hiro-system-kit", default-features = false }
-serde-wasm-bindgen = { workspace = true }
 wasm-bindgen = { workspace = true }
 web-sys = { workspace = true }
 


### PR DESCRIPTION
### Description

Remove unused dependencies in `clarinet-cli` and `clarity-repl`. I tried to build/test locally, but if the CI still passes we can be sure they were really unused.