### PR TITLE
feat(static-cost): add warnings and resolving for local traits

### DIFF
--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -1101,13 +1101,17 @@ async fn get_cost_analysis(
             call_stack: &mut call_stack,
         };
 
-        // Use static_cost which returns (StaticCost, Option<TraitCount>)
-        // TraitCount is HashMap<String, (u64, u64)>, so we can use it directly
-        static_cost(&mut env, &invoke_ctx, contract_id).map_err(|e| {
+        let result = static_cost(&mut env, &invoke_ctx, contract_id).map_err(|e| {
             clarity_repl::uprint!("[LSP] static_cost failed with error: {}", e);
             let error_msg = format!("Cost analysis failed for contract {}: {}", contract_id, e);
             VmExecutionError::Internal(VmInternalError::Expect(error_msg))
-        })
+        })?;
+
+        for warning in &result.warnings {
+            clarity_repl::uprint!("[LSP] Cost warning: {}", warning);
+        }
+
+        Ok(result.costs)
     });
 
     cost_result

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -1025,7 +1025,7 @@ pub async fn build_state(
             // Run static_cost_tree for this contract
             let Some(cost_result) = get_cost_analysis(session, contract_id, clarity_version).await
             else {
-                clarity_repl::uprint!("[LSP] Cost analysis failed for contract: {}", contract_id);
+                clarity_repl::uprint!("[LSP] Cost analysis failed for contract: {contract_id}");
                 continue;
             };
             clarity_repl::uprint!(
@@ -1074,9 +1074,7 @@ async fn get_cost_analysis(
     use clarity_static_cost::static_cost::static_cost;
 
     clarity_repl::uprint!(
-        "[LSP] get_cost_analysis called for contract: {} (clarity version: {:?})",
-        contract_id,
-        clarity_version
+        "[LSP] get_cost_analysis called for contract: {contract_id} (clarity version: {clarity_version:?})"
     );
 
     let tx_sender: clarity_types::types::PrincipalData = session.interpreter.get_tx_sender().into();
@@ -1086,7 +1084,7 @@ async fn get_cost_analysis(
         .interpreter
         .get_global_context(epoch, false)
         .map_err(|e| {
-            clarity_repl::uprint!("[LSP] Failed to get global context: {}", e);
+            clarity_repl::uprint!("[LSP] Failed to get global context: {e}");
             e
         })
         .ok()?;
@@ -1110,8 +1108,8 @@ async fn get_cost_analysis(
             };
 
             let result = static_cost(&mut env, &invoke_ctx, contract_id).map_err(|e| {
-                clarity_repl::uprint!("[LSP] static_cost failed with error: {}", e);
-                let error_msg = format!("Cost analysis failed for contract {}: {}", contract_id, e);
+                clarity_repl::uprint!("[LSP] static_cost failed with error: {e}");
+                let error_msg = format!("Cost analysis failed for contract {contract_id}: {e}");
                 VmExecutionError::Internal(VmInternalError::Expect(error_msg))
             })?;
 
@@ -1119,10 +1117,10 @@ async fn get_cost_analysis(
                 .warnings
                 .iter()
                 .map(|w| {
-                    clarity_repl::uprint!("[LSP] Cost warning: {}", w);
+                    clarity_repl::uprint!("[LSP] Cost warning: {w}");
                     ClarityDiagnostic {
                         level: ClarityLevel::Warning,
-                        message: format!("{w}"),
+                        message: w.to_string(),
                         spans: vec![],
                         suggestion: None,
                     }
@@ -1137,7 +1135,7 @@ async fn get_cost_analysis(
 
     cost_result
         .map_err(|e| {
-            clarity_repl::uprint!("[LSP] Cost analysis failed with error: {:?}", e);
+            clarity_repl::uprint!("[LSP] Cost analysis failed with error: {e:?}");
         })
         .ok()
 }

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -1023,8 +1023,7 @@ pub async fn build_state(
                 .unwrap_or(DEFAULT_CLARITY_VERSION);
 
             // Run static_cost_tree for this contract
-            let Some(cost_analysis) =
-                get_cost_analysis(session, contract_id, clarity_version).await
+            let Some(cost_result) = get_cost_analysis(session, contract_id, clarity_version).await
             else {
                 clarity_repl::uprint!("[LSP] Cost analysis failed for contract: {}", contract_id);
                 continue;
@@ -1032,9 +1031,15 @@ pub async fn build_state(
             clarity_repl::uprint!(
                 "[LSP] Cost analysis completed for {}: {} functions analyzed",
                 contract_id,
-                cost_analysis.len()
+                cost_result.costs.len()
             );
-            cost_analyses.insert(contract_id.clone(), cost_analysis);
+            if !cost_result.warnings.is_empty() {
+                diagnostics
+                    .entry(contract_id.clone())
+                    .or_insert_with(Vec::new)
+                    .extend(cost_result.warnings);
+            }
+            cost_analyses.insert(contract_id.clone(), cost_result.costs);
         }
     }
 
@@ -1053,12 +1058,17 @@ pub async fn build_state(
     Ok(())
 }
 
+struct CostAnalysisResult {
+    costs: HashMap<String, (StaticCost, Option<HashMap<String, (u64, u64)>>)>,
+    warnings: Vec<ClarityDiagnostic>,
+}
+
 // Helper function to compute cost analysis for a contract
 async fn get_cost_analysis(
     session: &mut clarity_repl::repl::Session,
     contract_id: &QualifiedContractIdentifier,
     clarity_version: ClarityVersion,
-) -> Option<HashMap<String, (StaticCost, Option<HashMap<String, (u64, u64)>>)>> {
+) -> Option<CostAnalysisResult> {
     use clarity::vm::contexts::{CallStack, ContractContext, ExecutionState, InvocationContext};
     use clarity::vm::errors::{VmExecutionError, VmInternalError};
     use clarity_static_cost::static_cost::static_cost;
@@ -1083,36 +1093,47 @@ async fn get_cost_analysis(
 
     global_context.begin();
 
-    let cost_result: Result<
-        HashMap<String, (StaticCost, Option<HashMap<String, (u64, u64)>>)>,
-        clarity::vm::errors::VmExecutionError,
-    > = global_context.execute(|g| {
-        let contract_context = ContractContext::new(contract_id.clone(), clarity_version);
-        let mut call_stack = CallStack::new();
+    let cost_result: Result<CostAnalysisResult, clarity::vm::errors::VmExecutionError> =
+        global_context.execute(|g| {
+            let contract_context = ContractContext::new(contract_id.clone(), clarity_version);
+            let mut call_stack = CallStack::new();
 
-        let invoke_ctx = InvocationContext {
-            contract_context: &contract_context,
-            sender: Some(tx_sender.clone()),
-            caller: Some(tx_sender),
-            sponsor: None,
-        };
-        let mut env = ExecutionState {
-            global_context: g,
-            call_stack: &mut call_stack,
-        };
+            let invoke_ctx = InvocationContext {
+                contract_context: &contract_context,
+                sender: Some(tx_sender.clone()),
+                caller: Some(tx_sender),
+                sponsor: None,
+            };
+            let mut env = ExecutionState {
+                global_context: g,
+                call_stack: &mut call_stack,
+            };
 
-        let result = static_cost(&mut env, &invoke_ctx, contract_id).map_err(|e| {
-            clarity_repl::uprint!("[LSP] static_cost failed with error: {}", e);
-            let error_msg = format!("Cost analysis failed for contract {}: {}", contract_id, e);
-            VmExecutionError::Internal(VmInternalError::Expect(error_msg))
-        })?;
+            let result = static_cost(&mut env, &invoke_ctx, contract_id).map_err(|e| {
+                clarity_repl::uprint!("[LSP] static_cost failed with error: {}", e);
+                let error_msg = format!("Cost analysis failed for contract {}: {}", contract_id, e);
+                VmExecutionError::Internal(VmInternalError::Expect(error_msg))
+            })?;
 
-        for warning in &result.warnings {
-            clarity_repl::uprint!("[LSP] Cost warning: {}", warning);
-        }
+            let warnings = result
+                .warnings
+                .iter()
+                .map(|w| {
+                    clarity_repl::uprint!("[LSP] Cost warning: {}", w);
+                    ClarityDiagnostic {
+                        level: ClarityLevel::Warning,
+                        message: format!("{w}"),
+                        spans: vec![],
+                        suggestion: None,
+                    }
+                })
+                .collect();
 
-        Ok(result.costs)
-    });
+            Ok(CostAnalysisResult {
+                costs: result.costs,
+                warnings,
+            })
+        });
 
     cost_result
         .map_err(|e| {

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -1023,18 +1023,18 @@ pub async fn build_state(
                 .unwrap_or(DEFAULT_CLARITY_VERSION);
 
             // Run static_cost_tree for this contract
-            if let Some(cost_analysis) =
+            let Some(cost_analysis) =
                 get_cost_analysis(session, contract_id, clarity_version).await
-            {
-                clarity_repl::uprint!(
-                    "[LSP] Cost analysis completed for {}: {} functions analyzed",
-                    contract_id,
-                    cost_analysis.len()
-                );
-                cost_analyses.insert(contract_id.clone(), cost_analysis);
-            } else {
+            else {
                 clarity_repl::uprint!("[LSP] Cost analysis failed for contract: {}", contract_id);
-            }
+                continue;
+            };
+            clarity_repl::uprint!(
+                "[LSP] Cost analysis completed for {}: {} functions analyzed",
+                contract_id,
+                cost_analysis.len()
+            );
+            cost_analyses.insert(contract_id.clone(), cost_analysis);
         }
     }
 

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -30,8 +30,8 @@ use super::{
 /// Configuration for static cost analysis.
 #[derive(Debug, Clone)]
 pub struct StaticCostConfig {
-    /// Original source code of the contract (used to compute contract-size overhead).
-    pub contract_source: String,
+    /// Size of the contract source in bytes, used to compute contract-size overhead.
+    pub contract_size: u64,
     /// Mapping from fully-qualified trait identifiers to concrete contract
     /// implementations. Used to resolve trait-based `contract-call?` targets
     /// during static analysis.
@@ -293,7 +293,7 @@ pub fn static_cost(
         clarity_version,
         epoch,
         Some(&StaticCostConfig {
-            contract_source,
+            contract_size: contract_source.len() as u64,
             trait_implementations: HashMap::new(),
         }),
         env,
@@ -419,7 +419,7 @@ pub fn static_cost_from_ast(
     invoke_ctx: &InvocationContext,
 ) -> Result<StaticCostResult, StaticCostError> {
     let empty_impls = HashMap::new();
-    let contract_size = config.map(|c| c.contract_source.len() as u64);
+    let contract_size = config.map(|c| c.contract_size);
     let trait_implementations = config
         .map(|c| &c.trait_implementations)
         .unwrap_or(&empty_impls);
@@ -671,9 +671,27 @@ fn get_contract_call_target_cost(
     if let Some(contract_id) = contract_id {
         match static_cost(env, ctx.invoke_ctx, &contract_id) {
             Ok(result) => {
+                // Propagate any warnings from the callee analysis so that
+                // incomplete analysis in transitive dependencies is surfaced.
+                ctx.warnings.borrow_mut().extend(result.warnings);
+
                 if let Some((cost, _trait_count)) = result.costs.get(function_name.as_str()) {
                     return Some(cost.clone());
                 }
+                // Contract resolved but the called function was not found in
+                // its cost map — emit a warning rather than silently returning
+                // zero cost.
+                ctx.warnings.borrow_mut().push(CostWarning {
+                    function_name: ctx.current_function.unwrap_or("<unknown>").to_string(),
+                    kind: CostWarningKind::ContractCallCostError {
+                        contract_id: contract_id.to_string(),
+                        called_function: function_name.to_string(),
+                        error: format!(
+                            "function '{}' not found in contract cost map",
+                            function_name
+                        ),
+                    },
+                });
             }
             Err(e) => {
                 ctx.warnings.borrow_mut().push(CostWarning {

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -26,6 +26,17 @@ use super::{
     calculate_total_cost_with_branching, calculate_value_cost, TraitCount, TraitCountCollector,
     TraitCountContext, TraitCountPropagator, TraitCountVisitor,
 };
+
+/// Configuration for static cost analysis.
+#[derive(Debug, Clone)]
+pub struct StaticCostConfig {
+    /// Original source code of the contract (used to compute contract-size overhead).
+    pub contract_source: String,
+    /// Mapping from fully-qualified trait identifiers to concrete contract
+    /// implementations. Used to resolve trait-based `contract-call?` targets
+    /// during static analysis.
+    pub trait_implementations: HashMap<TraitIdentifier, Vec<QualifiedContractIdentifier>>,
+}
 // TODO:
 // unwrap evaluates both branches (https://github.com/clarity-lang/reference/issues/59)
 
@@ -149,12 +160,10 @@ pub struct AnalysisContext<'a> {
     pub clarity_version: &'a ClarityVersion,
     pub epoch: StacksEpochId,
     pub invoke_ctx: &'a InvocationContext<'a>,
-    /// Mapping from unqualified trait names to concrete contract implementations.
-    /// Used to resolve trait-based `contract-call?` targets during static analysis.
-    /// Note: keys are simple trait names (e.g. `"sip-010-trait"`), not fully-qualified
-    /// identifiers. This is sufficient for in-project analysis where trait names are
-    /// unique, but could collide if multiple traits share the same name.
-    pub trait_implementations: &'a HashMap<String, Vec<QualifiedContractIdentifier>>,
+    /// Mapping from fully-qualified trait identifiers to concrete contract
+    /// implementations. Used to resolve trait-based `contract-call?` targets
+    /// during static analysis.
+    pub trait_implementations: &'a HashMap<TraitIdentifier, Vec<QualifiedContractIdentifier>>,
     /// Warnings accumulated during analysis (e.g. unresolved trait calls).
     pub warnings: &'a RefCell<Vec<CostWarning>>,
     /// Name of the function currently being analyzed (for warning context).
@@ -279,11 +288,14 @@ pub fn static_cost(
     let epoch = env.global_context.epoch_id;
     let ast = make_ast(&contract_source, epoch, clarity_version)?;
 
-    static_cost_from_ast_with_source(
+    static_cost_from_ast(
         &ast,
         clarity_version,
         epoch,
-        Some(&contract_source),
+        Some(&StaticCostConfig {
+            contract_source,
+            trait_implementations: HashMap::new(),
+        }),
         env,
         invoke_ctx,
     )
@@ -402,41 +414,15 @@ pub fn static_cost_from_ast(
     contract_ast: &clarity::vm::ast::ContractAST,
     clarity_version: &ClarityVersion,
     epoch: StacksEpochId,
+    config: Option<&StaticCostConfig>,
     env: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
 ) -> Result<StaticCostResult, StaticCostError> {
-    static_cost_from_ast_with_source(contract_ast, clarity_version, epoch, None, env, invoke_ctx)
-}
-
-pub fn static_cost_from_ast_with_source(
-    contract_ast: &clarity::vm::ast::ContractAST,
-    clarity_version: &ClarityVersion,
-    epoch: StacksEpochId,
-    contract_source: Option<&str>,
-    env: &mut ExecutionState,
-    invoke_ctx: &InvocationContext,
-) -> Result<StaticCostResult, StaticCostError> {
-    static_cost_from_ast_with_options(
-        contract_ast,
-        clarity_version,
-        epoch,
-        contract_source,
-        &HashMap::new(),
-        env,
-        invoke_ctx,
-    )
-}
-
-pub fn static_cost_from_ast_with_options(
-    contract_ast: &clarity::vm::ast::ContractAST,
-    clarity_version: &ClarityVersion,
-    epoch: StacksEpochId,
-    contract_source: Option<&str>,
-    trait_implementations: &HashMap<String, Vec<QualifiedContractIdentifier>>,
-    env: &mut ExecutionState,
-    invoke_ctx: &InvocationContext,
-) -> Result<StaticCostResult, StaticCostError> {
-    let contract_size = contract_source.map(|s| s.len() as u64);
+    let empty_impls = HashMap::new();
+    let contract_size = config.map(|c| c.contract_source.len() as u64);
+    let trait_implementations = config
+        .map(|c| &c.trait_implementations)
+        .unwrap_or(&empty_impls);
 
     let (cost_trees_with_traits, warnings) = static_cost_tree_from_ast(
         contract_ast,
@@ -485,7 +471,7 @@ pub fn static_cost_tree_from_ast(
     ast: &clarity::vm::ast::ContractAST,
     clarity_version: &ClarityVersion,
     epoch: StacksEpochId,
-    trait_implementations: &HashMap<String, Vec<QualifiedContractIdentifier>>,
+    trait_implementations: &HashMap<TraitIdentifier, Vec<QualifiedContractIdentifier>>,
     env: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
 ) -> Result<
@@ -730,7 +716,7 @@ fn resolve_trait_call_cost(
         _ => return None,
     };
 
-    let implementations = ctx.trait_implementations.get(&trait_id.name.to_string())?;
+    let implementations = ctx.trait_implementations.get(trait_id)?;
 
     let mut envelope: Option<StaticCost> = None;
     for impl_contract in implementations {
@@ -1959,7 +1945,8 @@ mod tests {
     ) -> Result<StaticCost, StaticCostError> {
         let cost_map: HashMap<String, Option<StaticCost>> = HashMap::new();
         let function_defs: HashMap<String, &[SymbolicExpression]> = HashMap::new();
-        let trait_impls: HashMap<String, Vec<QualifiedContractIdentifier>> = HashMap::new();
+        let trait_impls: HashMap<TraitIdentifier, Vec<QualifiedContractIdentifier>> =
+            HashMap::new();
         let warnings = RefCell::new(Vec::new());
 
         let epoch = StacksEpochId::latest(); // XXX this should be matched with the clarity version
@@ -2005,7 +1992,8 @@ mod tests {
         let contract_context =
             ContractContext::new(QualifiedContractIdentifier::transient(), *clarity_version);
         let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
-        let result = static_cost_from_ast(&ast, clarity_version, epoch, &mut env, &invoke_ctx)?;
+        let result =
+            static_cost_from_ast(&ast, clarity_version, epoch, None, &mut env, &invoke_ctx)?;
         Ok(result
             .costs
             .into_iter()
@@ -2481,7 +2469,8 @@ mod tests {
         let contract_context =
             ContractContext::new(QualifiedContractIdentifier::transient(), *clarity_version);
         let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
-        let result = static_cost_from_ast(&ast, clarity_version, epoch, &mut env, &invoke_ctx)?;
+        let result =
+            static_cost_from_ast(&ast, clarity_version, epoch, None, &mut env, &invoke_ctx)?;
         Ok(result
             .costs
             .into_iter()

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -669,9 +669,24 @@ fn get_contract_call_target_cost(
     };
 
     if let Some(contract_id) = contract_id {
-        let result = static_cost(env, ctx.invoke_ctx, &contract_id).ok()?;
-        let (cost, _trait_count) = result.costs.get(function_name.as_str())?;
-        return Some(cost.clone());
+        match static_cost(env, ctx.invoke_ctx, &contract_id) {
+            Ok(result) => {
+                if let Some((cost, _trait_count)) = result.costs.get(function_name.as_str()) {
+                    return Some(cost.clone());
+                }
+            }
+            Err(e) => {
+                ctx.warnings.borrow_mut().push(CostWarning {
+                    function_name: ctx.current_function.unwrap_or("<unknown>").to_string(),
+                    kind: CostWarningKind::ContractCallCostError {
+                        contract_id: contract_id.to_string(),
+                        called_function: function_name.to_string(),
+                        error: e.to_string(),
+                    },
+                });
+            }
+        }
+        return None;
     }
 
     // Try trait-based dispatch: the target is an Atom referencing a trait parameter.
@@ -720,8 +735,14 @@ fn resolve_trait_call_cost(
 
     let mut envelope: Option<StaticCost> = None;
     for impl_contract in implementations {
-        let result = static_cost(env, ctx.invoke_ctx, impl_contract).ok()?;
-        let (cost, _) = result.costs.get(function_name.as_str())?;
+        let result = match static_cost(env, ctx.invoke_ctx, impl_contract) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let (cost, _) = match result.costs.get(function_name.as_str()) {
+            Some(entry) => entry,
+            None => continue,
+        };
         envelope = Some(match envelope {
             None => cost.clone(),
             Some(prev) => StaticCost {

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -149,8 +149,11 @@ pub struct AnalysisContext<'a> {
     pub clarity_version: &'a ClarityVersion,
     pub epoch: StacksEpochId,
     pub invoke_ctx: &'a InvocationContext<'a>,
-    /// Mapping from trait identifier strings to concrete contract implementations.
+    /// Mapping from unqualified trait names to concrete contract implementations.
     /// Used to resolve trait-based `contract-call?` targets during static analysis.
+    /// Note: keys are simple trait names (e.g. `"sip-010-trait"`), not fully-qualified
+    /// identifiers. This is sufficient for in-project analysis where trait names are
+    /// unique, but could collide if multiple traits share the same name.
     pub trait_implementations: &'a HashMap<String, Vec<QualifiedContractIdentifier>>,
     /// Warnings accumulated during analysis (e.g. unresolved trait calls).
     pub warnings: &'a RefCell<Vec<CostWarning>>,
@@ -258,7 +261,7 @@ pub fn static_cost(
     env: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
     contract_identifier: &QualifiedContractIdentifier,
-) -> Result<HashMap<String, (StaticCost, Option<TraitCount>)>, StaticCostError> {
+) -> Result<StaticCostResult, StaticCostError> {
     let contract_source = env
         .global_context
         .database
@@ -276,15 +279,14 @@ pub fn static_cost(
     let epoch = env.global_context.epoch_id;
     let ast = make_ast(&contract_source, epoch, clarity_version)?;
 
-    let result = static_cost_from_ast_with_source(
+    static_cost_from_ast_with_source(
         &ast,
         clarity_version,
         epoch,
         Some(&contract_source),
         env,
         invoke_ctx,
-    )?;
-    Ok(result.costs)
+    )
 }
 
 /// Extract function signature arguments from a function definition expression.
@@ -648,14 +650,20 @@ fn extract_function_name(expr: &SymbolicExpression) -> Option<String> {
 /// Look up the cost of the function targeted by a `contract-call?`.
 ///
 /// `args` corresponds to `exprs[1..]` of the contract-call expression:
-///   args[0] = target contract — either an AtomValue(Principal(Contract(..)))
-///             for static dispatch, or a Field(TraitIdentifier) / trait ref
-///             for dynamic dispatch
-///   args[1] = function name   (Atom)
+///   args[0] = target contract, one of:
+///             - `LiteralValue(Principal(Contract(..)))` — fully-qualified static dispatch
+///             - `Field(TraitIdentifier)` — `.contract-name` sugar, also static dispatch
+///             - `Atom(name)` — a variable bound to a trait type, dynamic dispatch
+///   args[1] = function name (Atom)
 ///   args[2..] = call arguments
 ///
-/// Returns `None` for dynamic (trait-based) dispatch or if the target
-/// contract / function cannot be resolved.
+/// For static dispatch the target contract's cost is looked up directly.
+/// For dynamic (trait-based) dispatch, trait resolution is attempted via the
+/// `trait_implementations` map on the analysis context. If unresolved, a
+/// `CostWarning` is emitted and `None` is returned.
+///
+/// Note: `TraitReference` is not a valid `contract-call?` target in Clarity
+/// (it appears only in `use-trait` / `impl-trait` / trait definitions).
 fn get_contract_call_target_cost(
     args: &[SymbolicExpression],
     user_args: &UserArgumentsContext,
@@ -675,8 +683,8 @@ fn get_contract_call_target_cost(
     };
 
     if let Some(contract_id) = contract_id {
-        let costs = static_cost(env, ctx.invoke_ctx, &contract_id).ok()?;
-        let (cost, _trait_count) = costs.get(function_name.as_str())?;
+        let result = static_cost(env, ctx.invoke_ctx, &contract_id).ok()?;
+        let (cost, _trait_count) = result.costs.get(function_name.as_str())?;
         return Some(cost.clone());
     }
 
@@ -726,8 +734,8 @@ fn resolve_trait_call_cost(
 
     let mut envelope: Option<StaticCost> = None;
     for impl_contract in implementations {
-        let costs = static_cost(env, ctx.invoke_ctx, impl_contract).ok()?;
-        let (cost, _) = costs.get(function_name.as_str())?;
+        let result = static_cost(env, ctx.invoke_ctx, impl_contract).ok()?;
+        let (cost, _) = result.costs.get(function_name.as_str())?;
         envelope = Some(match envelope {
             None => cost.clone(),
             Some(prev) => StaticCost {

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -1,5 +1,6 @@
 // Static cost analysis for Clarity contracts
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use clarity::vm::analysis::errors::SyntaxBindingErrorType;
@@ -19,7 +20,7 @@ use clarity_types::types::TraitIdentifier;
 use stacks_common::types::StacksEpochId;
 
 use super::cost_functions::ClarityCostFunctionExt;
-use super::error::StaticCostError;
+use super::error::{CostWarning, CostWarningKind, StaticCostError};
 use super::{
     calculate_function_cost, calculate_function_cost_from_native_function,
     calculate_total_cost_with_branching, calculate_value_cost, TraitCount, TraitCountCollector,
@@ -148,6 +149,13 @@ pub struct AnalysisContext<'a> {
     pub clarity_version: &'a ClarityVersion,
     pub epoch: StacksEpochId,
     pub invoke_ctx: &'a InvocationContext<'a>,
+    /// Mapping from trait identifier strings to concrete contract implementations.
+    /// Used to resolve trait-based `contract-call?` targets during static analysis.
+    pub trait_implementations: &'a HashMap<String, Vec<QualifiedContractIdentifier>>,
+    /// Warnings accumulated during analysis (e.g. unresolved trait calls).
+    pub warnings: &'a RefCell<Vec<CostWarning>>,
+    /// Name of the function currently being analyzed (for warning context).
+    pub current_function: Option<&'a str>,
 }
 
 /// A type to track summed execution costs for different paths
@@ -235,6 +243,14 @@ fn make_ast(
     .map_err(|e| StaticCostError::AstParse(format!("{e:?}")))
 }
 
+/// Result of static cost analysis, containing per-function costs and any
+/// warnings about incomplete analysis (e.g. unresolved trait calls).
+#[derive(Debug, Clone)]
+pub struct StaticCostResult {
+    pub costs: HashMap<String, (StaticCost, Option<TraitCount>)>,
+    pub warnings: Vec<CostWarning>,
+}
+
 /// Static execution cost for functions within Environment.
 /// Returns the static cost for each function in the contract.
 /// {some-function-name: (StaticCost, Some({some-function-name: (1,1)}))}
@@ -260,14 +276,15 @@ pub fn static_cost(
     let epoch = env.global_context.epoch_id;
     let ast = make_ast(&contract_source, epoch, clarity_version)?;
 
-    static_cost_from_ast_with_source(
+    let result = static_cost_from_ast_with_source(
         &ast,
         clarity_version,
         epoch,
         Some(&contract_source),
         env,
         invoke_ctx,
-    )
+    )?;
+    Ok(result.costs)
 }
 
 /// Extract function signature arguments from a function definition expression.
@@ -385,7 +402,7 @@ pub fn static_cost_from_ast(
     epoch: StacksEpochId,
     env: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
-) -> Result<HashMap<String, (StaticCost, Option<TraitCount>)>, StaticCostError> {
+) -> Result<StaticCostResult, StaticCostError> {
     static_cost_from_ast_with_source(contract_ast, clarity_version, epoch, None, env, invoke_ctx)
 }
 
@@ -396,11 +413,37 @@ pub fn static_cost_from_ast_with_source(
     contract_source: Option<&str>,
     env: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
-) -> Result<HashMap<String, (StaticCost, Option<TraitCount>)>, StaticCostError> {
+) -> Result<StaticCostResult, StaticCostError> {
+    static_cost_from_ast_with_options(
+        contract_ast,
+        clarity_version,
+        epoch,
+        contract_source,
+        &HashMap::new(),
+        env,
+        invoke_ctx,
+    )
+}
+
+pub fn static_cost_from_ast_with_options(
+    contract_ast: &clarity::vm::ast::ContractAST,
+    clarity_version: &ClarityVersion,
+    epoch: StacksEpochId,
+    contract_source: Option<&str>,
+    trait_implementations: &HashMap<String, Vec<QualifiedContractIdentifier>>,
+    env: &mut ExecutionState,
+    invoke_ctx: &InvocationContext,
+) -> Result<StaticCostResult, StaticCostError> {
     let contract_size = contract_source.map(|s| s.len() as u64);
 
-    let cost_trees_with_traits =
-        static_cost_tree_from_ast(contract_ast, clarity_version, epoch, env, invoke_ctx)?;
+    let (cost_trees_with_traits, warnings) = static_cost_tree_from_ast(
+        contract_ast,
+        clarity_version,
+        epoch,
+        trait_implementations,
+        env,
+        invoke_ctx,
+    )?;
 
     let trait_count = cost_trees_with_traits
         .values()
@@ -427,23 +470,35 @@ pub fn static_cost_from_ast_with_source(
         })
         .collect();
 
-    Ok(costs
-        .into_iter()
-        .map(|(name, cost)| (name, (cost, trait_count.clone())))
-        .collect())
+    Ok(StaticCostResult {
+        costs: costs
+            .into_iter()
+            .map(|(name, cost)| (name, (cost, trait_count.clone())))
+            .collect(),
+        warnings,
+    })
 }
 
 pub fn static_cost_tree_from_ast(
     ast: &clarity::vm::ast::ContractAST,
     clarity_version: &ClarityVersion,
     epoch: StacksEpochId,
+    trait_implementations: &HashMap<String, Vec<QualifiedContractIdentifier>>,
     env: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
-) -> Result<HashMap<String, (CostAnalysisNode, Option<TraitCount>)>, StaticCostError> {
+) -> Result<
+    (
+        HashMap<String, (CostAnalysisNode, Option<TraitCount>)>,
+        Vec<CostWarning>,
+    ),
+    StaticCostError,
+> {
     let exprs = &ast.expressions;
     let mut user_args = UserArgumentsContext::new();
     let mut costs_map: HashMap<String, Option<StaticCost>> = HashMap::new();
     let mut costs: HashMap<String, Option<CostAnalysisNode>> = HashMap::new();
+    let warnings = RefCell::new(Vec::new());
+
     // first pass: extract function names and collect define-map key/value types
     {
         let mut free_tracker = clarity::vm::costs::LimitedCostTracker::new_free();
@@ -499,6 +554,9 @@ pub fn static_cost_tree_from_ast(
                 clarity_version,
                 epoch,
                 invoke_ctx,
+                trait_implementations,
+                warnings: &warnings,
+                current_function: Some(&function_name),
             };
             let (_, cost_analysis_tree) = build_cost_analysis_tree(expr, &user_args, &ctx, env, 0)?;
             // Compute static cost for this function so subsequent calls can look it up.
@@ -525,11 +583,16 @@ pub fn static_cost_tree_from_ast(
     // Compute trait_count while creating the root CostAnalysisNode
     let trait_count = get_trait_count(&cost_trees);
 
-    // Return each node with its trait_count
-    Ok(cost_trees
-        .into_iter()
-        .map(|(name, node)| (name, (node, trait_count.clone())))
-        .collect())
+    let warnings = warnings.into_inner();
+
+    // Return each node with its trait_count, plus warnings
+    Ok((
+        cost_trees
+            .into_iter()
+            .map(|(name, node)| (name, (node, trait_count.clone())))
+            .collect(),
+        warnings,
+    ))
 }
 
 /// Compute the `data_size` that the VM accumulates during `eval_all`.
@@ -595,23 +658,98 @@ fn extract_function_name(expr: &SymbolicExpression) -> Option<String> {
 /// contract / function cannot be resolved.
 fn get_contract_call_target_cost(
     args: &[SymbolicExpression],
+    user_args: &UserArgumentsContext,
+    ctx: &AnalysisContext,
     env: &mut ExecutionState,
-    invoke_ctx: &InvocationContext,
 ) -> Option<StaticCost> {
     let first = args.first()?;
     let function_name = args.get(1)?.match_atom()?;
 
+    // Try static dispatch: literal contract principal or .contract-name field
     let contract_id = match first
         .match_atom_value()
         .or_else(|| first.match_literal_value())
     {
-        Some(Value::Principal(PrincipalData::Contract(id))) => id.clone(),
-        _ => first.match_field()?.contract_identifier.clone(),
+        Some(Value::Principal(PrincipalData::Contract(id))) => Some(id.clone()),
+        _ => first.match_field().map(|f| f.contract_identifier.clone()),
     };
 
-    let costs = static_cost(env, invoke_ctx, &contract_id).ok()?;
-    let (cost, _trait_count) = costs.get(function_name.as_str())?;
-    Some(cost.clone())
+    if let Some(contract_id) = contract_id {
+        let costs = static_cost(env, ctx.invoke_ctx, &contract_id).ok()?;
+        let (cost, _trait_count) = costs.get(function_name.as_str())?;
+        return Some(cost.clone());
+    }
+
+    // Try trait-based dispatch: the target is an Atom referencing a trait parameter.
+    let trait_var_name = first.match_atom()?;
+    if let Some(cost) = resolve_trait_call_cost(trait_var_name, function_name, user_args, ctx, env)
+    {
+        return Some(cost);
+    }
+
+    // Unresolved: emit a warning
+    ctx.warnings.borrow_mut().push(CostWarning {
+        function_name: ctx.current_function.unwrap_or("<unknown>").to_string(),
+        kind: CostWarningKind::UnresolvedTraitCall {
+            target_variable: trait_var_name.to_string(),
+            called_function: function_name.to_string(),
+        },
+    });
+
+    None
+}
+
+/// Attempt to resolve the cost of a trait-based `contract-call?` by looking up
+/// the variable's trait type and checking the `trait_implementations` map for
+/// known concrete contracts.
+///
+/// When multiple implementations are registered for a trait, the returned cost
+/// uses the minimum of each implementation's min and the maximum of each
+/// implementation's max — i.e. the widest possible cost envelope.
+fn resolve_trait_call_cost(
+    trait_var_name: &ClarityName,
+    function_name: &ClarityName,
+    user_args: &UserArgumentsContext,
+    ctx: &AnalysisContext,
+    env: &mut ExecutionState,
+) -> Option<StaticCost> {
+    let arg_type = user_args.get_argument_type(trait_var_name)?;
+    let trait_id = match arg_type {
+        TypeSignature::CallableType(clarity_types::types::signatures::CallableSubtype::Trait(
+            trait_id,
+        )) => trait_id,
+        TypeSignature::TraitReferenceType(trait_id) => trait_id,
+        _ => return None,
+    };
+
+    let implementations = ctx.trait_implementations.get(&trait_id.name.to_string())?;
+
+    let mut envelope: Option<StaticCost> = None;
+    for impl_contract in implementations {
+        let costs = static_cost(env, ctx.invoke_ctx, impl_contract).ok()?;
+        let (cost, _) = costs.get(function_name.as_str())?;
+        envelope = Some(match envelope {
+            None => cost.clone(),
+            Some(prev) => StaticCost {
+                min: ExecutionCost {
+                    runtime: prev.min.runtime.min(cost.min.runtime),
+                    write_length: prev.min.write_length.min(cost.min.write_length),
+                    write_count: prev.min.write_count.min(cost.min.write_count),
+                    read_length: prev.min.read_length.min(cost.min.read_length),
+                    read_count: prev.min.read_count.min(cost.min.read_count),
+                },
+                max: ExecutionCost {
+                    runtime: prev.max.runtime.max(cost.max.runtime),
+                    write_length: prev.max.write_length.max(cost.max.write_length),
+                    write_count: prev.max.write_count.max(cost.max.write_count),
+                    read_length: prev.max.read_length.max(cost.max.read_length),
+                    read_count: prev.max.read_count.max(cost.max.read_count),
+                },
+            },
+        });
+    }
+
+    envelope
 }
 
 pub fn build_cost_analysis_tree(
@@ -1546,7 +1684,7 @@ fn build_listlike_cost_analysis_tree(
                 // the target contract.
                 if native_function == NativeFunctions::ContractCall {
                     if let Some(called_fn_cost) =
-                        get_contract_call_target_cost(&exprs[1..], env, ctx.invoke_ctx)
+                        get_contract_call_target_cost(&exprs[1..], user_args, ctx, env)
                     {
                         super::saturating_add_cost(&mut cost.min, &called_fn_cost.min);
                         super::saturating_add_cost(&mut cost.max, &called_fn_cost.max);
@@ -1813,6 +1951,8 @@ mod tests {
     ) -> Result<StaticCost, StaticCostError> {
         let cost_map: HashMap<String, Option<StaticCost>> = HashMap::new();
         let function_defs: HashMap<String, &[SymbolicExpression]> = HashMap::new();
+        let trait_impls: HashMap<String, Vec<QualifiedContractIdentifier>> = HashMap::new();
+        let warnings = RefCell::new(Vec::new());
 
         let epoch = StacksEpochId::latest(); // XXX this should be matched with the clarity version
         let ast = make_ast(source, epoch, clarity_version)?;
@@ -1831,6 +1971,9 @@ mod tests {
             clarity_version,
             epoch,
             invoke_ctx: &invoke_ctx,
+            trait_implementations: &trait_impls,
+            warnings: &warnings,
+            current_function: None,
         };
         let (_, cost_analysis_tree) =
             build_cost_analysis_tree(expr, &user_args, &ctx, &mut env, 0)?;
@@ -1854,8 +1997,9 @@ mod tests {
         let contract_context =
             ContractContext::new(QualifiedContractIdentifier::transient(), *clarity_version);
         let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
-        let costs = static_cost_from_ast(&ast, clarity_version, epoch, &mut env, &invoke_ctx)?;
-        Ok(costs
+        let result = static_cost_from_ast(&ast, clarity_version, epoch, &mut env, &invoke_ctx)?;
+        Ok(result
+            .costs
             .into_iter()
             .map(|(name, (cost, _trait_count))| (name, cost))
             .collect())
@@ -1906,6 +2050,9 @@ mod tests {
             clarity_version: &ClarityVersion::Clarity3,
             epoch,
             invoke_ctx: &invoke_ctx,
+            trait_implementations: &HashMap::new(),
+            warnings: &RefCell::new(Vec::new()),
+            current_function: None,
         };
         let (_, cost_tree) = build_cost_analysis_tree(expr, &user_args, &ctx, &mut env, 0).unwrap();
 
@@ -1968,6 +2115,9 @@ mod tests {
             clarity_version: &ClarityVersion::Clarity3,
             epoch,
             invoke_ctx: &invoke_ctx,
+            trait_implementations: &HashMap::new(),
+            warnings: &RefCell::new(Vec::new()),
+            current_function: None,
         };
         let (_, cost_tree) = build_cost_analysis_tree(expr, &user_args, &ctx, &mut env, 0).unwrap();
 
@@ -2016,6 +2166,9 @@ mod tests {
             clarity_version: &ClarityVersion::Clarity3,
             epoch,
             invoke_ctx: &invoke_ctx,
+            trait_implementations: &HashMap::new(),
+            warnings: &RefCell::new(Vec::new()),
+            current_function: None,
         };
         let (_, cost_tree) = build_cost_analysis_tree(expr, &user_args, &ctx, &mut env, 0).unwrap();
 
@@ -2054,6 +2207,9 @@ mod tests {
             clarity_version: &ClarityVersion::Clarity3,
             epoch,
             invoke_ctx: &invoke_ctx,
+            trait_implementations: &HashMap::new(),
+            warnings: &RefCell::new(Vec::new()),
+            current_function: None,
         };
         let (_, cost_tree) = build_cost_analysis_tree(expr, &user_args, &ctx, &mut env, 0).unwrap();
 
@@ -2317,8 +2473,9 @@ mod tests {
         let contract_context =
             ContractContext::new(QualifiedContractIdentifier::transient(), *clarity_version);
         let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
-        let costs = static_cost_from_ast(&ast, clarity_version, epoch, &mut env, &invoke_ctx)?;
-        Ok(costs
+        let result = static_cost_from_ast(&ast, clarity_version, epoch, &mut env, &invoke_ctx)?;
+        Ok(result
+            .costs
             .into_iter()
             .map(|(name, (cost, _trait_count))| (name, cost))
             .collect())

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -685,10 +685,7 @@ fn get_contract_call_target_cost(
                     kind: CostWarningKind::ContractCallCostError {
                         contract_id: contract_id.to_string(),
                         called_function: function_name.to_string(),
-                        error: format!(
-                            "function '{}' not found in contract cost map",
-                            function_name
-                        ),
+                        error: format!("function '{function_name}' not found in contract cost map"),
                     },
                 });
             }

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -265,7 +265,6 @@ pub struct StaticCostResult {
 
 /// Static execution cost for functions within Environment.
 /// Returns the static cost for each function in the contract.
-/// {some-function-name: (StaticCost, Some({some-function-name: (1,1)}))}
 pub fn static_cost(
     env: &mut ExecutionState,
     invoke_ctx: &InvocationContext,
@@ -753,13 +752,11 @@ fn resolve_trait_call_cost(
 
     let mut envelope: Option<StaticCost> = None;
     for impl_contract in implementations {
-        let result = match static_cost(env, ctx.invoke_ctx, impl_contract) {
-            Ok(r) => r,
-            Err(_) => continue,
+        let Ok(result) = static_cost(env, ctx.invoke_ctx, impl_contract) else {
+            continue;
         };
-        let (cost, _) = match result.costs.get(function_name.as_str()) {
-            Some(entry) => entry,
-            None => continue,
+        let Some((cost, _)) = result.costs.get(function_name.as_str()) else {
+            continue;
         };
         envelope = Some(match envelope {
             None => cost.clone(),

--- a/components/clarity-static-cost/src/static_cost/error.rs
+++ b/components/clarity-static-cost/src/static_cost/error.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Debug, thiserror::Error)]
 pub enum StaticCostError {
     /// The contract's Clarity source could not be parsed into an AST.
@@ -23,4 +25,42 @@ pub enum StaticCostError {
     /// A cost function evaluation failed.
     #[error("cost calculation failed: {0}")]
     CostCalculation(String),
+}
+
+/// A warning emitted during static cost analysis when the analysis is
+/// incomplete — e.g. a trait-based `contract-call?` whose target cost
+/// cannot be resolved statically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CostWarning {
+    pub function_name: String,
+    pub kind: CostWarningKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CostWarningKind {
+    /// A `contract-call?` targets a trait parameter whose implementing
+    /// contract is unknown, so the cost of the called function is not
+    /// included in the estimate.
+    UnresolvedTraitCall {
+        /// The variable name used as the contract target (e.g. `pool-trait`).
+        target_variable: String,
+        /// The function being called on the trait (e.g. `get-active-bin-id`).
+        called_function: String,
+    },
+}
+
+impl fmt::Display for CostWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            CostWarningKind::UnresolvedTraitCall {
+                target_variable,
+                called_function,
+            } => write!(
+                f,
+                "{}: contract-call? to trait parameter `{}` function `{}` \
+                 has unresolved cost (target contract unknown)",
+                self.function_name, target_variable, called_function,
+            ),
+        }
+    }
 }

--- a/components/clarity-static-cost/src/static_cost/error.rs
+++ b/components/clarity-static-cost/src/static_cost/error.rs
@@ -47,6 +47,16 @@ pub enum CostWarningKind {
         /// The function being called on the trait (e.g. `get-active-bin-id`).
         called_function: String,
     },
+    /// A `contract-call?` targets a known contract, but computing its cost
+    /// failed (e.g. the contract source was not found or could not be parsed).
+    ContractCallCostError {
+        /// The fully-qualified contract identifier that was called.
+        contract_id: String,
+        /// The function being called.
+        called_function: String,
+        /// Description of the error.
+        error: String,
+    },
 }
 
 impl fmt::Display for CostWarning {
@@ -60,6 +70,15 @@ impl fmt::Display for CostWarning {
                 "{}: contract-call? to trait parameter `{}` function `{}` \
                  has unresolved cost (target contract unknown)",
                 self.function_name, target_variable, called_function,
+            ),
+            CostWarningKind::ContractCallCostError {
+                contract_id,
+                called_function,
+                error,
+            } => write!(
+                f,
+                "{}: contract-call? to `{}` function `{}` failed: {}",
+                self.function_name, contract_id, called_function, error,
             ),
         }
     }

--- a/components/clarity-static-cost/src/static_cost/error.rs
+++ b/components/clarity-static-cost/src/static_cost/error.rs
@@ -42,7 +42,7 @@ pub enum CostWarningKind {
     /// contract is unknown, so the cost of the called function is not
     /// included in the estimate.
     UnresolvedTraitCall {
-        /// The variable name used as the contract target (e.g. `pool-trait`).
+        /// The parameter variable name used as the contract target (e.g. `token-contract`).
         target_variable: String,
         /// The function being called on the trait (e.g. `get-active-bin-id`).
         called_function: String,

--- a/components/clarity-static-cost/src/static_cost/error.rs
+++ b/components/clarity-static-cost/src/static_cost/error.rs
@@ -42,7 +42,7 @@ pub enum CostWarningKind {
     /// contract is unknown, so the cost of the called function is not
     /// included in the estimate.
     UnresolvedTraitCall {
-        /// The parameter variable name used as the contract target (e.g. `token-contract`).
+        /// The parameter variable name used as the contract target (e.g. `pool`).
         target_variable: String,
         /// The function being called on the trait (e.g. `get-active-bin-id`).
         called_function: String,

--- a/components/clarity-static-cost/src/static_cost/mod.rs
+++ b/components/clarity-static-cost/src/static_cost/mod.rs
@@ -14,9 +14,9 @@ use clarity::vm::representations::ClarityName;
 use clarity::vm::{ClarityVersion, Value};
 use clarity_types::representations::SymbolicExpression;
 pub use cost_analysis::{
-    build_cost_analysis_tree, static_cost, static_cost_from_ast, static_cost_from_ast_with_options,
-    static_cost_from_ast_with_source, static_cost_tree_from_ast, AnalysisContext, CostAnalysisNode,
-    CostExprNode, StaticCost, StaticCostResult, SummingExecutionCost, UserArgumentsContext,
+    build_cost_analysis_tree, static_cost, static_cost_from_ast, static_cost_tree_from_ast,
+    AnalysisContext, CostAnalysisNode, CostExprNode, StaticCost, StaticCostConfig,
+    StaticCostResult, SummingExecutionCost, UserArgumentsContext,
 };
 pub use cost_functions::ClarityCostFunctionExt;
 pub use error::{CostWarning, CostWarningKind, StaticCostError};

--- a/components/clarity-static-cost/src/static_cost/mod.rs
+++ b/components/clarity-static-cost/src/static_cost/mod.rs
@@ -14,12 +14,12 @@ use clarity::vm::representations::ClarityName;
 use clarity::vm::{ClarityVersion, Value};
 use clarity_types::representations::SymbolicExpression;
 pub use cost_analysis::{
-    build_cost_analysis_tree, static_cost, static_cost_from_ast, static_cost_from_ast_with_source,
-    static_cost_tree_from_ast, AnalysisContext, CostAnalysisNode, CostExprNode, StaticCost,
-    SummingExecutionCost, UserArgumentsContext,
+    build_cost_analysis_tree, static_cost, static_cost_from_ast, static_cost_from_ast_with_options,
+    static_cost_from_ast_with_source, static_cost_tree_from_ast, AnalysisContext, CostAnalysisNode,
+    CostExprNode, StaticCost, StaticCostResult, SummingExecutionCost, UserArgumentsContext,
 };
 pub use cost_functions::ClarityCostFunctionExt;
-pub use error::StaticCostError;
+pub use error::{CostWarning, CostWarningKind, StaticCostError};
 pub use special_costs::get_cost_for_special_function;
 use stacks_common::types::StacksEpochId;
 pub use trait_counter::{

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -13,7 +13,7 @@ use clarity::vm::{ast, ClarityVersion, ContractName};
 use clarity_static_cost::static_cost::{
     build_cost_analysis_tree, static_cost_from_ast, static_cost_from_ast_with_options,
     static_cost_from_ast_with_source, static_cost_tree_from_ast, AnalysisContext, CostAnalysisNode,
-    CostExprNode, UserArgumentsContext,
+    CostExprNode, CostWarning, CostWarningKind, UserArgumentsContext,
 };
 use indoc::indoc;
 #[cfg(test)]
@@ -1738,8 +1738,6 @@ fn test_empty_list_in_expression_does_not_panic() {
     assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
 }
 
-use clarity_static_cost::static_cost::{CostWarning, CostWarningKind};
-
 /// Test that a contract with trait-based contract-call? whose target cannot be
 /// resolved emits an UnresolvedTraitCall warning.
 #[test]
@@ -1896,8 +1894,10 @@ fn test_trait_resolution_with_implementations() {
     "#};
 
     let deployer = StandardPrincipalData::transient();
-    let pool_id = QualifiedContractIdentifier::new(deployer.clone(), "pool".into());
-    let caller_id = QualifiedContractIdentifier::new(deployer, "caller".into());
+    let pool_id =
+        QualifiedContractIdentifier::new(deployer.clone(), ContractName::from_literal("pool"));
+    let caller_id =
+        QualifiedContractIdentifier::new(deployer, ContractName::from_literal("caller"));
 
     // Set up environment with deployed contracts
     let mut memory_store = MemoryBackingStore::new();

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -534,7 +534,7 @@ fn run_cost_analysis_test(
                 &clarity_version,
                 epoch,
                 Some(&StaticCostConfig {
-                    contract_source: src.to_string(),
+                    contract_size: src.len() as u64,
                     trait_implementations: HashMap::new(),
                 }),
                 env,
@@ -1325,7 +1325,7 @@ fn test_contract_call_includes_callee_cost() {
             &clarity_version,
             epoch,
             Some(&StaticCostConfig {
-                contract_source: caller_src.to_string(),
+                contract_size: caller_src.len() as u64,
                 trait_implementations: HashMap::new(),
             }),
             &mut env,
@@ -2000,7 +2000,7 @@ fn test_trait_resolution_with_implementations() {
             &clarity_version,
             epoch,
             Some(&StaticCostConfig {
-                contract_source: caller_src.to_string(),
+                contract_size: caller_src.len() as u64,
                 trait_implementations: HashMap::new(),
             }),
             &mut env,
@@ -2034,7 +2034,7 @@ fn test_trait_resolution_with_implementations() {
             &clarity_version,
             epoch,
             Some(&StaticCostConfig {
-                contract_source: caller_src.to_string(),
+                contract_size: caller_src.len() as u64,
                 trait_implementations: trait_impls.clone(),
             }),
             &mut env,
@@ -2191,7 +2191,7 @@ fn test_trait_resolution_skips_failing_implementation() {
             &clarity_version,
             epoch,
             Some(&StaticCostConfig {
-                contract_source: caller_src.to_string(),
+                contract_size: caller_src.len() as u64,
                 trait_implementations: trait_impls,
             }),
             &mut env,

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -2078,3 +2078,149 @@ fn test_trait_resolution_with_implementations() {
         cost_no_impls.max.read_count
     );
 }
+
+/// Test that when trait implementations include a contract that is NOT deployed
+/// (i.e. `static_cost()` fails for it), the failing implementation is skipped
+/// and the valid one is still used. No unresolved-trait warning should be emitted
+/// because at least one implementation resolved successfully.
+#[test]
+fn test_trait_resolution_skips_failing_implementation() {
+    let epoch = StacksEpochId::Epoch33;
+    let clarity_version = ClarityVersion::Clarity4;
+
+    let pool_src = indoc! {r#"
+        (define-data-var balance uint u1000)
+
+        (define-public (get-balance (who principal))
+            (ok (var-get balance))
+        )
+    "#};
+
+    let caller_src = indoc! {r#"
+        (define-trait pool-trait (
+            (get-balance (principal) (response uint uint))
+        ))
+
+        (define-public (check-balance (pool <pool-trait>) (who principal))
+            (contract-call? pool get-balance who)
+        )
+    "#};
+
+    let deployer = StandardPrincipalData::transient();
+    let pool_id =
+        QualifiedContractIdentifier::new(deployer.clone(), ContractName::from_literal("pool"));
+    let caller_id =
+        QualifiedContractIdentifier::new(deployer.clone(), ContractName::from_literal("caller"));
+    // A contract that is NOT deployed
+    let ghost_id = QualifiedContractIdentifier::new(deployer, ContractName::from_literal("ghost"));
+
+    let mut memory_store = MemoryBackingStore::new();
+    let mut db = memory_store.as_clarity_db();
+    db.begin();
+    db.set_clarity_epoch_version(epoch).unwrap();
+    db.commit().unwrap();
+    db.begin();
+    db.set_tenure_height(1).unwrap();
+    db.commit().unwrap();
+    db.begin();
+    db.setup_block_metadata(Some(1)).unwrap();
+    db.commit().unwrap();
+
+    let costs_contract_id = boot_code_id("costs", false);
+    let costs_4_contract_id = boot_code_id("costs-4", false);
+    let cost_voting_contract_id = boot_code_id("cost-voting", false);
+    {
+        let mut temp_env = OwnedEnvironment::new(db, epoch);
+        temp_env
+            .initialize_versioned_contract(
+                costs_contract_id,
+                clarity_version,
+                BOOT_CODE_COSTS,
+                None,
+            )
+            .expect("Failed to initialize costs contract");
+        temp_env
+            .initialize_versioned_contract(
+                costs_4_contract_id,
+                clarity_version,
+                BOOT_CODE_COSTS_4,
+                None,
+            )
+            .expect("Failed to initialize costs-4 contract");
+        temp_env
+            .initialize_versioned_contract(
+                cost_voting_contract_id,
+                clarity_version,
+                &BOOT_CODE_COST_VOTING_TESTNET.to_string(),
+                None,
+            )
+            .expect("Failed to initialize cost-voting contract");
+        let (extracted_db, _) = temp_env.destruct().unwrap();
+        db = extracted_db;
+    }
+
+    let mut owned_env = OwnedEnvironment::new_max_limit(db, epoch, false);
+
+    // Deploy only pool and caller — ghost is NOT deployed
+    owned_env
+        .initialize_versioned_contract(pool_id.clone(), clarity_version, pool_src, None)
+        .expect("Failed to deploy pool contract");
+    owned_env
+        .initialize_versioned_contract(caller_id.clone(), clarity_version, caller_src, None)
+        .expect("Failed to deploy caller contract");
+
+    let caller_ast = ast::build_ast(&caller_id, caller_src, &mut (), clarity_version, epoch)
+        .expect("Failed to build caller AST");
+
+    // Provide two implementations: one real (pool) and one missing (ghost)
+    let pool_trait_id = TraitIdentifier::new(
+        caller_id.issuer.clone(),
+        caller_id.name.clone(),
+        ClarityName::from_literal("pool-trait"),
+    );
+    let mut trait_impls: HashMap<TraitIdentifier, Vec<QualifiedContractIdentifier>> =
+        HashMap::new();
+    trait_impls.insert(pool_trait_id, vec![pool_id.clone(), ghost_id]);
+
+    owned_env.begin();
+    let result = {
+        let contract_context = ContractContext::new(caller_id.clone(), clarity_version);
+        let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
+        static_cost_from_ast(
+            &caller_ast,
+            &clarity_version,
+            epoch,
+            Some(&StaticCostConfig {
+                contract_source: caller_src.to_string(),
+                trait_implementations: trait_impls,
+            }),
+            &mut env,
+            &invoke_ctx,
+        )
+        .expect("Analysis should succeed even with missing implementation")
+    };
+    let _ = owned_env.commit();
+
+    // The failing implementation is skipped; the valid one (pool) still resolves,
+    // so there should be no unresolved-trait warning.
+    let unresolved_warnings: Vec<_> = result
+        .warnings
+        .iter()
+        .filter(|w| matches!(w.kind, CostWarningKind::UnresolvedTraitCall { .. }))
+        .collect();
+    assert!(
+        unresolved_warnings.is_empty(),
+        "Expected no unresolved-trait warnings when at least one implementation succeeds, got: {:?}",
+        unresolved_warnings
+    );
+
+    // The resolved cost should include the pool contract's cost
+    let (cost, _) = result
+        .costs
+        .get("check-balance")
+        .expect("check-balance not found");
+    assert!(
+        cost.max.runtime > 0,
+        "Resolved cost should be non-zero when valid implementation exists"
+    );
+}

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -10,9 +11,9 @@ use clarity::vm::types::{
 };
 use clarity::vm::{ast, ClarityVersion, ContractName};
 use clarity_static_cost::static_cost::{
-    build_cost_analysis_tree, static_cost_from_ast, static_cost_from_ast_with_source,
-    static_cost_tree_from_ast, AnalysisContext, CostAnalysisNode, CostExprNode,
-    UserArgumentsContext,
+    build_cost_analysis_tree, static_cost_from_ast, static_cost_from_ast_with_options,
+    static_cost_from_ast_with_source, static_cost_tree_from_ast, AnalysisContext, CostAnalysisNode,
+    CostExprNode, UserArgumentsContext,
 };
 use indoc::indoc;
 #[cfg(test)]
@@ -76,12 +77,17 @@ fn test_build_cost_analysis_tree_function_definition() {
         clarity_version,
         |env, invoke_ctx| {
             let function_defs = std::collections::HashMap::new();
+            let trait_impls = std::collections::HashMap::new();
+            let warnings = RefCell::new(Vec::new());
             let ctx = AnalysisContext {
                 cost_map: &cost_map,
                 function_defs: &function_defs,
                 clarity_version: &clarity_version,
                 epoch,
                 invoke_ctx,
+                trait_implementations: &trait_impls,
+                warnings: &warnings,
+                current_function: None,
             };
             build_cost_analysis_tree(expr, &user_args, &ctx, env, 0)
         },
@@ -120,15 +126,15 @@ fn test_let_cost() {
     let db = memory_store.as_clarity_db();
     let mut owned_env = OwnedEnvironment::new(db, epoch);
 
-    let function_map = with_cost_analysis_environment(
+    let result = with_cost_analysis_environment(
         &mut owned_env,
         &contract_id,
         clarity_version,
         |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
     )
     .unwrap();
-    let (let_cost, _) = function_map.get("let").unwrap();
-    let (let2_cost, _) = function_map.get("let2").unwrap();
+    let (let_cost, _) = result.costs.get("let").unwrap();
+    let (let2_cost, _) = result.costs.get("let2").unwrap();
     assert_ne!(let2_cost.min.runtime, let_cost.min.runtime);
 }
 
@@ -163,7 +169,7 @@ fn test_dependent_function_calls() {
     let db = memory_store.as_clarity_db();
     let mut owned_env = OwnedEnvironment::new(db, epoch);
 
-    let function_map = with_cost_analysis_environment(
+    let result = with_cost_analysis_environment(
         &mut owned_env,
         &contract_id,
         clarity_version,
@@ -171,8 +177,8 @@ fn test_dependent_function_calls() {
     )
     .unwrap();
 
-    let (add_one_cost, _) = function_map.get("add-one").unwrap();
-    let (somefunc_cost, _) = function_map.get("somefunc").unwrap();
+    let (add_one_cost, _) = result.costs.get("add-one").unwrap();
+    let (somefunc_cost, _) = result.costs.get("somefunc").unwrap();
 
     assert!(add_one_cost.min.runtime >= somefunc_cost.min.runtime);
     assert!(add_one_cost.max.runtime >= somefunc_cost.max.runtime);
@@ -201,11 +207,20 @@ fn test_get_trait_count_direct() {
     let db = memory_store.as_clarity_db();
     let mut owned_env = OwnedEnvironment::new(db, epoch);
 
-    let costs = with_cost_analysis_environment(
+    let (costs, _warnings) = with_cost_analysis_environment(
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_tree_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_tree_from_ast(
+                &ast,
+                &clarity_version,
+                epoch,
+                &HashMap::new(),
+                env,
+                invoke_ctx,
+            )
+        },
     )
     .unwrap();
 
@@ -247,7 +262,7 @@ fn test_trait_counting() {
     let mut memory_store = MemoryBackingStore::new();
     let db = memory_store.as_clarity_db();
     let mut owned_env = OwnedEnvironment::new(db, epoch);
-    let static_cost = with_cost_analysis_environment(
+    let result = with_cost_analysis_environment(
         &mut owned_env,
         &contract_id,
         ClarityVersion::Clarity3,
@@ -257,12 +272,12 @@ fn test_trait_counting() {
     )
     .unwrap();
 
-    let send_trait_count_map = static_cost.get("send").unwrap().1.clone().unwrap();
+    let send_trait_count_map = result.costs.get("send").unwrap().1.clone().unwrap();
     let send_trait_count = send_trait_count_map.get("send").unwrap();
     assert_eq!(send_trait_count.0, 1);
     assert_eq!(send_trait_count.1, 1);
 
-    let something_trait_count_map = static_cost.get("something").unwrap().1.clone().unwrap();
+    let something_trait_count_map = result.costs.get("something").unwrap().1.clone().unwrap();
     let something_trait_count = something_trait_count_map.get("something").unwrap();
     assert_eq!(something_trait_count.0, 0);
     assert_eq!(something_trait_count.1, 10);
@@ -365,7 +380,7 @@ fn test_pox_4_costs() {
     let mut memory_store = MemoryBackingStore::new();
     let db = memory_store.as_clarity_db();
     let mut owned_env = OwnedEnvironment::new(db, epoch);
-    let cost_map = with_cost_analysis_environment(
+    let result = with_cost_analysis_environment(
         &mut owned_env,
         &contract_id,
         clarity_version,
@@ -386,12 +401,13 @@ fn test_pox_4_costs() {
 
     for function_name in key_functions {
         assert!(
-            cost_map.contains_key(function_name),
+            result.costs.contains_key(function_name),
             "Expected function '{}' to be present in cost map",
             function_name
         );
 
-        let (_cost, _trait_count) = cost_map
+        let (_cost, _trait_count) = result
+            .costs
             .get(function_name)
             .unwrap_or_else(|| panic!("Failed to get cost for function '{}'", function_name));
     }
@@ -511,6 +527,7 @@ fn run_cost_analysis_test(
     .expect("Failed to get static cost analysis");
 
     let (static_cost, _) = static_cost_map
+        .costs
         .get(function_name)
         .unwrap_or_else(|| panic!("Function '{}' not found in static cost map", function_name));
 
@@ -519,11 +536,20 @@ fn run_cost_analysis_test(
     println!("dynamic cost: {:?}", dynamic_cost);
 
     // Get the cost tree to debug and print it with values
-    let cost_trees_with_traits = with_cost_analysis_environment(
+    let (cost_trees_with_traits, _warnings) = with_cost_analysis_environment(
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_tree_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_tree_from_ast(
+                &ast,
+                &clarity_version,
+                epoch,
+                &HashMap::new(),
+                env,
+                invoke_ctx,
+            )
+        },
     )
     .expect("Failed to get static cost tree");
     if let Some((cost_tree, _)) = cost_trees_with_traits.get(function_name) {
@@ -1289,6 +1315,7 @@ fn test_contract_call_includes_callee_cost() {
     let _ = owned_env.commit();
 
     let (static_cost, _) = static_cost_map
+        .costs
         .get("call-counter")
         .expect("call-counter not found in static cost map");
 
@@ -1378,6 +1405,7 @@ fn test_trait_counts_simplified() {
     .expect("Failed to get static cost analysis");
 
     let trait_count = static_cost_map
+        .costs
         .values()
         .next()
         .and_then(|(_, trait_count)| trait_count.clone());
@@ -1449,6 +1477,7 @@ fn test_trait_counts_let_bound_variable() {
     .expect("Failed to get static cost analysis");
 
     let trait_count = static_cost_map
+        .costs
         .values()
         .next()
         .and_then(|(_, trait_count)| trait_count.clone());
@@ -1648,6 +1677,7 @@ fn test_trait_counts_for_gl_contract() {
     .expect("Failed to get static cost analysis");
 
     let trait_count = static_cost_map
+        .costs
         .values()
         .next()
         .and_then(|(_, trait_count)| trait_count.clone());
@@ -1706,4 +1736,301 @@ fn test_empty_list_in_expression_does_not_panic() {
 
     // Should complete without panicking
     assert!(result.is_ok(), "Expected Ok, got: {:?}", result.err());
+}
+
+use clarity_static_cost::static_cost::{CostWarning, CostWarningKind};
+
+/// Test that a contract with trait-based contract-call? whose target cannot be
+/// resolved emits an UnresolvedTraitCall warning.
+#[test]
+fn test_unresolved_trait_call_emits_warning() {
+    let src = indoc! {r#"
+        (define-trait pool-trait (
+            (get-balance (principal) (response uint uint))
+        ))
+
+        (define-public (check-balance (pool <pool-trait>) (who principal))
+            (contract-call? pool get-balance who)
+        )
+    "#};
+
+    let contract_id = QualifiedContractIdentifier::transient();
+    let epoch = StacksEpochId::Epoch33;
+    let clarity_version = ClarityVersion::Clarity4;
+    let ast =
+        clarity::vm::ast::build_ast(&contract_id, src, &mut (), clarity_version, epoch).unwrap();
+
+    let mut memory_store = MemoryBackingStore::new();
+    let db = memory_store.as_clarity_db();
+    let mut owned_env = OwnedEnvironment::new(db, epoch);
+
+    let result = with_cost_analysis_environment(
+        &mut owned_env,
+        &contract_id,
+        clarity_version,
+        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+    )
+    .expect("static cost analysis should succeed");
+
+    // Should have at least one warning about the unresolved trait call
+    assert!(
+        !result.warnings.is_empty(),
+        "Expected warnings for unresolved trait-based contract-call?, got none"
+    );
+
+    let warning = &result.warnings[0];
+    assert_eq!(warning.function_name, "check-balance");
+    assert_eq!(
+        warning.kind,
+        CostWarningKind::UnresolvedTraitCall {
+            target_variable: "pool".to_string(),
+            called_function: "get-balance".to_string(),
+        }
+    );
+}
+
+/// Test that a fold over a function containing an unresolved trait call
+/// emits a warning. This mimics the DLMM router pattern.
+#[test]
+fn test_fold_with_trait_call_emits_warning() {
+    let src = indoc! {r#"
+        (define-trait pool-trait (
+            (swap (uint) (response {in: uint, out: uint} uint))
+        ))
+
+        (define-private (swap-step
+            (bin-id int)
+            (acc (response {pool: <pool-trait>, amount: uint, total: uint} uint))
+        )
+            (let (
+                (data (unwrap! acc (err u1)))
+                (pool (get pool data))
+                (amount (get amount data))
+            )
+                (if (> amount u0)
+                    (let ((result (try! (contract-call? pool swap amount))))
+                        (ok {pool: pool, amount: (- amount (get in result)), total: (+ (get total data) (get out result))}))
+                    (ok data))
+            )
+        )
+
+        (define-constant BIN_RANGE (list 0 1 2 3 4 5 6 7 8 9))
+
+        (define-public (swap-multi
+            (pool <pool-trait>)
+            (amount uint)
+        )
+            (let (
+                (result (try! (fold swap-step BIN_RANGE (ok {pool: pool, amount: amount, total: u0}))))
+            )
+                (ok (get total result))
+            )
+        )
+    "#};
+
+    let contract_id = QualifiedContractIdentifier::transient();
+    let epoch = StacksEpochId::Epoch33;
+    let clarity_version = ClarityVersion::Clarity4;
+    let ast =
+        clarity::vm::ast::build_ast(&contract_id, src, &mut (), clarity_version, epoch).unwrap();
+
+    let mut memory_store = MemoryBackingStore::new();
+    let db = memory_store.as_clarity_db();
+    let mut owned_env = OwnedEnvironment::new(db, epoch);
+
+    let result = with_cost_analysis_environment(
+        &mut owned_env,
+        &contract_id,
+        clarity_version,
+        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+    )
+    .expect("static cost analysis should succeed");
+
+    // The swap-step function has a trait-based contract-call? that can't be resolved
+    let swap_step_warnings: Vec<&CostWarning> = result
+        .warnings
+        .iter()
+        .filter(|w| w.function_name == "swap-step")
+        .collect();
+
+    assert!(
+        !swap_step_warnings.is_empty(),
+        "Expected warnings for swap-step's unresolved trait call, got none. All warnings: {:?}",
+        result.warnings
+    );
+
+    assert_eq!(
+        swap_step_warnings[0].kind,
+        CostWarningKind::UnresolvedTraitCall {
+            target_variable: "pool".to_string(),
+            called_function: "swap".to_string(),
+        }
+    );
+}
+
+/// Test that providing trait implementations resolves the cost and produces
+/// no warnings for the resolved calls.
+#[test]
+fn test_trait_resolution_with_implementations() {
+    let epoch = StacksEpochId::Epoch33;
+    let clarity_version = ClarityVersion::Clarity4;
+
+    // The "pool" contract that implements the trait
+    let pool_src = indoc! {r#"
+        (define-data-var balance uint u1000)
+
+        (define-public (get-balance (who principal))
+            (ok (var-get balance))
+        )
+    "#};
+
+    // The contract that calls via a trait
+    let caller_src = indoc! {r#"
+        (define-trait pool-trait (
+            (get-balance (principal) (response uint uint))
+        ))
+
+        (define-public (check-balance (pool <pool-trait>) (who principal))
+            (contract-call? pool get-balance who)
+        )
+    "#};
+
+    let deployer = StandardPrincipalData::transient();
+    let pool_id = QualifiedContractIdentifier::new(deployer.clone(), "pool".into());
+    let caller_id = QualifiedContractIdentifier::new(deployer, "caller".into());
+
+    // Set up environment with deployed contracts
+    let mut memory_store = MemoryBackingStore::new();
+    let mut db = memory_store.as_clarity_db();
+    db.begin();
+    db.set_clarity_epoch_version(epoch).unwrap();
+    db.commit().unwrap();
+    db.begin();
+    db.set_tenure_height(1).unwrap();
+    db.commit().unwrap();
+    db.begin();
+    db.setup_block_metadata(Some(1)).unwrap();
+    db.commit().unwrap();
+
+    let costs_contract_id = boot_code_id("costs", false);
+    let costs_4_contract_id = boot_code_id("costs-4", false);
+    let cost_voting_contract_id = boot_code_id("cost-voting", false);
+    {
+        let mut temp_env = OwnedEnvironment::new(db, epoch);
+        temp_env
+            .initialize_versioned_contract(
+                costs_contract_id,
+                clarity_version,
+                BOOT_CODE_COSTS,
+                None,
+            )
+            .expect("Failed to initialize costs contract");
+        temp_env
+            .initialize_versioned_contract(
+                costs_4_contract_id,
+                clarity_version,
+                BOOT_CODE_COSTS_4,
+                None,
+            )
+            .expect("Failed to initialize costs-4 contract");
+        temp_env
+            .initialize_versioned_contract(
+                cost_voting_contract_id,
+                clarity_version,
+                &BOOT_CODE_COST_VOTING_TESTNET.to_string(),
+                None,
+            )
+            .expect("Failed to initialize cost-voting contract");
+        let (extracted_db, _) = temp_env.destruct().unwrap();
+        db = extracted_db;
+    }
+
+    let mut owned_env = OwnedEnvironment::new_max_limit(db, epoch, false);
+
+    // Deploy pool contract first, then caller
+    owned_env
+        .initialize_versioned_contract(pool_id.clone(), clarity_version, pool_src, None)
+        .expect("Failed to deploy pool contract");
+    owned_env
+        .initialize_versioned_contract(caller_id.clone(), clarity_version, caller_src, None)
+        .expect("Failed to deploy caller contract");
+
+    // First: analyze WITHOUT trait implementations — should get warnings
+    let caller_ast = ast::build_ast(&caller_id, caller_src, &mut (), clarity_version, epoch)
+        .expect("Failed to build caller AST");
+    owned_env.begin();
+    let result_no_impls = {
+        let contract_context = ContractContext::new(caller_id.clone(), clarity_version);
+        let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
+        static_cost_from_ast_with_source(
+            &caller_ast,
+            &clarity_version,
+            epoch,
+            Some(caller_src),
+            &mut env,
+            &invoke_ctx,
+        )
+        .expect("Failed to get static cost analysis")
+    };
+    let _ = owned_env.commit();
+
+    assert!(
+        !result_no_impls.warnings.is_empty(),
+        "Expected warnings without trait implementations"
+    );
+
+    // Second: analyze WITH trait implementations — should resolve and no warnings
+    let mut trait_impls: HashMap<String, Vec<QualifiedContractIdentifier>> = HashMap::new();
+    trait_impls.insert("pool-trait".to_string(), vec![pool_id.clone()]);
+
+    owned_env.begin();
+    let result_with_impls = {
+        let contract_context = ContractContext::new(caller_id.clone(), clarity_version);
+        let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
+        static_cost_from_ast_with_options(
+            &caller_ast,
+            &clarity_version,
+            epoch,
+            Some(caller_src),
+            &trait_impls,
+            &mut env,
+            &invoke_ctx,
+        )
+        .expect("Failed to get static cost analysis with trait implementations")
+    };
+    let _ = owned_env.commit();
+
+    assert!(
+        result_with_impls.warnings.is_empty(),
+        "Expected no warnings with trait implementations, got: {:?}",
+        result_with_impls.warnings
+    );
+
+    // The resolved cost should be higher than the unresolved one (which had zero cost
+    // for the trait call)
+    let (cost_no_impls, _) = result_no_impls
+        .costs
+        .get("check-balance")
+        .expect("check-balance not found");
+    let (cost_with_impls, _) = result_with_impls
+        .costs
+        .get("check-balance")
+        .expect("check-balance not found");
+
+    println!("Cost without trait impl: {:?}", cost_no_impls);
+    println!("Cost with trait impl: {:?}", cost_with_impls);
+
+    assert!(
+        cost_with_impls.max.runtime > cost_no_impls.max.runtime,
+        "Resolved cost ({}) should be higher than unresolved cost ({}) due to callee function cost",
+        cost_with_impls.max.runtime,
+        cost_no_impls.max.runtime
+    );
+
+    assert!(
+        cost_with_impls.max.read_count > cost_no_impls.max.read_count,
+        "Resolved read_count ({}) should be higher than unresolved ({})",
+        cost_with_impls.max.read_count,
+        cost_no_impls.max.read_count
+    );
 }

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -5,16 +5,18 @@ use std::path::Path;
 use clarity::vm::contexts::{ContractContext, ExecutionState, InvocationContext, OwnedEnvironment};
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::database::MemoryBackingStore;
+use clarity::vm::representations::ClarityName;
 use clarity::vm::types::{
     ListData, ListTypeData, PrincipalData, QualifiedContractIdentifier, SequenceData,
     StandardPrincipalData, TypeSignature,
 };
 use clarity::vm::{ast, ClarityVersion, ContractName};
 use clarity_static_cost::static_cost::{
-    build_cost_analysis_tree, static_cost_from_ast, static_cost_from_ast_with_options,
-    static_cost_from_ast_with_source, static_cost_tree_from_ast, AnalysisContext, CostAnalysisNode,
-    CostExprNode, CostWarning, CostWarningKind, UserArgumentsContext,
+    build_cost_analysis_tree, static_cost_from_ast, static_cost_tree_from_ast, AnalysisContext,
+    CostAnalysisNode, CostExprNode, CostWarning, CostWarningKind, StaticCostConfig,
+    UserArgumentsContext,
 };
+use clarity_types::types::TraitIdentifier;
 use indoc::indoc;
 #[cfg(test)]
 use rstest::rstest;
@@ -130,7 +132,9 @@ fn test_let_cost() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .unwrap();
     let (let_cost, _) = result.costs.get("let").unwrap();
@@ -173,7 +177,9 @@ fn test_dependent_function_calls() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .unwrap();
 
@@ -267,7 +273,14 @@ fn test_trait_counting() {
         &contract_id,
         ClarityVersion::Clarity3,
         |env, invoke_ctx| {
-            static_cost_from_ast(&ast, &ClarityVersion::Clarity3, epoch, env, invoke_ctx)
+            static_cost_from_ast(
+                &ast,
+                &ClarityVersion::Clarity3,
+                epoch,
+                None,
+                env,
+                invoke_ctx,
+            )
         },
     )
     .unwrap();
@@ -384,7 +397,9 @@ fn test_pox_4_costs() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .unwrap();
 
@@ -514,11 +529,14 @@ fn run_cost_analysis_test(
         &contract_id,
         clarity_version,
         |env, invoke_ctx| {
-            static_cost_from_ast_with_source(
+            static_cost_from_ast(
                 &ast,
                 &clarity_version,
                 epoch,
-                Some(src),
+                Some(&StaticCostConfig {
+                    contract_source: src.to_string(),
+                    trait_implementations: HashMap::new(),
+                }),
                 env,
                 invoke_ctx,
             )
@@ -1302,11 +1320,14 @@ fn test_contract_call_includes_callee_cost() {
     let static_cost_map = {
         let contract_context = ContractContext::new(caller_id.clone(), clarity_version);
         let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
-        static_cost_from_ast_with_source(
+        static_cost_from_ast(
             &caller_ast,
             &clarity_version,
             epoch,
-            Some(caller_src),
+            Some(&StaticCostConfig {
+                contract_source: caller_src.to_string(),
+                trait_implementations: HashMap::new(),
+            }),
             &mut env,
             &invoke_ctx,
         )
@@ -1400,7 +1421,9 @@ fn test_trait_counts_simplified() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .expect("Failed to get static cost analysis");
 
@@ -1472,7 +1495,9 @@ fn test_trait_counts_let_bound_variable() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .expect("Failed to get static cost analysis");
 
@@ -1672,7 +1697,9 @@ fn test_trait_counts_for_gl_contract() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .expect("Failed to get static cost analysis");
 
@@ -1731,7 +1758,9 @@ fn test_empty_list_in_expression_does_not_panic() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     );
 
     // Should complete without panicking
@@ -1766,7 +1795,9 @@ fn test_unresolved_trait_call_emits_warning() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .expect("static cost analysis should succeed");
 
@@ -1840,7 +1871,9 @@ fn test_fold_with_trait_call_emits_warning() {
         &mut owned_env,
         &contract_id,
         clarity_version,
-        |env, invoke_ctx| static_cost_from_ast(&ast, &clarity_version, epoch, env, invoke_ctx),
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
     )
     .expect("static cost analysis should succeed");
 
@@ -1962,11 +1995,14 @@ fn test_trait_resolution_with_implementations() {
     let result_no_impls = {
         let contract_context = ContractContext::new(caller_id.clone(), clarity_version);
         let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
-        static_cost_from_ast_with_source(
+        static_cost_from_ast(
             &caller_ast,
             &clarity_version,
             epoch,
-            Some(caller_src),
+            Some(&StaticCostConfig {
+                contract_source: caller_src.to_string(),
+                trait_implementations: HashMap::new(),
+            }),
             &mut env,
             &invoke_ctx,
         )
@@ -1980,19 +2016,27 @@ fn test_trait_resolution_with_implementations() {
     );
 
     // Second: analyze WITH trait implementations — should resolve and no warnings
-    let mut trait_impls: HashMap<String, Vec<QualifiedContractIdentifier>> = HashMap::new();
-    trait_impls.insert("pool-trait".to_string(), vec![pool_id.clone()]);
+    let pool_trait_id = TraitIdentifier::new(
+        caller_id.issuer.clone(),
+        caller_id.name.clone(),
+        ClarityName::from_literal("pool-trait"),
+    );
+    let mut trait_impls: HashMap<TraitIdentifier, Vec<QualifiedContractIdentifier>> =
+        HashMap::new();
+    trait_impls.insert(pool_trait_id, vec![pool_id.clone()]);
 
     owned_env.begin();
     let result_with_impls = {
         let contract_context = ContractContext::new(caller_id.clone(), clarity_version);
         let (mut env, invoke_ctx) = owned_env.get_exec_environment(None, None, &contract_context);
-        static_cost_from_ast_with_options(
+        static_cost_from_ast(
             &caller_ast,
             &clarity_version,
             epoch,
-            Some(caller_src),
-            &trait_impls,
+            Some(&StaticCostConfig {
+                contract_source: caller_src.to_string(),
+                trait_implementations: trait_impls.clone(),
+            }),
             &mut env,
             &invoke_ctx,
         )

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776050130,
-        "narHash": "sha256-/f/6/1WOfBJaGMfqV3VxWD9lpFRbPpF+Cx4MO+0mGok=",
+        "lastModified": 1777605393,
+        "narHash": "sha256-Hjp0VOOHgHcTrX23iVvnfAudPcuCmfkfpQNFwv2v/ks=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3c27f4c92a7d977556dd2c10bb564d9c61b375e9",
+        "rev": "ff88db34cfa486fc4964a6991cab1678d82eee8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Static cost analysis now warns when trait-based contract-call? cannot be resolved, and supports automatic trait resolution when concrete implementations are provided within the clarinet project.

Still requires a mechanism for specifying external trait resolution (to be handled in a separate branch)