### PR TITLE
feat: add documentSymbols capability to LSP, #2327

### DIFF
--- a/components/clarity-lsp/src/common/requests/capabilities.rs
+++ b/components/clarity-lsp/src/common/requests/capabilities.rs
@@ -35,7 +35,7 @@ impl Default for InitializationOptions {
             completion: true,
             completion_smart_parenthesis_wrap: true,
             completion_include_native_placeholders: true,
-            document_symbols: false,
+            document_symbols: true,
             formatting: true,
             go_to_definition: true,
             hover: true,

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -109,7 +109,7 @@
           },
           "clarity-lsp.documentSymbols": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "order": 0,
             "description": "Show contract symbols in breadcrumb (beta)."
           },


### PR DESCRIPTION
- Fixes https://github.com/stx-labs/clarinet/issues/2327

Turns out this was a very simple change! I verified this by running `npm run dev` in `components/clarity-vscode`, and then in the VSCode window that opened, I see both the outline, and the `@` search works too.