### PR TITLE
fix: Strip `#[env(simnet)]` code out of on-chain deployments

### DIFF
--- a/components/clarinet-cli/tests/cli.rs
+++ b/components/clarinet-cli/tests/cli.rs
@@ -656,8 +656,13 @@ fn test_devnet_deployment_strips_env_simnet() {
     }
 }
 
-/// `clarinet deployments generate --devnet` should produce a deployment plan
-/// whose cost reflects the stripped (shorter) source, not the full source.
+/// `clarinet deployments generate --devnet` produces a YAML plan; loading that
+/// plan back via `load_deployment` must strip `#[env(simnet)]` from the source
+/// that ends up in `ContractPublish` transactions. `ContractPublishSpecificationFile`
+/// has no `source` field — the YAML only stores `path` — so source is re-read
+/// from disk on every load. Stripping has to happen at load time, otherwise
+/// `clarinet deployments apply --use-on-disk-deployment-plan` ships simnet code
+/// on-chain (see https://github.com/hirosystems/clarinet/issues/2343).
 #[test]
 fn test_deployments_generate_devnet_strips_env_simnet() {
     let (_temp_dir, project_path) =
@@ -674,9 +679,6 @@ fn test_deployments_generate_devnet_strips_env_simnet() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // Load the generated plan. `load_deployment` re-reads the .clar source from
-    // disk (unstripped), but preserves the `cost` field from the YAML — which was
-    // computed from the stripped source during generation.
     let yaml_path = project_path
         .join("deployments")
         .join("default.devnet-plan.yaml");
@@ -692,12 +694,29 @@ fn test_deployments_generate_devnet_strips_env_simnet() {
         for tx in &batch.transactions {
             if let TransactionSpecification::ContractPublish(spec) = tx {
                 assert!(
+                    spec.source.contains("double"),
+                    "non-simnet code should be preserved after load, got:\n{}",
+                    spec.source
+                );
+                assert!(
+                    !spec.source.contains("test-double"),
+                    "#[env(simnet)] code should be stripped from ContractPublish source after load_deployment, got:\n{}",
+                    spec.source
+                );
+                assert!(
                     spec.cost < full_cost,
                     "cost should reflect stripped source (expected < {full_cost}, got {})",
                     spec.cost
                 );
             }
         }
+    }
+
+    for (source, _) in deployment.contracts.values() {
+        assert!(
+            !source.contains("test-double"),
+            "#[env(simnet)] code should be stripped from contracts map after load, got:\n{source}"
+        );
     }
 }
 

