### PR TITLE
fix: devnet timing

### DIFF
--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1584,6 +1584,8 @@ db_path = "stacks-signer-{signer_id}.sqlite"
                     }
                     tokio::time::sleep(Duration::from_millis(500)).await;
                 }
+                // the container seems to need an extra second to be really ready
+                tokio::time::sleep(Duration::from_millis(1000)).await;
 
                 ctx.try_log(|logger| {
                     slog::info!(logger, "Importing events from {}", events_path.display())


### PR DESCRIPTION
### Description

Apparently #2220 was a regression, making the devnet less stable. If the container is ready in the first iteration of the loop, there seem  to be to little time for the container to be "really ready" - whatever that means.

And the devnet would fail to start.

I see no difference in the container info within the loop and after the sleep. So far, I haven't found a way to reliably check that the startup is ready to continue. Adding this additional sleep as a patch of #2220, and we'll keep investigating in #2225 once this is merged. 

