### PR TITLE
chore: release 3.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+# [3.17.0](https://github.com/stx-labs/clarinet/compare/v3.16.0...v3.17.0) (2026-04-28)
+
+##### New Features
+
+* **linter:**  Add `unnecessary_tuple` lint (#2356) (2d1e0445)
+
+##### Bug Fixes
+
+*  Strip `#[env(simnet)]` code out of on-chain deployments (#2374) (4d0d1082)
+*  Fix `#[env(simnet)]` annotation dimming (#2369) (b554c001)
+*  Bump `rustls-webpki` version to fix `cargo audit` (#2366) (531edf99)
+*  Exact static costs for deterministic inputs (#2322) (58af0cfa)
+*  Pin new rand and rustls-webpki versions (#2361) (10de774b)
+* **linter:**  Don't warn on private functions in `#[env(simnet)]` blocks (#2358) (6974492a)
+
+##### Performance Improvements
+
+* Remove unnecessary call to `Session::new()`, saving ~70ms per run (#2365) (d2f6e565)
+
+##### Build System / Dependencies
+
+* **clarity-vscode:**
+  - Remove unused dependencies from build (#2350) (87dd963a)
+  - Switch from Webpack to Rspack (#2349) (f75c9d23)
+
+##### Chores
+
+*  Remove regex parsing for annotations (#2371) (f8a81f35)
+*  Use rust-overlay for nix pkg pinning (#2359) (9aaf8d63)
+
+##### Continuous Integration
+
+*  Fix sdk version update (#2354) (64088b53)
+
+##### Refactors
+
+*  Remove `components/stacks-codec` (#2360) (a331befc), (#2370) (b05f5ef6)
+*  Pass borrowed types when possible (#2346) (dc2d6080)
+
 # [3.16.0](https://github.com/stx-labs/clarinet/compare/v3.15.1...v3.16.0) (2026-04-02)
 
 ##### New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "chrono",
  "clap",
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "clarinet-defaults"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "clarity",
 ]
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "bitcoin",
  "clarinet-defaults",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-static-cost"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "clarity",
  "clarity-types",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "observer"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "axum",
  "base58",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.16.0"
+version = "3.17.0"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["components/clarinet-cli"]
 opt-level = 3
 
 [workspace.package]
-version = "3.16.0"
+version = "3.17.0"
 
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",


### PR DESCRIPTION
# [3.17.0](https://github.com/stx-labs/clarinet/compare/v3.16.0...v3.17.0) (2026-04-28)

##### New Features

* **linter:**  Add `unnecessary_tuple` lint (#2356) (2d1e0445)

##### Bug Fixes

*  Strip `#[env(simnet)]` code out of on-chain deployments (#2374) (4d0d1082)
*  Fix `#[env(simnet)]` annotation dimming (#2369) (b554c001)
*  Bump `rustls-webpki` version to fix `cargo audit` (#2366) (531edf99)
*  Exact static costs for deterministic inputs (#2322) (58af0cfa)
*  Pin new rand and rustls-webpki versions (#2361) (10de774b)
* **linter:**  Don't warn on private functions in `#[env(simnet)]` blocks (#2358) (6974492a)

##### Performance Improvements

* Remove unnecessary call to `Session::new()`, saving ~70ms per run (#2365) (d2f6e565)

##### Build System / Dependencies

* **clarity-vscode:**
  - Remove unused dependencies from build (#2350) (87dd963a)
  - Switch from Webpack to Rspack (#2349) (f75c9d23)

##### Chores

*  Remove regex parsing for annotations (#2371) (f8a81f35)
*  Use rust-overlay for nix pkg pinning (#2359) (9aaf8d63)

##### Continuous Integration

*  Fix sdk version update (#2354) (64088b53)

##### Refactors

*  Remove `components/stacks-codec` (#2360) (a331befc), (#2370) (b05f5ef6)
*  Pass borrowed types when possible (#2346) (dc2d6080)
