### PR TITLE
fix: simnet annotation dimming

### DIFF
--- a/components/clarity-repl/src/utils.rs
+++ b/components/clarity-repl/src/utils.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use ::clarity::types::StacksEpochId;
 use ::clarity::vm::ast::parser;
 use ::clarity::vm::ast::stack_depth_checker::StackDepthLimits;
@@ -149,7 +147,12 @@ fn collect_env_simnet_spans(exprs: &[PreSymbolicExpression], out: &mut Vec<Span>
         }
 
         if let Comment(comment) = &expr.pre_expr {
-            if let Ok(AnnotationKind::Env(_)) = AnnotationKind::from_str(comment) {
+            let is_env_annotation = comment
+                .trim()
+                .strip_prefix("#[")
+                .and_then(|s| s.strip_suffix(']'))
+                .is_some_and(|inner| matches!(inner.trim().parse(), Ok(AnnotationKind::Env(_))));
+            if is_env_annotation {
                 let annotation_line = expr.span.start_line;
                 let is_eol_comment = exprs[..idx].iter().any(|prev| {
                     prev.span.end_line == annotation_line && !matches!(prev.pre_expr, Comment(_))
@@ -357,5 +360,37 @@ mod tests {
         assert_eq!(spans[0].end_line, 2);
         assert_eq!(spans[1].start_line, 6);
         assert_eq!(spans[1].end_line, 7);
+    }
+
+    #[test]
+    fn ignores_malformed_env_annotation_missing_hash() {
+        #[rustfmt::skip]
+        let source = indoc!(r#"
+            ;; [env(simnet)]
+            (define-public (set-admin (new-admin principal))
+                (begin
+                    (ok (var-set contract-owner new-admin))
+                )
+            )
+        "#);
+
+        let spans = get_env_simnet_spans(source).unwrap();
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn ignores_malformed_env_annotation_hash_inside_brackets() {
+        #[rustfmt::skip]
+        let source = indoc!(r#"
+            ;; [#env(simnet)]
+            (define-public (set-admin (new-admin principal))
+                (begin
+                    (ok (var-set contract-owner new-admin))
+                )
+            )
+        "#);
+
+        let spans = get_env_simnet_spans(source).unwrap();
+        assert!(spans.is_empty());
     }
 }


### PR DESCRIPTION
fix the annotation matching to strip the `#[` before matching to ensure we don't included the wrong annotations

- closes #2368 
 
 ## correct
<img width="458" height="157" alt="Screenshot 2026-04-24 at 10 16 54 AM" src="https://github.com/user-attachments/assets/6150b627-8d62-40a3-a258-a9931fd6b3b7" />

## incorrect
<img width="464" height="185" alt="Screenshot 2026-04-24 at 10 17 06 AM" src="https://github.com/user-attachments/assets/a8eb20b6-b510-4764-a0c4-e4b3d4871d96" />