--- a/components/clarinet-cli/tests/cli.rs
+++ b/components/clarinet-cli/tests/cli.rs
@@ -630,9 +630,11 @@ fn test_devnet_deployment_strips_env_simnet() {
 
     // Devnet uses ContractPublish (real transactions), not EmulatedContractPublish.
     // Verify the simnet-only code was stripped from every contract source.
+    let mut publish_txs_inspected = 0;
     for batch in &deployment.plan.batches {
         for tx in &batch.transactions {
             if let TransactionSpecification::ContractPublish(spec) = tx {
+                publish_txs_inspected += 1;
                 assert!(
                     spec.source.contains("double"),
                     "non-simnet code should be preserved, got:\n{}",
@@ -646,8 +648,16 @@ fn test_devnet_deployment_strips_env_simnet() {
             }
         }
     }
+    assert!(
+        publish_txs_inspected > 0,
+        "expected at least one ContractPublish transaction in the devnet plan"
+    );
 
     // Also check the contracts map used for analysis.
+    assert!(
+        !deployment.contracts.is_empty(),
+        "expected at least one contract in the deployment"
+    );
     for (source, _) in deployment.contracts.values() {
         assert!(
             !source.contains("test-double"),
@@ -690,9 +700,11 @@ fn test_deployments_generate_devnet_strips_env_simnet() {
     let default_fee_rate: u64 = 10;
     let full_cost = default_fee_rate * full_source.len() as u64;
 
+    let mut publish_txs_inspected = 0;
     for batch in &deployment.plan.batches {
         for tx in &batch.transactions {
             if let TransactionSpecification::ContractPublish(spec) = tx {
+                publish_txs_inspected += 1;
                 assert!(
                     spec.source.contains("double"),
                     "non-simnet code should be preserved after load, got:\n{}",
@@ -711,7 +723,15 @@ fn test_deployments_generate_devnet_strips_env_simnet() {
             }
         }
     }
+    assert!(
+        publish_txs_inspected > 0,
+        "expected at least one ContractPublish transaction in the loaded plan"
+    );
 
+    assert!(
+        !deployment.contracts.is_empty(),
+        "expected at least one contract in the loaded deployment"
+    );
     for (source, _) in deployment.contracts.values() {
         assert!(
             !source.contains("test-double"),

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -775,10 +775,12 @@ pub async fn generate_default_deployment(
             .clone();
 
         if environment == Environment::OnChain {
-            let (clean, had_annotation) =
-                remove_env_simnet(source.clone()).unwrap_or((source, false));
-            source = clean;
-            found_env_simnet |= had_annotation;
+            // Best effort: if the source can't be parsed, fall through to the
+            // analysis pass below which will surface the parse error.
+            if let Ok(Some(clean)) = remove_env_simnet(&source) {
+                source = clean;
+                found_env_simnet = true;
+            }
         }
 
         let contract_id = QualifiedContractIdentifier::new(sender.clone(), contract_name.clone());

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1135,8 +1135,11 @@ impl DeploymentSpecification {
                                     // `#[env(simnet)]` code from the source that gets broadcast.
                                     // The YAML never persists `source` for ContractPublish (it
                                     // only stores `path`), so this fires on every load.
-                                    let (clean, _) = remove_env_simnet(spec.source.clone()).unwrap_or((spec.source.clone(), false));
-                                    spec.source = clean;
+                                    if let Some(stripped) = remove_env_simnet(&spec.source).map_err(|e|
+                                        format!("failed to strip #[env(simnet)] code from contract publish source at {:?}: {e}", spec.location)
+                                    )? {
+                                        spec.source = stripped;
+                                    }
 
                                     let contract_id = QualifiedContractIdentifier::new(spec.expected_sender.clone(), spec.contract_name.clone());
                                     contracts.insert(contract_id, (spec.source.clone(), spec.location.clone()));
@@ -1278,16 +1281,18 @@ impl DeploymentSpecification {
                     TransactionSpecification::ContractPublish(spec) => &mut spec.source,
                     _ => continue,
                 };
-                let (clean, found_env_simnet) = remove_env_simnet(source.to_string())?;
-                *source = clean;
-                global_found_env_simnet |= found_env_simnet;
+                if let Some(clean) = remove_env_simnet(source)? {
+                    *source = clean;
+                    global_found_env_simnet = true;
+                }
             }
         }
 
-        for (ref mut source, _) in self.contracts.values_mut() {
-            let (clean, found_env_simnet) = remove_env_simnet(source.to_string())?;
-            *source = clean;
-            global_found_env_simnet |= found_env_simnet;
+        for (source, _) in self.contracts.values_mut() {
+            if let Some(clean) = remove_env_simnet(source)? {
+                *source = clean;
+                global_found_env_simnet = true;
+            }
         }
 
         Ok(global_found_env_simnet)

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1129,11 +1129,17 @@ impl DeploymentSpecification {
                                     TransactionSpecification::RequirementPublish(spec)
                                 }
                                 TransactionSpecificationFile::ContractPublish(spec) => {
-                                    let spec = ContractPublishSpecification::from_specifications(spec, project_root)?;
+                                    let mut spec = ContractPublishSpecification::from_specifications(spec, project_root)?;
+
+                                    // Devnet/Testnet/Mainnet are all on-chain; strip
+                                    // `#[env(simnet)]` code from the source that gets broadcast.
+                                    // The YAML never persists `source` for ContractPublish (it
+                                    // only stores `path`), so this fires on every load.
+                                    let (clean, _) = remove_env_simnet(spec.source.clone()).unwrap_or((spec.source.clone(), false));
+                                    spec.source = clean;
 
                                     let contract_id = QualifiedContractIdentifier::new(spec.expected_sender.clone(), spec.contract_name.clone());
-                                    let (source, _) = remove_env_simnet(spec.source.clone()).unwrap_or((spec.source.clone(), false));
-                                    contracts.insert(contract_id, (source, spec.location.clone()));
+                                    contracts.insert(contract_id, (spec.source.clone(), spec.location.clone()));
                                     TransactionSpecification::ContractPublish(spec)
                                 }
                                 TransactionSpecificationFile::BtcTransfer(spec) => {
@@ -1267,12 +1273,14 @@ impl DeploymentSpecification {
         let mut global_found_env_simnet = false;
         for batch in self.plan.batches.iter_mut() {
             for transaction in batch.transactions.iter_mut() {
-                if let TransactionSpecification::EmulatedContractPublish(ref mut spec) = transaction
-                {
-                    let (clean, found_env_simnet) = remove_env_simnet(spec.source.to_string())?;
-                    spec.source = clean;
-                    global_found_env_simnet |= found_env_simnet;
-                }
+                let source = match transaction {
+                    TransactionSpecification::EmulatedContractPublish(spec) => &mut spec.source,
+                    TransactionSpecification::ContractPublish(spec) => &mut spec.source,
+                    _ => continue,
+                };
+                let (clean, found_env_simnet) = remove_env_simnet(source.to_string())?;
+                *source = clean;
+                global_found_env_simnet |= found_env_simnet;
             }
         }
 

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1279,6 +1279,7 @@ impl DeploymentSpecification {
                 let source = match transaction {
                     TransactionSpecification::EmulatedContractPublish(spec) => &mut spec.source,
                     TransactionSpecification::ContractPublish(spec) => &mut spec.source,
+                    TransactionSpecification::RequirementPublish(spec) => &mut spec.source,
                     _ => continue,
                 };
                 if let Some(clean) = remove_env_simnet(source)? {

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -1125,7 +1125,16 @@ impl DeploymentSpecification {
                                     if matches!(network, StacksNetwork::Mainnet) {
                                         return Err(format!("{} only supports transactions of type 'contract-call' and 'contract-publish", specs.network.to_lowercase()))
                                     }
-                                    let spec = RequirementPublishSpecification::from_specifications(spec, project_root)?;
+                                    let mut spec = RequirementPublishSpecification::from_specifications(spec, project_root)?;
+
+                                    // Devnet/Testnet broadcast RequirementPublish on-chain;
+                                    // strip `#[env(simnet)]` from those sources too.
+                                    if let Some(stripped) = remove_env_simnet(&spec.source).map_err(|e|
+                                        format!("failed to strip #[env(simnet)] code from requirement publish source at {:?}: {e}", spec.location)
+                                    )? {
+                                        spec.source = stripped;
+                                    }
+
                                     TransactionSpecification::RequirementPublish(spec)
                                 }
                                 TransactionSpecificationFile::ContractPublish(spec) => {

--- a/components/clarity-repl/src/utils.rs
+++ b/components/clarity-repl/src/utils.rs
@@ -103,9 +103,9 @@ pub fn get_env_simnet_spans(source: &str) -> Result<Vec<Span>, String> {
 }
 
 /// Strips `#[env(simnet)]`-annotated code from `source`. Returns `Ok(None)` if
-/// no annotation is found (the caller should keep the original `source`),
-/// `Ok(Some(stripped))` if annotated code was removed, or `Err` if `source`
-/// could not be parsed.
+/// no removable `#[env(simnet)]` blocks are found (the caller should keep the
+/// original `source`), `Ok(Some(stripped))` if annotated code was removed, or
+/// `Err` if `source` could not be parsed.
 pub fn remove_env_simnet(source: &str) -> Result<Option<String>, String> {
     let spans = get_env_simnet_spans(source)?;
 

--- a/components/clarity-repl/src/utils.rs
+++ b/components/clarity-repl/src/utils.rs
@@ -102,11 +102,15 @@ pub fn get_env_simnet_spans(source: &str) -> Result<Vec<Span>, String> {
     Ok(spans)
 }
 
-pub fn remove_env_simnet(source: String) -> Result<(String, bool), String> {
-    let spans = get_env_simnet_spans(&source)?;
+/// Strips `#[env(simnet)]`-annotated code from `source`. Returns `Ok(None)` if
+/// no annotation is found (the caller should keep the original `source`),
+/// `Ok(Some(stripped))` if annotated code was removed, or `Err` if `source`
+/// could not be parsed.
+pub fn remove_env_simnet(source: &str) -> Result<Option<String>, String> {
+    let spans = get_env_simnet_spans(source)?;
 
     if spans.is_empty() {
-        return Ok((source, false));
+        return Ok(None);
     }
 
     let mut lines = source.lines().map(Some).collect::<Vec<Option<&str>>>();
@@ -124,7 +128,7 @@ pub fn remove_env_simnet(source: String) -> Result<(String, bool), String> {
         result.push('\n');
     }
 
-    Ok((result, true))
+    Ok(Some(result))
 }
 
 fn collect_env_simnet_spans(exprs: &[PreSymbolicExpression], out: &mut Vec<Span>) {
@@ -211,16 +215,14 @@ mod tests {
         "#);
 
         // test that we can remove a marked fn
-        let (clean, found) =
-            remove_env_simnet(with_env_simnet.to_string()).expect("remove_env_simnet failed");
+        let clean = remove_env_simnet(with_env_simnet)
+            .expect("remove_env_simnet failed")
+            .expect("expected stripped source");
         assert_eq!(clean, without_env_simnet);
-        assert!(found);
 
         // test that nothing is removed if nothing is marked
-        let (clean, found) =
-            remove_env_simnet(without_env_simnet.to_string()).expect("remove_env_simnet failed");
-        assert_eq!(clean, without_env_simnet);
-        assert!(!found);
+        let result = remove_env_simnet(without_env_simnet).expect("remove_env_simnet failed");
+        assert!(result.is_none(), "expected no change");
     }
 
     #[test]
@@ -249,10 +251,10 @@ mod tests {
             )
         "#);
 
-        let (clean, found) =
-            remove_env_simnet(with_env_simnet.to_string()).expect("remove_env_simnet failed");
+        let clean = remove_env_simnet(with_env_simnet)
+            .expect("remove_env_simnet failed")
+            .expect("expected stripped source");
         assert_eq!(clean, without_env_simnet);
-        assert!(found);
     }
 
     #[test]
@@ -267,10 +269,8 @@ mod tests {
             )
         "#);
 
-        let (clean, found) =
-            remove_env_simnet(source.to_string()).expect("remove_env_simnet failed");
-        assert_eq!(clean, source);
-        assert!(!found);
+        let result = remove_env_simnet(source).expect("remove_env_simnet failed");
+        assert!(result.is_none(), "EOL annotation should be ignored");
     }
 
     #[test]


### PR DESCRIPTION
### Description

Strip `#[env(simnet)]` code out of on-chain deployments

The initial PR (#2154) worked in VSCode and dimmed out the `#[env(simnet)]` code, but did not actually remove it from the deployments

This PR also fixes the function signature for `remove_env_simnet()`, so that it does not need an to take an owned string, which eliminates several unnecessary `clone()`s

### Related Issues

- Follow-up of #2154
- Fixes #2343

### Manual Testing

Here's the procedure I used to check that `#[env(simnet)]` is actually removed from a deployment:

#### Create a new project with a single contract

```sh
clarinet new env-simnet-test --disable-telemetry
cd env-simnet-test
clarinet contract new my-contract
```
#### Add the following code to `contracts/my-contract.clar`

```clarity
(define-read-only (get-one)
  u1)

;; #[env(simnet)]
(define-read-only (get-two)
  u2)
```

#### Start the devnet

```sh
clarinet devnet start
```

#### Check `get-two` is not in the contract

```sh
curl -s http://localhost:3999/v2/contracts/interface/ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM/my-contract | jq '.functions[].name'
```

This should return

```console
"get-one"
```

### Checklist

- [x] Tests added in this PR (if applicable)

