### PR TITLE
fix: reject unknown warning kinds in allow annotations

### DIFF
--- a/components/clarity-repl/src/analysis/annotation.rs
+++ b/components/clarity-repl/src/analysis/annotation.rs
@@ -40,9 +40,14 @@ impl std::str::FromStr for AnnotationKind {
                 let params: Vec<WarningKind> = value
                     .unwrap_or("")
                     .split(',')
+                    .map(str::trim)
                     .filter(|s| !s.is_empty())
-                    .filter_map(|s| s.trim().parse().ok())
-                    .collect();
+                    .map(|s| {
+                        s.parse().map_err(|_| {
+                            format!("unknown warning kind '{s}' in 'allow' annotation")
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
                 if params.is_empty() {
                     Err("missing value for 'allow' annotation".to_string())
                 } else {
@@ -178,6 +183,20 @@ mod tests {
             }
             _ => panic!("failed to parse multiple allow annotation correctly"),
         };
+    }
+
+    #[test]
+    fn parse_allow_rejects_unknown_warning_kind() {
+        // If the user includes an unknown warning kind alongside a valid one,
+        // parsing should fail rather than silently dropping the unknown name and
+        // accepting only the recognized parts. Today the `filter_map(.. .ok())`
+        // in the `allow` arm hides the typo.
+        let result = "#[allow(unused_const, not_a_real_warning)]".parse::<AnnotationKind>();
+        assert!(
+            result.is_err(),
+            "expected Err for unknown warning kind, got {result:?} \
+             (the unknown kind 'not_a_real_warning' was silently dropped)"
+        );
     }
 
     #[test]

--- a/components/clarity-repl/src/analysis/annotation.rs
+++ b/components/clarity-repl/src/analysis/annotation.rs
@@ -40,9 +40,9 @@ impl std::str::FromStr for AnnotationKind {
                 let params: Vec<WarningKind> = value
                     .unwrap_or("")
                     .split(',')
-                    .map(str::trim)
                     .filter(|s| !s.is_empty())
                     .map(|s| {
+                        let s = s.trim();
                         s.parse().map_err(|_| {
                             format!("unknown warning kind '{s}' in 'allow' annotation")
                         })
@@ -189,8 +189,7 @@ mod tests {
     fn parse_allow_rejects_unknown_warning_kind() {
         // If the user includes an unknown warning kind alongside a valid one,
         // parsing should fail rather than silently dropping the unknown name and
-        // accepting only the recognized parts. Today the `filter_map(.. .ok())`
-        // in the `allow` arm hides the typo.
+        // accepting only the recognized parts.
         let result = "#[allow(unused_const, not_a_real_warning)]".parse::<AnnotationKind>();
         assert!(
             result.is_err(),

--- a/components/clarity-repl/src/analysis/annotation.rs
+++ b/components/clarity-repl/src/analysis/annotation.rs
@@ -42,8 +42,7 @@ impl std::str::FromStr for AnnotationKind {
                     .split(',')
                     .filter(|s| !s.is_empty())
                     .map(|s| {
-                        let s = s.trim();
-                        s.parse().map_err(|_| {
+                        s.trim().parse().map_err(|_| {
                             format!("unknown warning kind '{s}' in 'allow' annotation")
                         })
                     })


### PR DESCRIPTION
The `allow` arm in `AnnotationKind::from_str` used `filter_map(.. .ok())`, which silently dropped unknown warning kinds rather than reporting them. `#[allow(unused_const, not_a_real_warning)]` would parse as an `Allow` with just `unused_const\`, hiding the typo from the user.

Switched to a fail-fast `map(|s| s.parse().map_err(...)).collect::<Result<_, _>>()?` shape, mirroring the existing `filter` arm. The error message surfaces the unknown name so the diagnostic emitted by `Interpreter::collect_annotations` reads `unknown warning kind 'not_a_real_warning' in 'allow' annotation`.

Test from the issue body added verbatim. All 12 `analysis::annotation` tests pass and all 6 `repl::interpreter::tests::annotation_*` diagnostic tests still pass (`annotation_allow_missing_value`, etc.) — the empty-allow path still hits the existing `if params.is_empty()` branch.

Followup to the carve-out in #2371's review.

closes #2372