### PR TITLE
fix(clarity-repl): reject unknown values in #[allow(...)] annotations (#2372)

### DIFF
--- a/components/clarity-repl/src/analysis/annotation.rs
+++ b/components/clarity-repl/src/analysis/annotation.rs
@@ -37,12 +37,21 @@ impl std::str::FromStr for AnnotationKind {
 
         match name {
             "allow" => {
+                // Surface unknown warning kinds instead of silently
+                // dropping them with `filter_map(.. .ok())`. A typo
+                // like `not_a_real_warning` should be a hard error so
+                // the developer notices, not a silent allow-list miss.
                 let params: Vec<WarningKind> = value
                     .unwrap_or("")
                     .split(',')
+                    .map(str::trim)
                     .filter(|s| !s.is_empty())
-                    .filter_map(|s| s.trim().parse().ok())
-                    .collect();
+                    .map(|s| {
+                        s.parse::<WarningKind>().map_err(|_| {
+                            format!("unknown warning kind '{s}' in 'allow' annotation")
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
                 if params.is_empty() {
                     Err("missing value for 'allow' annotation".to_string())
                 } else {
@@ -231,6 +240,39 @@ mod tests {
             Ok(AnnotationKind::FilterAll) => (),
             _ => panic!("failed to parse 'filter(*)' correctly"),
         };
+    }
+
+    #[test]
+    fn parse_allow_rejects_unknown_warning_kind() {
+        // Regression for stx-labs/clarinet#2372: if the user includes
+        // an unknown warning kind alongside a valid one, parsing must
+        // fail instead of silently dropping the unknown name and
+        // accepting only the recognized parts.
+        let result = "#[allow(unused_const, not_a_real_warning)]".parse::<AnnotationKind>();
+        match result {
+            Err(msg) => assert!(
+                msg.contains("not_a_real_warning"),
+                "error message should name the unknown kind, got: {msg:?}"
+            ),
+            Ok(_) => panic!(
+                "expected Err for unknown warning kind, got Ok (the unknown kind \
+                 'not_a_real_warning' was silently dropped)"
+            ),
+        }
+    }
+
+    #[test]
+    fn parse_allow_rejects_only_unknown_warning_kind() {
+        // Single unknown kind: must error with a useful message rather
+        // than failing the empty-vec branch with a generic complaint.
+        let result = "#[allow(not_a_real_warning)]".parse::<AnnotationKind>();
+        match result {
+            Err(msg) => assert!(
+                msg.contains("not_a_real_warning"),
+                "error message should name the unknown kind, got: {msg:?}"
+            ),
+            Ok(_) => panic!("expected Err for unknown warning kind, got Ok"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #2372.

## Summary
The `allow` arm of `AnnotationKind::from_str` parsed warning kinds with `filter_map(|s| s.trim().parse().ok())`, which **silently dropped** any token that failed to parse. A typo like `#[allow(unused_const, not_a_real_warning)]` quietly degraded to `#[allow(unused_const)]` and the developer never learned that the second name was unrecognized.

Switching to a fallible `map(...).collect::<Result<_, _>>()?` surfaces an actionable error message that includes the offending name:
```
unknown warning kind 'not_a_real_warning' in 'allow' annotation
```

## Tests
Added two regression cases in `analysis::annotation::tests`:
- [x] `parse_allow_rejects_unknown_warning_kind` — the exact snippet from the issue: mixed valid + invalid kinds errors out and the error message names the offending token.
- [x] `parse_allow_rejects_only_unknown_warning_kind` — guards the empty-vec branch from regressing into a generic \"missing value\" message when the only kind is bogus.
- [x] All 13 tests in `analysis::annotation::tests` pass (2 new + 11 pre-existing).
- [x] `cargo clippy -p clarity-repl --lib -- -D warnings` clean.

## Notes
- Behavior change is intentional: previously valid annotations are still accepted (existing `parse_allow_unchecked_data` and `parse_allow_multiple` tests still pass). Annotations that contained typos that *previously slipped through* will now error — matching the user-visible expectation that an `allow` annotation either disables a known warning or fails loudly.
- Related to PR #2371 review thread linked in the issue.