### PR TITLE
refactor: don't expose clarity crate from clarity-repl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "clarinet-files",
  "clarinet-format",
  "clarinet-utils",
+ "clarity",
  "clarity-lsp",
  "clarity-repl",
  "colored",
@@ -805,6 +806,7 @@ version = "3.15.0"
 dependencies = [
  "clap",
  "clarinet-files",
+ "clarity",
  "clarity-repl",
  "serde",
  "serde_json",

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -16,6 +16,7 @@ categories = [
 ]
 
 [dependencies]
+clarity = { workspace = true }
 colored = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossterm = { workspace = true }

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -24,13 +24,14 @@ use clarinet_files::{
     StacksNetwork,
 };
 use clarinet_format::formatter::{self, ClarityFormatter};
+use clarity::types::StacksEpochId;
+use clarity::vm::analysis::AnalysisDatabase;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::diagnostic::Diagnostic;
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::ClarityVersion;
 use clarity_lsp::state::Environment;
 use clarity_repl::analysis::call_checker::ContractAnalysis;
-use clarity_repl::clarity::vm::analysis::AnalysisDatabase;
-use clarity_repl::clarity::vm::costs::LimitedCostTracker;
-use clarity_repl::clarity::vm::diagnostic::Diagnostic;
-use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
-use clarity_repl::clarity::{ClarityVersion, StacksEpochId};
 use clarity_repl::frontend::Terminal;
 use clarity_repl::repl::diagnostic::output_diagnostic;
 use clarity_repl::repl::settings::{ApiUrl, RemoteDataSettings};
@@ -2788,7 +2789,7 @@ mod tests {
                 name: "special".to_string(),
                 deployer: ContractDeployer::LabeledDeployer("wallet_1".to_string()),
                 clarity_version: ClarityVersion::Clarity3,
-                epoch: Epoch::Specific(clarity_repl::clarity::StacksEpochId::Epoch25),
+                epoch: Epoch::Specific(StacksEpochId::Epoch25),
                 skip_analysis: false,
             };
 
@@ -2996,7 +2997,7 @@ mod tests {
 
     #[test]
     fn test_check_json_output() {
-        use clarity_repl::clarity::vm::diagnostic::Level as DiagnosticLevel;
+        use clarity::vm::diagnostic::Level as DiagnosticLevel;
 
         let snippet = indoc::indoc! {"
             (define-constant A u1)

--- a/components/clarinet-cli/src/frontend/telemetry.rs
+++ b/components/clarinet-cli/src/frontend/telemetry.rs
@@ -1,5 +1,5 @@
 use clarinet_files::StacksNetwork;
-use clarity_repl::clarity::util::hash::{bytes_to_hex, Hash160};
+use clarity::util::hash::{bytes_to_hex, Hash160};
 use mac_address::get_mac_address;
 use segment::message::{Message, Track, User};
 use segment::{Client, HttpClient};

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -2,10 +2,8 @@ mod native_bridge;
 
 use std::sync::mpsc;
 
+use clarity::vm::diagnostic::{Diagnostic as ClarityDiagnostic, Level as ClarityLevel};
 use clarity_lsp::utils;
-use clarity_repl::clarity::vm::diagnostic::{
-    Diagnostic as ClarityDiagnostic, Level as ClarityLevel,
-};
 use crossbeam_channel::unbounded;
 use tower_lsp_server::ls_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 use tower_lsp_server::{LspService, Server};

--- a/components/clarinet-deployments/src/diagnostic_digest.rs
+++ b/components/clarinet-deployments/src/diagnostic_digest.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use clarity_repl::clarity::diagnostic::{Diagnostic, Level};
-use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::diagnostic::{Diagnostic, Level};
+use clarity::vm::types::QualifiedContractIdentifier;
 use clarity_repl::repl::diagnostic::output_code;
 use colored::Colorize;
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -11,14 +11,12 @@ use std::path::Path;
 
 use clarinet_defaults::DEFAULT_EPOCH;
 use clarinet_files::{paths, FileAccessor, NetworkManifest, ProjectManifest, StacksNetwork};
+use clarity::types::StacksEpochId;
+use clarity::vm::ast::ContractAST;
+use clarity::vm::diagnostic::Diagnostic;
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
+use clarity::vm::{ContractName, EvaluationResult, ExecutionResult, SymbolicExpression};
 use clarity_repl::analysis::ast_dependency_detector::{ASTDependencyDetector, DependencySet};
-use clarity_repl::clarity::vm::ast::ContractAST;
-use clarity_repl::clarity::vm::diagnostic::Diagnostic;
-use clarity_repl::clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
-use clarity_repl::clarity::vm::{
-    ContractName, EvaluationResult, ExecutionResult, SymbolicExpression,
-};
-use clarity_repl::clarity::StacksEpochId;
 use clarity_repl::repl::boot::{
     get_boot_contract_epoch_and_clarity_version, BOOT_CONTRACTS_DATA, SBTC_DEPOSIT_MAINNET_ADDRESS,
     SBTC_MAINNET_ADDRESS, SBTC_TESTNET_ADDRESS_PRINCIPAL, SBTC_TOKEN_MAINNET_ADDRESS,

--- a/components/clarinet-deployments/src/onchain/bitcoin_deployment.rs
+++ b/components/clarinet-deployments/src/onchain/bitcoin_deployment.rs
@@ -16,7 +16,7 @@ use bitcoincore_rpc::bitcoin::secp256k1::{Message, PublicKey, Secp256k1, SecretK
 use bitcoincore_rpc::bitcoin::Address;
 use bitcoincore_rpc::{Client, RpcApi};
 use bitcoincore_rpc_json::ListUnspentResultEntry;
-use clarity_repl::clarity::util::hash::bytes_to_hex;
+use clarity::util::hash::bytes_to_hex;
 
 use crate::types::BtcTransferSpecification;
 

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -6,16 +6,11 @@ use bitcoincore_rpc::{Auth, Client};
 use clarinet_defaults::DEFAULT_EPOCH;
 use clarinet_files::{AccountConfig, NetworkManifest, StacksNetwork};
 use clarinet_utils::get_bip32_keys_from_mnemonic;
-use clarity_repl::clarity::chainstate::StacksAddress;
-use clarity_repl::clarity::codec::StacksMessageCodec;
-use clarity_repl::clarity::util::secp256k1::{
-    MessageSignature, Secp256k1PrivateKey, Secp256k1PublicKey,
-};
-use clarity_repl::clarity::vm::types::{
-    PrincipalData, QualifiedContractIdentifier, StandardPrincipalData,
-};
-use clarity_repl::clarity::vm::{ClarityName, Value};
-use clarity_repl::clarity::{ClarityVersion, ContractName, EvaluationResult};
+use clarity::codec::StacksMessageCodec;
+use clarity::types::chainstate::StacksAddress;
+use clarity::util::secp256k1::{MessageSignature, Secp256k1PrivateKey, Secp256k1PublicKey};
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{ClarityName, ClarityVersion, ContractName, EvaluationResult, Value};
 use clarity_repl::repl::boot::{
     BOOT_CONTRACTS_NAMES, BOOT_MAINNET_ADDRESS, BOOT_TESTNET_ADDRESS, SBTC_CONTRACTS_NAMES,
     SBTC_MAINNET_ADDRESS, SBTC_TESTNET_ADDRESS,

--- a/components/clarinet-deployments/src/requirements.rs
+++ b/components/clarinet-deployments/src/requirements.rs
@@ -2,9 +2,10 @@ use std::path::{Path, PathBuf};
 
 use clarinet_defaults::{DEFAULT_CLARITY_VERSION, DEFAULT_EPOCH};
 use clarinet_files::{paths, FileAccessor};
-use clarity_repl::clarity::chainstate::StacksAddress;
-use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
-use clarity_repl::clarity::{Address, ClarityVersion, StacksEpochId};
+use clarity::types::chainstate::StacksAddress;
+use clarity::types::{Address, StacksEpochId};
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::ClarityVersion;
 use clarity_repl::repl::clarity_version_from_u8;
 use clarity_repl::repl::remote_data::epoch_for_height;
 use reqwest;

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -3,15 +3,14 @@ use std::path::{Path, PathBuf};
 
 use clarinet_defaults::DEFAULT_CLARITY_VERSION;
 use clarinet_files::{paths, DevnetConfig, FileAccessor, StacksNetwork};
+use clarity::types::StacksEpochId;
+use clarity::util::hash::{hex_bytes, to_hex};
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::ast::ContractAST;
+use clarity::vm::diagnostic::Diagnostic;
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{ClarityName, ClarityVersion, ContractName, Value};
 use clarity_repl::analysis::ast_dependency_detector::DependencySet;
-use clarity_repl::clarity::util::hash::{hex_bytes, to_hex};
-use clarity_repl::clarity::vm::analysis::ContractAnalysis;
-use clarity_repl::clarity::vm::ast::ContractAST;
-use clarity_repl::clarity::vm::diagnostic::Diagnostic;
-use clarity_repl::clarity::vm::types::{
-    PrincipalData, QualifiedContractIdentifier, StandardPrincipalData,
-};
-use clarity_repl::clarity::{ClarityName, ClarityVersion, ContractName, StacksEpochId, Value};
 use clarity_repl::repl::{clarity_version_from_u8, clarity_version_to_u8, Session};
 use clarity_repl::utils::remove_env_simnet;
 use serde::{Deserialize, Serialize};
@@ -393,7 +392,7 @@ pub struct StxTransferSpecification {
 pub mod memo_serde {
     use std::fmt::Write;
 
-    use clarity_repl::clarity::util::hash::hex_bytes;
+    use clarity::util::hash::hex_bytes;
     use serde::{Deserialize, Deserializer, Serializer};
 
     use super::Memo;
@@ -436,7 +435,7 @@ pub mod memo_serde {
     }
 }
 pub mod principal_data_serde {
-    use clarity_repl::clarity::vm::types::PrincipalData;
+    use clarity::vm::types::PrincipalData;
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(x: &PrincipalData, s: S) -> Result<S::Ok, S::Error>
@@ -672,7 +671,7 @@ pub mod source_serde {
 }
 
 pub mod standard_principal_data_serde {
-    use clarity_repl::clarity::vm::types::{PrincipalData, StandardPrincipalData};
+    use clarity::vm::types::{PrincipalData, StandardPrincipalData};
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(x: &StandardPrincipalData, s: S) -> Result<S::Ok, S::Error>
@@ -692,7 +691,7 @@ pub mod standard_principal_data_serde {
 }
 
 pub mod qualified_contract_identifier_serde {
-    use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
+    use clarity::vm::types::QualifiedContractIdentifier;
     use serde::{Deserializer, Serializer};
 
     pub fn serialize<S>(x: &QualifiedContractIdentifier, s: S) -> Result<S::Ok, S::Error>
@@ -715,7 +714,7 @@ pub mod qualified_contract_identifier_serde {
 pub mod remap_principals_serde {
     use std::collections::{BTreeMap, HashMap};
 
-    use clarity_repl::clarity::vm::types::{PrincipalData, StandardPrincipalData};
+    use clarity::vm::types::{PrincipalData, StandardPrincipalData};
     use serde::ser::SerializeMap;
     use serde::{Deserializer, Serializer};
 
@@ -753,7 +752,7 @@ pub mod remap_principals_serde {
 
 pub mod clarity_version_serde {
     use clarinet_files::INVALID_CLARITY_VERSION;
-    use clarity_repl::clarity::ClarityVersion;
+    use clarity::vm::ClarityVersion;
     use clarity_repl::repl::{clarity_version_from_u8, clarity_version_to_u8};
     use serde::{Deserialize, Deserializer, Serializer};
 
@@ -949,7 +948,7 @@ pub mod contracts_serde {
 
     use base64::engine::general_purpose::STANDARD as b64;
     use base64::Engine as _;
-    use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
+    use clarity::vm::types::QualifiedContractIdentifier;
     use serde::ser::SerializeSeq;
     use serde::{Deserializer, Serializer};
 

--- a/components/clarinet-deployments/tests/deployment_plan.rs
+++ b/components/clarinet-deployments/tests/deployment_plan.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 
 use clarinet_deployments::types::*;
 use clarinet_files::StacksNetwork;
-use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
-use clarity_repl::clarity::{ClarityName, ClarityVersion, ContractName};
+use clarity::vm::types::QualifiedContractIdentifier;
+use clarity::vm::{ClarityName, ClarityVersion, ContractName};
 
 fn get_test_txs() -> (TransactionSpecification, TransactionSpecification) {
     let contract_id =

--- a/components/clarinet-deployments/tests/genesis_accounts_funding.rs
+++ b/components/clarinet-deployments/tests/genesis_accounts_funding.rs
@@ -8,7 +8,7 @@ use clarinet_files::StacksNetwork;
 use clarity::types::chainstate::StacksAddress;
 use clarity::types::Address;
 use clarity::vm::types::StandardPrincipalData;
-use clarity_repl::clarity::{ClarityVersion, ContractName};
+use clarity::vm::{ClarityVersion, ContractName};
 use clarity_repl::repl::{Session, SessionSettings};
 
 static SBTC_DEPLOYER: LazyLock<StandardPrincipalData> = LazyLock::new(|| {

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -12,15 +12,13 @@ use clarinet_deployments::{
     update_session_with_deployment_plan,
 };
 use clarinet_files::{paths, FileAccessor, ProjectManifest, StacksNetwork, WASMFileSystemAccessor};
+use clarity::types::chainstate::StacksAddress;
 use clarity::types::Address;
-use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExpression};
-use clarity_repl::clarity::analysis::contract_interface_builder::{
+use clarity::vm::analysis::contract_interface_builder::{
     ContractInterface, ContractInterfaceFunction, ContractInterfaceFunctionAccess,
 };
-use clarity_repl::clarity::chainstate::StacksAddress;
-use clarity_repl::clarity::vm::types::{
-    PrincipalData, QualifiedContractIdentifier, StandardPrincipalData,
-};
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExpression};
 use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::hooks::perf::CostField;
 use clarity_repl::repl::session::CostsReport;

--- a/components/clarinet-sdk-wasm/src/utils/events.rs
+++ b/components/clarinet-sdk-wasm/src/utils/events.rs
@@ -1,5 +1,4 @@
-use clarity_repl::clarity::events::{FTEventType, NFTEventType, STXEventType};
-use clarity_repl::clarity::vm::events::StacksTransactionEvent;
+use clarity::vm::events::{FTEventType, NFTEventType, STXEventType, StacksTransactionEvent};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]

--- a/components/clarity-events/Cargo.toml
+++ b/components/clarity-events/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
+clarity = { workspace = true }
 clarinet-files = { path = "../clarinet-files", default-features = false }
 clarity-repl = { path = "../clarity-repl", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/components/clarity-events/src/analysis/mod.rs
+++ b/components/clarity-events/src/analysis/mod.rs
@@ -1,15 +1,14 @@
 use std::collections::{BTreeMap, HashMap};
 
-use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, TypedVar};
-use clarity_repl::clarity::analysis::type_checker::v2_05::TypeChecker;
-use clarity_repl::clarity::util::hash;
-use clarity_repl::clarity::vm::analysis::types::ContractAnalysis;
-use clarity_repl::clarity::vm::types::{
+use clarity::util::hash;
+use clarity::vm::analysis::type_checker::v2_05::TypeChecker;
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::types::{
     AssetIdentifier, BuffData, CharType, PrincipalData, QualifiedContractIdentifier, SequenceData,
-    SequenceSubtype, StringSubtype, TypeSignature, Value,
+    SequenceSubtype, StringSubtype, TypeSignature,
 };
-use clarity_repl::clarity::vm::{ClarityName, SymbolicExpression};
-use clarity_repl::clarity::{ClarityVersion, SymbolicExpressionType};
+use clarity::vm::{ClarityName, ClarityVersion, SymbolicExpression, SymbolicExpressionType, Value};
+use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, TypedVar};
 use clarity_repl::repl::clarity_values::value_to_string;
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};

--- a/components/clarity-events/src/bin.rs
+++ b/components/clarity-events/src/bin.rs
@@ -5,9 +5,9 @@ use std::path::Path;
 use analysis::{EventCollector, Settings};
 use clap::{Parser, Subcommand};
 use clarinet_files::paths;
-use clarity_repl::clarity::analysis::type_checker::v2_05::TypeChecker;
-use clarity_repl::clarity::costs::LimitedCostTracker;
-use clarity_repl::clarity::EvaluationResult;
+use clarity::vm::analysis::type_checker::v2_05::TypeChecker;
+use clarity::vm::costs::LimitedCostTracker;
+use clarity::vm::EvaluationResult;
 use clarity_repl::repl::{Session, SessionSettings};
 use serde_json::json;
 

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 use clarinet_files::{paths, FileAccessor, ProjectManifest};
-use clarity_repl::clarity::diagnostic::Diagnostic;
 use clarity_repl::repl::boot::get_boot_contract_epoch_and_clarity_version;
 use clarity_repl::repl::ContractDeployer;
+use clarity_types::diagnostic::Diagnostic;
 use ls_types::{
     CodeLens, CodeLensParams, CompletionItem, CompletionParams, DocumentFormattingParams,
     DocumentRangeFormattingParams, DocumentSymbol, DocumentSymbolParams, GotoDefinitionParams,
@@ -663,7 +663,7 @@ mod lsp_tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    use clarity_repl::clarity::ClarityVersion;
+    use clarity::vm::ClarityVersion;
     use indoc::indoc;
     use ls_types::{
         DocumentRangeFormattingParams, FormattingOptions, Position, Range, TextDocumentIdentifier,

--- a/components/clarity-lsp/src/common/requests/api_ref.rs
+++ b/components/clarity-lsp/src/common/requests/api_ref.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use clarity_repl::clarity::docs::{
+use clarity::vm::docs::{
     make_api_reference, make_define_reference, make_keyword_reference, FunctionAPI,
 };
-use clarity_repl::clarity::functions::define::DefineFunctions;
-use clarity_repl::clarity::functions::NativeFunctions;
-use clarity_repl::clarity::variables::NativeVariables;
-use clarity_repl::clarity::ClarityVersion;
+use clarity::vm::functions::define::DefineFunctions;
+use clarity::vm::functions::NativeFunctions;
+use clarity::vm::variables::NativeVariables;
+use clarity::vm::ClarityVersion;
 
 fn code(code: &str) -> String {
     ["```clarity", code.trim(), "```"].join("\n")

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -2,16 +2,14 @@ use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
 
 use clarinet_defaults::DEFAULT_EPOCH;
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::docs::{make_api_reference, make_define_reference, make_keyword_reference};
+use clarity::vm::functions::define::DefineFunctions;
+use clarity::vm::functions::NativeFunctions;
 use clarity::vm::types::{BlockInfoProperty, FunctionType, TypeSignatureExt};
+use clarity::vm::variables::NativeVariables;
+use clarity::vm::{ClarityName, ClarityVersion, SymbolicExpression};
 use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, LetBinding, TypedVar};
-use clarity_repl::clarity::analysis::ContractAnalysis;
-use clarity_repl::clarity::docs::{
-    make_api_reference, make_define_reference, make_keyword_reference,
-};
-use clarity_repl::clarity::functions::define::DefineFunctions;
-use clarity_repl::clarity::functions::NativeFunctions;
-use clarity_repl::clarity::variables::NativeVariables;
-use clarity_repl::clarity::{ClarityName, ClarityVersion, SymbolicExpression};
 use clarity_types::types::TypeSignature;
 use ls_types::{
     CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
@@ -829,9 +827,10 @@ fn get_iterator_cb_completion_item(version: &ClarityVersion, func: &str) -> Vec<
 
 #[cfg(test)]
 mod get_contract_global_data_tests {
-    use clarity_repl::clarity::ast::build_ast;
-    use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
-    use clarity_repl::clarity::{ClarityVersion, StacksEpochId};
+    use clarity::types::StacksEpochId;
+    use clarity::vm::ast::build_ast;
+    use clarity::vm::types::QualifiedContractIdentifier;
+    use clarity::vm::ClarityVersion;
     use ls_types::Position;
 
     use super::ContractDefinedData;
@@ -882,9 +881,10 @@ mod get_contract_global_data_tests {
 
 #[cfg(test)]
 mod get_contract_local_data_tests {
-    use clarity_repl::clarity::ast::build_ast;
-    use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
-    use clarity_repl::clarity::{ClarityVersion, StacksEpochId};
+    use clarity::types::StacksEpochId;
+    use clarity::vm::ast::build_ast;
+    use clarity::vm::types::QualifiedContractIdentifier;
+    use clarity::vm::ClarityVersion;
     use ls_types::Position;
 
     use super::ContractDefinedData;
@@ -937,9 +937,10 @@ mod get_contract_local_data_tests {
 
 #[cfg(test)]
 mod populate_snippet_with_options_tests {
-    use clarity_repl::clarity::ast::build_ast;
-    use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
-    use clarity_repl::clarity::{ClarityVersion, StacksEpochId};
+    use clarity::types::StacksEpochId;
+    use clarity::vm::ast::build_ast;
+    use clarity::vm::types::QualifiedContractIdentifier;
+    use clarity::vm::ClarityVersion;
     use ls_types::Position;
 
     use super::ContractDefinedData;

--- a/components/clarity-lsp/src/common/requests/definitions.rs
+++ b/components/clarity-lsp/src/common/requests/definitions.rs
@@ -1,12 +1,10 @@
 use std::collections::HashMap;
 
-use clarity::vm::ClarityVersion;
+use clarity::vm::functions::define::DefineFunctions;
+use clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData, TraitIdentifier};
+use clarity::vm::{ClarityVersion, SymbolicExpression};
 use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, LetBinding, TypedVar};
-use clarity_repl::clarity::functions::define::DefineFunctions;
-use clarity_repl::clarity::vm::types::{
-    QualifiedContractIdentifier, StandardPrincipalData, TraitIdentifier,
-};
-use clarity_repl::clarity::{ClarityName, SymbolicExpression};
+use clarity_types::ClarityName;
 use ls_types::Range;
 
 use super::helpers::span_to_range;
@@ -102,7 +100,7 @@ impl<'a> ASTVisitor<'a> for Definitions {
     }
 
     fn traverse_expr(&mut self, expr: &'a SymbolicExpression) -> bool {
-        use clarity_repl::clarity::vm::representations::SymbolicExpressionType::*;
+        use clarity::vm::representations::SymbolicExpressionType::*;
         match &expr.expr {
             AtomValue(value) => self.visit_atom_value(expr, value),
             Atom(name) => self.visit_atom(expr, name),
@@ -673,9 +671,10 @@ pub fn get_public_function_and_trait_definitions(
 mod definitions_visitor_tests {
     use std::collections::HashMap;
 
-    use clarity_repl::clarity::ast::build_ast;
-    use clarity_repl::clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
-    use clarity_repl::clarity::{ClarityVersion, StacksEpochId, SymbolicExpression};
+    use clarity::types::StacksEpochId;
+    use clarity::vm::ast::build_ast;
+    use clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
+    use clarity::vm::{ClarityVersion, SymbolicExpression};
     use ls_types::{Position, Range};
 
     use super::{DefinitionLocation, Definitions};

--- a/components/clarity-lsp/src/common/requests/document_symbols.rs
+++ b/components/clarity-lsp/src/common/requests/document_symbols.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use clarity::vm::ClarityVersion;
+use clarity::vm::{ClarityVersion, SymbolicExpression, SymbolicExpressionType};
 use clarity_repl::analysis::ast_visitor::{traverse, ASTVisitor, LetBinding};
-use clarity_repl::clarity::representations::Span;
-use clarity_repl::clarity::{ClarityName, SymbolicExpression, SymbolicExpressionType};
+use clarity_types::representations::Span;
+use clarity_types::ClarityName;
 use ls_types::{DocumentSymbol, SymbolKind};
 use serde::{Deserialize, Serialize};
 
@@ -89,7 +89,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_impl_trait(
         &mut self,
         expr: &'a SymbolicExpression,
-        trait_identifier: &clarity_repl::clarity::vm::types::TraitIdentifier,
+        trait_identifier: &clarity::vm::types::TraitIdentifier,
     ) -> bool {
         self.symbols.push(build_symbol(
             "impl-trait",
@@ -104,7 +104,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_define_data_var(
         &mut self,
         expr: &'a SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        name: &'a ClarityName,
         data_type: &'a SymbolicExpression,
         initial: &'a SymbolicExpression,
     ) -> bool {
@@ -144,7 +144,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_define_constant(
         &mut self,
         expr: &'a SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        name: &'a ClarityName,
         _value: &'a SymbolicExpression,
     ) -> bool {
         self.symbols.push(build_symbol(
@@ -160,7 +160,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_define_map(
         &mut self,
         expr: &'a SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        name: &'a ClarityName,
         key_type: &'a SymbolicExpression,
         value_type: &'a SymbolicExpression,
     ) -> bool {
@@ -194,7 +194,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_define_trait(
         &mut self,
         expr: &'a SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        name: &'a ClarityName,
         functions: &'a [SymbolicExpression],
     ) -> bool {
         let mut children = Vec::new();
@@ -224,7 +224,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_define_private(
         &mut self,
         expr: &'a SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        name: &'a ClarityName,
         _parameters: Option<Vec<clarity_repl::analysis::ast_visitor::TypedVar<'a>>>,
         body: &'a SymbolicExpression,
     ) -> bool {
@@ -240,10 +240,10 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
 
     fn visit_define_public(
         &mut self,
-        expr: &'a clarity_repl::clarity::SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        expr: &'a SymbolicExpression,
+        name: &'a ClarityName,
         _parameters: Option<Vec<clarity_repl::analysis::ast_visitor::TypedVar<'a>>>,
-        body: &'a clarity_repl::clarity::SymbolicExpression,
+        body: &'a SymbolicExpression,
     ) -> bool {
         self.symbols.push(build_symbol(
             &name.to_owned(),
@@ -257,10 +257,10 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
 
     fn visit_define_read_only(
         &mut self,
-        expr: &'a clarity_repl::clarity::SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        expr: &'a SymbolicExpression,
+        name: &'a ClarityName,
         _parameters: Option<Vec<clarity_repl::analysis::ast_visitor::TypedVar<'a>>>,
-        body: &'a clarity_repl::clarity::SymbolicExpression,
+        body: &'a SymbolicExpression,
     ) -> bool {
         self.symbols.push(build_symbol(
             &name.to_owned(),
@@ -275,7 +275,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_define_ft(
         &mut self,
         expr: &'a SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        name: &'a ClarityName,
         _supply: Option<&'a SymbolicExpression>,
     ) -> bool {
         self.symbols.push(build_symbol(
@@ -291,7 +291,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
     fn visit_define_nft(
         &mut self,
         expr: &'a SymbolicExpression,
-        name: &'a clarity_repl::clarity::ClarityName,
+        name: &'a ClarityName,
         nft_type: &'a SymbolicExpression,
     ) -> bool {
         let nft_type = match nft_type.expr.clone() {
@@ -488,16 +488,15 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
 
 #[cfg(test)]
 mod tests {
+    use clarity::types::StacksEpochId;
     use clarity::vm::ast::build_ast;
-    use clarity_repl::clarity::representations::Span;
-    use clarity_repl::clarity::vm::types::QualifiedContractIdentifier;
-    use clarity_repl::clarity::{ClarityVersion, StacksEpochId, SymbolicExpression};
+    use clarity::vm::types::QualifiedContractIdentifier;
+    use clarity::vm::{ClarityVersion, SymbolicExpression};
+    use clarity_types::representations::Span;
     use ls_types::{DocumentSymbol, SymbolKind};
 
     use super::ASTSymbols;
     use crate::common::requests::document_symbols::{build_symbol, ClaritySymbolKind};
-
-    // use crate::common::ast_to_symbols::{build_symbol, ASTSymbols, ClaritySymbolKind};
 
     fn new_span(start_line: u32, start_column: u32, end_line: u32, end_column: u32) -> Span {
         Span {

--- a/components/clarity-lsp/src/common/requests/helpers.rs
+++ b/components/clarity-lsp/src/common/requests/helpers.rs
@@ -1,7 +1,8 @@
 use std::cmp::Ordering;
 
-use clarity_repl::clarity::representations::Span;
-use clarity_repl::clarity::{ClarityName, SymbolicExpression, SymbolicExpressionType};
+use clarity::vm::{SymbolicExpression, SymbolicExpressionType};
+use clarity_types::representations::Span;
+use clarity_types::ClarityName;
 use ls_types::{Position, Range};
 
 pub fn span_to_range(span: &Span) -> Range {

--- a/components/clarity-lsp/src/common/requests/hover.rs
+++ b/components/clarity-lsp/src/common/requests/hover.rs
@@ -1,4 +1,4 @@
-use clarity_repl::clarity::SymbolicExpression;
+use clarity::vm::SymbolicExpression;
 use ls_types::Position;
 
 use super::api_ref::API_REF;

--- a/components/clarity-lsp/src/common/requests/signature_help.rs
+++ b/components/clarity-lsp/src/common/requests/signature_help.rs
@@ -1,4 +1,4 @@
-use clarity_repl::clarity::docs::FunctionAPI;
+use clarity::vm::docs::FunctionAPI;
 use ls_types::{ParameterInformation, ParameterLabel, Position, SignatureInformation};
 
 use super::api_ref::API_REF;
@@ -81,9 +81,9 @@ pub fn get_signatures(
 
 #[cfg(test)]
 mod definitions_visitor_tests {
-    use clarity_repl::clarity::functions::NativeFunctions;
-    use clarity_repl::clarity::ClarityVersion::Clarity2;
-    use clarity_repl::clarity::StacksEpochId::Epoch21;
+    use clarity::types::StacksEpochId;
+    use clarity::vm::functions::NativeFunctions;
+    use clarity::vm::ClarityVersion;
     use ls_types::ParameterLabel::Simple;
     use ls_types::{ParameterInformation, Position, SignatureInformation};
 
@@ -94,7 +94,12 @@ mod definitions_visitor_tests {
         source: String,
         position: &Position,
     ) -> Option<Vec<ls_types::SignatureInformation>> {
-        let contract = &ActiveContractData::new(Clarity2, Epoch21, None, source);
+        let contract = &ActiveContractData::new(
+            ClarityVersion::Clarity2,
+            StacksEpochId::Epoch21,
+            None,
+            source,
+        );
         get_signatures(contract, position)
     }
 

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -9,20 +9,18 @@ use clarinet_deployments::{
     update_session_with_deployment_plan,
 };
 use clarinet_files::{paths, FileAccessor, ProjectManifest, StacksNetwork};
-use clarity::vm::ast::build_ast;
-use clarity::vm::costs::ExecutionCost;
-use clarity::vm::diagnostic::Diagnostic;
+use clarity::types::StacksEpochId;
+use clarity::vm::analysis::ContractAnalysis;
+use clarity::vm::ast::{build_ast, ContractAST};
+use clarity::vm::diagnostic::{Diagnostic, Diagnostic as ClarityDiagnostic, Level as ClarityLevel};
+use clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{ClarityName, ClarityVersion, EvaluationResult, SymbolicExpression};
 use clarity_repl::analysis::ast_dependency_detector::DependencySet;
-use clarity_repl::clarity::analysis::ContractAnalysis;
-use clarity_repl::clarity::diagnostic::{Diagnostic as ClarityDiagnostic, Level as ClarityLevel};
-use clarity_repl::clarity::vm::ast::ContractAST;
-use clarity_repl::clarity::vm::types::{QualifiedContractIdentifier, StandardPrincipalData};
-use clarity_repl::clarity::vm::EvaluationResult;
-use clarity_repl::clarity::{ClarityName, ClarityVersion, StacksEpochId, SymbolicExpression};
 use clarity_repl::repl::interpreter::BLOCK_LIMIT_MAINNET;
 use clarity_repl::repl::ContractDeployer;
 use clarity_repl::utils::CHECK_ENVIRONMENTS;
 use clarity_static_cost::static_cost::StaticCost;
+use clarity_types::execution_cost::ExecutionCost;
 use ls_types::{
     CompletionItem, DocumentSymbol, Hover, Location, MessageType, Position, Range, SignatureHelp,
 };

--- a/components/clarity-lsp/src/utils/mod.rs
+++ b/components/clarity-lsp/src/utils/mod.rs
@@ -1,9 +1,7 @@
 use std::path::PathBuf;
 
 use clarinet_files::paths;
-use clarity_repl::clarity::vm::diagnostic::{
-    Diagnostic as ClarityDiagnostic, Level as ClarityLevel,
-};
+use clarity::vm::diagnostic::{Diagnostic as ClarityDiagnostic, Level as ClarityLevel};
 use ls_types::{Diagnostic as LspDiagnostic, DiagnosticSeverity, Position, Range, Uri};
 
 #[allow(unused_macros)]

--- a/components/clarity-repl/src/lib.rs
+++ b/components/clarity-repl/src/lib.rs
@@ -6,12 +6,6 @@ mod uprint;
 
 pub mod analysis;
 
-pub mod clarity {
-    #![allow(ambiguous_glob_reexports)]
-    pub use ::clarity::types::*;
-    pub use ::clarity::vm::*;
-    pub use ::clarity::*;
-}
 pub mod repl;
 pub mod utils;
 


### PR DESCRIPTION
### Context

The `clarity-repl` component re-exports the `clarity` modules.
In the code base, we have mix usages of `use clarity::` and `use clarity_repl::clarity::`

And it create useless coupling between some component that rely heavily on `clarity_repl` to import clarity

### Description

Remove this from clarity-repl.

```

pub mod clarity {
    #![allow(ambiguous_glob_reexports)]
    pub use ::clarity::types::*;
    pub use ::clarity::vm::*;
    pub use ::clarity::*;
}
```

Directly import from `clarity` in other components. Preventing other components to depends on clarity-repl.
