### PR TITLE
fix: remove annotation regex complexity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,6 @@ dependencies = [
  "mockito",
  "pico-args",
  "pox-locking",
- "regex",
  "reqwest",
  "rusqlite",
  "rustyline",

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -26,7 +26,6 @@ clarinet-defaults = { workspace = true }
 chrono = { workspace = true }
 colored = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
-regex = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["unbounded_depth"] }

--- a/components/clarity-repl/src/analysis/annotation.rs
+++ b/components/clarity-repl/src/analysis/annotation.rs
@@ -15,10 +15,14 @@ pub enum AnnotationKind {
 impl std::str::FromStr for AnnotationKind {
     type Err = String;
 
-    /// Parse an annotation body, e.g. `env(simnet)` or `allow(unchecked_data)`.
-    /// The `#[…]` wrapper must already be stripped by the caller.
+    /// Parse an annotation, e.g. `#[env(simnet)]` or `#[allow(unchecked_data)]`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim();
+        let s = s
+            .trim()
+            .strip_prefix("#[")
+            .and_then(|s| s.strip_suffix(']'))
+            .ok_or_else(|| "malformed annotation: expected #[...]".to_string())?
+            .trim();
         let (name, value) = match s.find('(') {
             Some(open) => {
                 let name = &s[..open];
@@ -26,14 +30,15 @@ impl std::str::FromStr for AnnotationKind {
                 let value = rest
                     .strip_suffix(')')
                     .ok_or_else(|| "malformed annotation: missing closing ')'".to_string())?;
-                (name, value.trim())
+                (name, Some(value.trim()))
             }
-            None => (s, ""),
+            None => (s, None),
         };
 
         match name {
             "allow" => {
                 let params: Vec<WarningKind> = value
+                    .unwrap_or("")
                     .split(',')
                     .filter(|s| !s.is_empty())
                     .filter_map(|s| s.trim().parse().ok())
@@ -45,6 +50,8 @@ impl std::str::FromStr for AnnotationKind {
                 }
             }
             "env" => {
+                let value =
+                    value.ok_or_else(|| "missing value for 'env' annotation".to_string())?;
                 let env: Environment = value
                     .parse()
                     .map_err(|_| format!("bad environment {value} for 'env' annotation"))?;
@@ -56,6 +63,8 @@ impl std::str::FromStr for AnnotationKind {
                 Ok(AnnotationKind::Env(env))
             }
             "filter" => {
+                let value =
+                    value.ok_or_else(|| "missing value for 'filter' annotation".to_string())?;
                 if value == "*" {
                     Ok(AnnotationKind::FilterAll)
                 } else {
@@ -149,7 +158,7 @@ mod tests {
 
     #[test]
     fn parse_allow_unchecked_data() {
-        match "allow(unchecked_data)".parse::<AnnotationKind>() {
+        match "#[allow(unchecked_data)]".parse::<AnnotationKind>() {
             Ok(AnnotationKind::Allow(params)) => {
                 assert_eq!(params.len(), 1);
                 assert!(matches!(params[0], WarningKind::UncheckedData));
@@ -160,7 +169,7 @@ mod tests {
 
     #[test]
     fn parse_allow_multiple() {
-        match "allow(unused_const, case_const)".parse::<AnnotationKind>() {
+        match "#[allow(unused_const, case_const)]".parse::<AnnotationKind>() {
             Ok(AnnotationKind::Allow(params)) => {
                 assert_eq!(params.len(), 2);
                 assert!(params.contains(&WarningKind::UnusedConst));
@@ -172,7 +181,7 @@ mod tests {
 
     #[test]
     fn parse_annotation_kind_error() {
-        match "invalid_string".parse::<AnnotationKind>() {
+        match "#[invalid_string]".parse::<AnnotationKind>() {
             Err(_) => (),
             _ => panic!("failed to return error for bad string"),
         };
@@ -180,7 +189,7 @@ mod tests {
 
     #[test]
     fn parse_annotation_kind_error2() {
-        match "invalid(string)".parse::<AnnotationKind>() {
+        match "#[invalid(string)]".parse::<AnnotationKind>() {
             Err(_) => (),
             _ => panic!("failed to return error for bad string"),
         };
@@ -195,8 +204,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_annotation_missing_brackets() {
+        match "allow(unchecked_data)".parse::<AnnotationKind>() {
+            Err(_) => (),
+            _ => panic!("failed to return error for annotation without #[...]"),
+        };
+    }
+
+    #[test]
     fn parse_filter() {
-        match "filter(foo,bar)".parse::<AnnotationKind>() {
+        match "#[filter(foo,bar)]".parse::<AnnotationKind>() {
             Ok(AnnotationKind::Filter(params)) => {
                 assert!(
                     params.len() == 2 && params[0].as_str() == "foo" && params[1].as_str() == "bar",
@@ -209,7 +226,7 @@ mod tests {
 
     #[test]
     fn parse_filter_all() {
-        match "filter(*)".parse::<AnnotationKind>() {
+        match "#[filter(*)]".parse::<AnnotationKind>() {
             Ok(AnnotationKind::FilterAll) => (),
             _ => panic!("failed to parse 'filter(*)' correctly"),
         };
@@ -217,7 +234,7 @@ mod tests {
 
     #[test]
     fn parse_filter_empty() {
-        match "filter".parse::<AnnotationKind>() {
+        match "#[filter]".parse::<AnnotationKind>() {
             Err(_) => (),
             _ => panic!("failed to return error for 'filter' with no parameters"),
         };

--- a/components/clarity-repl/src/analysis/annotation.rs
+++ b/components/clarity-repl/src/analysis/annotation.rs
@@ -1,6 +1,5 @@
 use clarity::vm::representations::Span;
 use clarity::vm::ClarityName;
-use regex::Regex;
 use strum::EnumString;
 
 use crate::utils::Environment;
@@ -16,58 +15,63 @@ pub enum AnnotationKind {
 impl std::str::FromStr for AnnotationKind {
     type Err = String;
 
+    /// Parse an annotation body, e.g. `env(simnet)` or `allow(unchecked_data)`.
+    /// The `#[…]` wrapper must already be stripped by the caller.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let re = Regex::new(r"([[:word:]]+)(\(([^)]+)\))?").unwrap();
-        if let Some(captures) = re.captures(s) {
-            let (base, value) = if captures.get(1).is_some() && captures.get(3).is_some() {
-                (&captures[1], &captures[3])
-            } else {
-                (&captures[1], "")
-            };
-            match base {
-                "allow" => {
-                    let params: Vec<WarningKind> = value
+        let s = s.trim();
+        let (name, value) = match s.find('(') {
+            Some(open) => {
+                let name = &s[..open];
+                let rest = &s[open + 1..];
+                let value = rest
+                    .strip_suffix(')')
+                    .ok_or_else(|| "malformed annotation: missing closing ')'".to_string())?;
+                (name, value.trim())
+            }
+            None => (s, ""),
+        };
+
+        match name {
+            "allow" => {
+                let params: Vec<WarningKind> = value
+                    .split(',')
+                    .filter(|s| !s.is_empty())
+                    .filter_map(|s| s.trim().parse().ok())
+                    .collect();
+                if params.is_empty() {
+                    Err("missing value for 'allow' annotation".to_string())
+                } else {
+                    Ok(AnnotationKind::Allow(params))
+                }
+            }
+            "env" => {
+                let env: Environment = value
+                    .parse()
+                    .map_err(|_| format!("bad environment {value} for 'env' annotation"))?;
+                if env == Environment::OnChain {
+                    return Err(
+                        "'onchain' is not a valid environment for 'env' annotation".to_string()
+                    );
+                }
+                Ok(AnnotationKind::Env(env))
+            }
+            "filter" => {
+                if value == "*" {
+                    Ok(AnnotationKind::FilterAll)
+                } else {
+                    let params: Vec<ClarityName> = value
                         .split(',')
                         .filter(|s| !s.is_empty())
-                        .filter_map(|s| s.trim().parse().ok())
+                        .map(|s| ClarityName::from(s.trim()))
                         .collect();
                     if params.is_empty() {
-                        Err("missing value for 'allow' annotation".to_string())
+                        Err("missing value for 'filter' annotation".to_string())
                     } else {
-                        Ok(AnnotationKind::Allow(params))
+                        Ok(AnnotationKind::Filter(params))
                     }
                 }
-                "env" => {
-                    let env: Environment = value
-                        .parse()
-                        .map_err(|_| format!("bad environment {value} for 'env' annotation"))?;
-                    if env == Environment::OnChain {
-                        return Err(
-                            "'onchain' is not a valid environment for 'env' annotation".to_string()
-                        );
-                    }
-                    Ok(AnnotationKind::Env(env))
-                }
-                "filter" => {
-                    if value == "*" {
-                        Ok(AnnotationKind::FilterAll)
-                    } else {
-                        let params: Vec<ClarityName> = value
-                            .split(',')
-                            .filter(|s| !s.is_empty())
-                            .map(|s| ClarityName::from(s.trim()))
-                            .collect();
-                        if params.is_empty() {
-                            Err("missing value for 'filter' annotation".to_string())
-                        } else {
-                            Ok(AnnotationKind::Filter(params))
-                        }
-                    }
-                }
-                _ => Err("unrecognized annotation".to_string()),
             }
-        } else {
-            Err("malformed annotation".to_string())
+            _ => Err("unrecognized annotation".to_string()),
         }
     }
 }

--- a/components/clarity-repl/src/analysis/annotation.rs
+++ b/components/clarity-repl/src/analysis/annotation.rs
@@ -25,7 +25,7 @@ impl std::str::FromStr for AnnotationKind {
             .trim();
         let (name, value) = match s.find('(') {
             Some(open) => {
-                let name = &s[..open];
+                let name = s[..open].trim();
                 let rest = &s[open + 1..];
                 let value = rest
                     .strip_suffix(')')

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -227,35 +227,26 @@ impl ClarityInterpreter {
         let mut diagnostics = vec![];
         for (n, line) in code_source.lines().enumerate() {
             if let Some(comment) = line.trim().strip_prefix(";;") {
-                if let Some(annotation_string) = comment.trim().strip_prefix("#[") {
+                if comment.trim().starts_with("#[") {
                     let span = Span {
                         start_line: (n + 1) as u32,
                         start_column: (line.find('#').unwrap_or(0) + 1) as u32,
                         end_line: (n + 1) as u32,
                         end_column: line.len() as u32,
                     };
-                    if let Some(annotation_string) = annotation_string.strip_suffix(']') {
-                        let kind: AnnotationKind = match annotation_string.trim().parse() {
-                            Ok(kind) => kind,
-                            Err(e) => {
-                                diagnostics.push(Diagnostic {
-                                    level: Level::Warning,
-                                    message: e.to_string(),
-                                    spans: vec![span.clone()],
-                                    suggestion: None,
-                                });
-                                continue;
-                            }
-                        };
-                        annotations.push(Annotation { kind, span });
-                    } else {
-                        diagnostics.push(Diagnostic {
-                            level: Level::Warning,
-                            message: "malformed annotation".to_string(),
-                            spans: vec![span],
-                            suggestion: None,
-                        });
-                    }
+                    let kind: AnnotationKind = match comment.trim().parse() {
+                        Ok(kind) => kind,
+                        Err(e) => {
+                            diagnostics.push(Diagnostic {
+                                level: Level::Warning,
+                                message: e.to_string(),
+                                spans: vec![span],
+                                suggestion: None,
+                            });
+                            continue;
+                        }
+                    };
+                    annotations.push(Annotation { kind, span });
                 }
             } else if let Some(comment_pos) = line.find(";;") {
                 let comment = &line[comment_pos + 2..];
@@ -2322,7 +2313,10 @@ mod tests {
         let (annotations, diagnostics) = interpreter.collect_annotations(source);
         assert!(annotations.is_empty());
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].message, "malformed annotation");
+        assert_eq!(
+            diagnostics[0].message,
+            "malformed annotation: expected #[...]"
+        );
     }
 
     #[test]

--- a/components/clarity-repl/src/utils.rs
+++ b/components/clarity-repl/src/utils.rs
@@ -147,12 +147,7 @@ fn collect_env_simnet_spans(exprs: &[PreSymbolicExpression], out: &mut Vec<Span>
         }
 
         if let Comment(comment) = &expr.pre_expr {
-            let is_env_annotation = comment
-                .trim()
-                .strip_prefix("#[")
-                .and_then(|s| s.strip_suffix(']'))
-                .is_some_and(|inner| matches!(inner.trim().parse(), Ok(AnnotationKind::Env(_))));
-            if is_env_annotation {
+            if let Ok(AnnotationKind::Env(_)) = comment.parse() {
                 let annotation_line = expr.span.start_line;
                 let is_eol_comment = exprs[..idx].iter().any(|prev| {
                     prev.span.end_line == annotation_line && !matches!(prev.pre_expr, Comment(_))

--- a/components/clarity-repl/src/utils.rs
+++ b/components/clarity-repl/src/utils.rs
@@ -393,4 +393,20 @@ mod tests {
         let spans = get_env_simnet_spans(source).unwrap();
         assert!(spans.is_empty());
     }
+
+    #[test]
+    fn ignores_malformed_env_annotation_trailing_garbage_inside_brackets() {
+        #[rustfmt::skip]
+        let source = indoc!(r#"
+            ;; #[env(simnet) this is not a real annotation]
+            (define-public (set-admin (new-admin principal))
+                (begin
+                    (ok (var-set contract-owner new-admin))
+                )
+            )
+        "#);
+
+        let spans = get_env_simnet_spans(source).unwrap();
+        assert!(spans.is_empty());
+    }
 }


### PR DESCRIPTION
followup to #2369 

The regex for env matching was too error-prone. Replaced with simpler string operations

