### PR TITLE
feat: group docker containers in devnet

### DIFF
--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -1,3 +1,4 @@
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::Write;
@@ -57,6 +58,7 @@ pub struct DevnetOrchestrator {
     docker_client: Option<Docker>,
     services_map_hosts: Option<ServicesMapHosts>,
     save_container_logs: bool,
+    container_index: Cell<u32>,
 }
 #[derive(Clone, Debug)]
 pub struct ServicesMapHosts {
@@ -175,6 +177,7 @@ impl DevnetOrchestrator {
             postgres_container_id: None,
             services_map_hosts: None,
             save_container_logs: false,
+            container_index: Cell::new(0),
         })
     }
 
@@ -203,8 +206,24 @@ impl DevnetOrchestrator {
         Ok(())
     }
 
-    fn project_labels(&self, reset: bool) -> HashMap<String, String> {
-        let mut labels = HashMap::from([("project".to_string(), self.network_name.clone())]);
+    fn project_labels(&self, service: &str, reset: bool) -> HashMap<String, String> {
+        self.container_index.set(self.container_index.get() + 1);
+        let mut labels = HashMap::from([
+            ("project".to_string(), self.network_name.clone()),
+            // the docker.compose.* labels make the project behave like a docker compose one
+            // so users can do `docker compose -p <self.name> logs -f`
+            ("com.docker.compose.project".to_string(), self.name.clone()),
+            ("com.docker.compose.config-hash".to_string(), "".to_string()),
+            ("com.docker.compose.oneoff".to_string(), "False".to_string()),
+            (
+                "com.docker.compose.service".to_string(),
+                service.to_string(),
+            ),
+            (
+                "com.docker.compose.container-number".to_string(),
+                self.container_index.get().to_string(),
+            ),
+        ]);
         if reset {
             labels.insert("reset".to_string(), "true".to_string());
         }
@@ -705,7 +724,7 @@ impl DevnetOrchestrator {
             ),
         ]);
 
-        let labels = self.project_labels(true);
+        let labels = self.project_labels("bitcoin-node", true);
 
         let mut env = vec![];
         if devnet_config.bitcoin_controller_automining_disabled {
@@ -1076,7 +1095,7 @@ impl DevnetOrchestrator {
             ),
         ]);
 
-        let labels = self.project_labels(true);
+        let labels = self.project_labels("stacks-node", true);
 
         let mut binds = vec![format!(
             "{}/conf:/src/stacks-node/",
@@ -1225,7 +1244,7 @@ impl DevnetOrchestrator {
         fs::create_dir_all(stacks_signer_data_path)
             .map_err(|e| format!("unable to create stacks directory: {e:?}"))?;
 
-        let labels = self.project_labels(true);
+        let labels = self.project_labels(&format!("stacks-signer-{signer_id}"), true);
 
         let mut binds = vec![format!(
             "{}/conf:/src/stacks-signer/",
@@ -1344,7 +1363,7 @@ impl DevnetOrchestrator {
             HashMap::new(),
         )]);
 
-        let labels = self.project_labels(true);
+        let labels = self.project_labels("stacks-api", true);
 
         let mut env = vec![
             format!("STACKS_CORE_RPC_HOST=stacks-node.{}", self.network_name),
@@ -1533,7 +1552,7 @@ impl DevnetOrchestrator {
 
         let exposed_ports = HashMap::new();
 
-        let labels = self.project_labels(true);
+        let labels = self.project_labels("postgres", true);
 
         let config = Config {
             labels: Some(labels),
@@ -1609,7 +1628,7 @@ impl DevnetOrchestrator {
 
         let exposed_ports = HashMap::from([(format!("{explorer_guest_port}/tcp"), HashMap::new())]);
 
-        let labels = self.project_labels(false);
+        let labels = self.project_labels("stacks-explorer", false);
 
         let mut env = vec![
             format!(
@@ -1707,7 +1726,7 @@ impl DevnetOrchestrator {
             HashMap::new(),
         )]);
 
-        let labels = self.project_labels(false);
+        let labels = self.project_labels("bitcoin-explorer", false);
 
         let config = Config {
             labels: Some(labels),


### PR DESCRIPTION
### Description

Grouping containers with the same project label, making them behave as a Docker Compose project.

I wanted to do that for a while and the recent introduction of `fn project_labels()` makes it quite easy

before / after
<img width="881" height="522" alt="before" src="https://github.com/user-attachments/assets/d0379c87-7e92-4335-9b70-d89fbd582629" />
<img width="917" height="581" alt="after" src="https://github.com/user-attachments/assets/a0a254cd-4fad-4c6f-a5f6-ac5e379c8a48" />

From a CLI perspective, it also allows to do cool stuff with `docker compose`
```sh
stacks-labs/clarity-starter
> docker compose -p project-template ps
NAME                                       IMAGE                                           ...
bitcoin-explorer.project-template.devnet   quay.io/hirosystems/bitcoin-explorer:devnet     ...
bitcoin-node.project-template.devnet       lncm/bitcoind:v27.2                             ...
postgres.project-template.devnet           postgres:alpine                                 ...
stacks-api.project-template.devnet         hirosystems/stacks-blockchain-api:latest        ...
stacks-explorer.project-template.devnet    hirosystems/explorer:latest                     ...
stacks-node.project-template.devnet        blockstack/stacks-blockchain:3.3.0.0.5-alpine   ...
stacks-signer-0.project-template.devnet    blockstack/stacks-signer:3.3.0.0.5.0-alpine     ...
```

Or log everything with
```sh
> docker compose -p project-template logs -f
```