### PR TITLE
fix(linter): Don't warn on private functions in `#[env(simnet)]` blocks

### DIFF
--- a/components/clarity-repl/src/analysis/lints/unused_private_fn.rs
+++ b/components/clarity-repl/src/analysis/lints/unused_private_fn.rs
@@ -47,6 +47,13 @@ impl<'a, 'b> UnusedPrivateFn<'a, 'b> {
             .unwrap_or(false)
     }
 
+    fn has_env_annotation(fn_data: &PrivateFnData, annotations: &[Annotation]) -> bool {
+        fn_data
+            .annotation
+            .map(|idx| matches!(annotations[idx].kind, AnnotationKind::Env(_)))
+            .unwrap_or(false)
+    }
+
     /// Make diagnostic message and suggestion for unused private fn
     pub(crate) fn make_diagnostic_strings(name: &ClarityName) -> (String, Option<String>) {
         (
@@ -65,7 +72,11 @@ impl<'a, 'b> UnusedPrivateFn<'a, 'b> {
         let private_fns = self.analysis_cache.get_private_fns();
 
         for (name, fn_data) in private_fns {
-            if fn_data.called || Self::allow(fn_data, annotations) || is_explicitly_unused(name) {
+            if fn_data.called
+                || Self::allow(fn_data, annotations)
+                || Self::has_env_annotation(fn_data, annotations)
+                || is_explicitly_unused(name)
+            {
                 continue;
             }
             let (message, suggestion) = Self::make_diagnostic_strings(name);
@@ -275,6 +286,21 @@ mod tests {
             (define-read-only (cube (x uint))
                 (* x (* x x)))
         ").to_string();
+
+        let (_, result) = run_snippet(snippet);
+
+        assert_eq!(result.lint_diagnostics.len(), 0);
+    }
+
+    #[test]
+    fn allow_with_env_simnet_annotation() {
+        #[rustfmt::skip]
+        let snippet = indoc!(r#"
+            ;; #[env(simnet)]
+            (define-private (test-double)
+              (ok (asserts! (is-eq u8 (* u4 u2)) (err "double u4 does not return u8")))
+            )
+        "#).to_string();
 
         let (_, result) = run_snippet(snippet);
 


### PR DESCRIPTION
### Description

Fixes: #2355

Don't generate diagnostics for private functions inside of `#[env(simnet)]` blocks, since these functions are intended to be used only in unit tests

#### Breaking change?

No

### Example

Do NOT warn on the following code:

```clarity
;; #[env(simnet)]
(define-private (test-double)
  (ok (asserts! (is-eq u8 (* u4 u2)) (err "double u4 does not return u8")))
)
```

### Checklist

- [x] Tests added in this PR (if applicable)

