### PR TITLE
deprecate stg.hiro.so in tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+      timezone: "Etc/UTC"

--- a/components/clarinet-cli/tests/console.rs
+++ b/components/clarinet-cli/tests/console.rs
@@ -44,7 +44,7 @@ fn can_init_console_with_mxs() {
         &[
             "--enable-remote-data",
             "--remote-data-api-url",
-            "https://api.testnet.stg.hiro.so",
+            "https://api.testnet.hiro.so",
             "--remote-data-initial-height",
             "74380",
         ],
@@ -63,7 +63,7 @@ fn can_init_console_with_mxs() {
         &[
             "--enable-remote-data",
             "--remote-data-api-url",
-            "https://api.stg.hiro.so",
+            "https://api.hiro.so",
             "--remote-data-initial-height",
             "907820",
         ],

--- a/components/clarinet-cli/tests/fixtures/mxs/Clarinet.toml
+++ b/components/clarinet-cli/tests/fixtures/mxs/Clarinet.toml
@@ -8,6 +8,6 @@ clarity_version = 3
 
 [repl.remote_data]
 enabled = true
-api_url = 'https://api.stg.hiro.so'
+api_url = 'https://api.hiro.so'
 initial_height = 522000
 use_mainnet_wallets = true

--- a/components/clarinet-sdk-wasm/src/test_wasm.rs
+++ b/components/clarinet-sdk-wasm/src/test_wasm.rs
@@ -73,7 +73,7 @@ async fn it_can_call_remote_data() {
     let mut sdk = SDK::new(js_noop, None);
     let options = RemoteDataSettings {
         enabled: true,
-        api_url: ApiUrl("https://api.testnet.stg.hiro.so".to_string()),
+        api_url: ApiUrl("https://api.testnet.hiro.so".to_string()),
         initial_height: Some(42000),
         use_mainnet_wallets: false,
     };

--- a/components/clarinet-sdk/node/tests/fixtures/ManifestWithMXS.toml
+++ b/components/clarinet-sdk/node/tests/fixtures/ManifestWithMXS.toml
@@ -17,6 +17,6 @@ epoch = 2.4
 
 [repl.remote_data]
 enabled = true
-api_url = 'https://api.stg.hiro.so'
+api_url = 'https://api.hiro.so'
 initial_height = 522000
 use_mainnet_wallets = true

--- a/components/clarinet-sdk/node/tests/remote-data.test.ts
+++ b/components/clarinet-sdk/node/tests/remote-data.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it, beforeEach, afterEach, afterAll, beforeAll } from
 // makes it simpler to handle wasm build
 import { getSDK, initSimnet } from "..";
 
-const api_url = "https://api.testnet.stg.hiro.so";
+const api_url = "https://api.testnet.hiro.so";
 const counterAddress = "STJCAB2T9TR2EJM7YS4DM2CGBBVTF7BV237Y8KNV.counter";
 const sender = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
 

--- a/components/clarity-repl/tests/empty_session_with_mxs.rs
+++ b/components/clarity-repl/tests/empty_session_with_mxs.rs
@@ -18,7 +18,7 @@ fn init_testnet_session(initial_heigth: u32) -> Session {
     settings.cache_location = Some(temp_dir.path().to_path_buf());
     settings.repl_settings.remote_data = RemoteDataSettings {
         enabled: true,
-        api_url: ApiUrl("https://api.testnet.stg.hiro.so".to_string()),
+        api_url: ApiUrl("https://api.testnet.hiro.so".to_string()),
         initial_height: Some(initial_heigth),
         use_mainnet_wallets: false,
     };
@@ -31,7 +31,7 @@ fn init_mainnet_session(initial_heigth: u32) -> Session {
     settings.cache_location = Some(temp_dir.path().to_path_buf());
     settings.repl_settings.remote_data = RemoteDataSettings {
         enabled: true,
-        api_url: ApiUrl("https://api.stg.hiro.so".to_string()),
+        api_url: ApiUrl("https://api.hiro.so".to_string()),
         initial_height: Some(initial_heigth),
         use_mainnet_wallets: true,
     };

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776050130,
-        "narHash": "sha256-/f/6/1WOfBJaGMfqV3VxWD9lpFRbPpF+Cx4MO+0mGok=",
+        "lastModified": 1777864665,
+        "narHash": "sha256-oE4lnjiBa3uE+dP9jM0jFzofP1xYIlK6IQBjLfWjH04=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3c27f4c92a7d977556dd2c10bb564d9c61b375e9",
+        "rev": "669151bbc7f2416b622af2f48e9136e2c9da5530",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Left out the "fix:" so that it isn't included in changelog
also includes https://github.com/stx-labs/clarinet/pull/2379 