### PR TITLE
tests: Reduce calls to Hiro API and improve retry logic

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,5 +9,17 @@ filter = "test(test_encrypt_mnemonic)"
 test-group = "cpu-heavy"
 threads-required = 4
 
+# Tests hitting external Hiro APIs share a rate limit. Running them in parallel
+# causes 429s with 55-60s retry delays that exceed test timeouts.
+# Serialize them to avoid concurrent rate-limit pressure, and give a generous
+# timeout since each test makes multiple API calls.
+[[profile.default.overrides]]
+filter = "binary(empty_session_with_mxs)"
+test-group = "hiro-api"
+slow-timeout = { period = "30s", terminate-after = 4 }
+
 [test-groups.cpu-heavy]
 max-threads = 4
+
+[test-groups.hiro-api]
+max-threads = 1

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,7 +14,7 @@ threads-required = 4
 # Serialize them to avoid concurrent rate-limit pressure, and give a generous
 # timeout since each test makes multiple API calls.
 [[profile.default.overrides]]
-filter = "binary(empty_session_with_mxs)"
+filter = "binary(empty_session_with_mxs) | binary(mxs_project) | test(can_init_console_with_mxs)"
 test-group = "hiro-api"
 slow-timeout = { period = "30s", terminate-after = 4 }
 

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -325,7 +325,7 @@ async fn run_did_open_and_collect_server_requests(code_lens_refresh: bool) -> Ve
     let collect_requests_fut = async {
         let mut methods = vec![];
         while let Ok(Some(req)) =
-            tokio::time::timeout(Duration::from_secs(10), request_stream.next()).await
+            tokio::time::timeout(Duration::from_secs(1), request_stream.next()).await
         {
             let method = req.method().to_string();
             if let Some(id) = req.id().cloned() {

--- a/components/clarinet-cli/src/lsp/mod.rs
+++ b/components/clarinet-cli/src/lsp/mod.rs
@@ -324,9 +324,14 @@ async fn run_did_open_and_collect_server_requests(code_lens_refresh: bool) -> Ve
 
     let collect_requests_fut = async {
         let mut methods = vec![];
+        // Use a longer timeout for the first request (server may need time to
+        // process didOpen under CI load), then a short drain timeout for any
+        // subsequent requests.
+        let mut timeout_secs = 10;
         while let Ok(Some(req)) =
-            tokio::time::timeout(Duration::from_secs(1), request_stream.next()).await
+            tokio::time::timeout(Duration::from_secs(timeout_secs), request_stream.next()).await
         {
+            timeout_secs = 1;
             let method = req.method().to_string();
             if let Some(id) = req.id().cloned() {
                 let _ = response_sink

--- a/components/clarinet-sdk/node/vitest.config.ts
+++ b/components/clarinet-sdk/node/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     silent: "passed-only",
     pool: "forks",
     maxWorkers: 1,
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     include: ["./tests/**/*.test.ts", "./vitest-helpers/tests/**/*.test.ts"],
   },
 });

--- a/components/clarity-repl/src/repl/remote_data/http_request/native.rs
+++ b/components/clarity-repl/src/repl/remote_data/http_request/native.rs
@@ -60,13 +60,9 @@ pub fn http_request<T: DeserializeOwned>(url: &str) -> Result<T, String> {
             return response.json::<T>().map_err(|e| e.to_string());
         }
 
-        if status != StatusCode::TOO_MANY_REQUESTS {
-            return handle_response(response);
-        }
-
-        let headers = response.headers().clone();
-        let (is_rate_limited, retry_after) = is_rate_limited(&headers);
-        if !is_rate_limited {
+        // Retry on server errors (5xx) and rate limits (429)
+        let is_retryable = status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS;
+        if !is_retryable {
             return handle_response(response);
         }
 
@@ -75,8 +71,18 @@ pub fn http_request<T: DeserializeOwned>(url: &str) -> Result<T, String> {
             return handle_response(response);
         }
 
-        let retry_delay = retry_after.unwrap_or(1);
-        uprint!("Rate limited, retrying after {retry_delay} seconds...\n");
-        std::thread::sleep(Duration::from_secs(retry_delay as u64));
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            let headers = response.headers().clone();
+            let (is_rate_limited, retry_after) = is_rate_limited(&headers);
+            if !is_rate_limited {
+                return handle_response(response);
+            }
+            let retry_delay = retry_after.unwrap_or(1);
+            uprint!("Rate limited, retrying after {retry_delay} seconds...\n");
+            std::thread::sleep(Duration::from_secs(retry_delay as u64));
+        } else {
+            uprint!("Server error ({status}), retrying in 3 seconds...\n");
+            std::thread::sleep(Duration::from_secs(3));
+        }
     }
 }

--- a/components/clarity-repl/tests/empty_session_with_mxs.rs
+++ b/components/clarity-repl/tests/empty_session_with_mxs.rs
@@ -5,12 +5,16 @@ use clarity::vm::{EvaluationResult, Value};
 use clarity_repl::repl::settings::{ApiUrl, RemoteDataSettings, Settings};
 use clarity_repl::repl::{Session, SessionSettings};
 
-// Use a deterministic shared cache directory so that contract metadata fetched
-// by one test process is reused by subsequent tests, reducing the total number
-// of Hiro API calls and rate-limit pressure. nextest runs each test in its own
-// process, so tempdir() would create isolated caches that can't be reused.
+// Use a shared cache directory so that contract metadata fetched by one test
+// process is reused by subsequent tests, reducing the total number of Hiro API
+// calls and rate-limit pressure. nextest runs each test in its own process, so
+// tempdir() would create isolated caches that can't be reused.
+//
+// Namespaced by PID of the parent process (the nextest runner) so that
+// concurrent or repeated runs don't interfere with each other.
 fn shared_cache_dir() -> PathBuf {
-    std::env::temp_dir().join("clarinet-test-mxs-cache")
+    let parent_pid = std::os::unix::process::parent_id();
+    std::env::temp_dir().join(format!("clarinet-test-mxs-cache-{parent_pid}"))
 }
 
 #[track_caller]
@@ -22,14 +26,14 @@ fn eval_snippet(session: &mut Session, snippet: &str) -> Value {
     }
 }
 
-fn init_testnet_session(initial_heigth: u32) -> Session {
+fn init_testnet_session(initial_height: u32) -> Session {
     let settings = SessionSettings {
         cache_location: Some(shared_cache_dir()),
         repl_settings: Settings {
             remote_data: RemoteDataSettings {
                 enabled: true,
                 api_url: ApiUrl("https://api.testnet.hiro.so".to_string()),
-                initial_height: Some(initial_heigth),
+                initial_height: Some(initial_height),
                 use_mainnet_wallets: false,
             },
             ..Default::default()
@@ -39,14 +43,14 @@ fn init_testnet_session(initial_heigth: u32) -> Session {
     Session::new(settings)
 }
 
-fn init_mainnet_session(initial_heigth: u32) -> Session {
+fn init_mainnet_session(initial_height: u32) -> Session {
     let settings = SessionSettings {
         cache_location: Some(shared_cache_dir()),
         repl_settings: Settings {
             remote_data: RemoteDataSettings {
                 enabled: true,
                 api_url: ApiUrl("https://api.hiro.so".to_string()),
-                initial_height: Some(initial_heigth),
+                initial_height: Some(initial_height),
                 use_mainnet_wallets: true,
             },
             ..Default::default()

--- a/components/clarity-repl/tests/empty_session_with_mxs.rs
+++ b/components/clarity-repl/tests/empty_session_with_mxs.rs
@@ -1,7 +1,17 @@
+use std::path::PathBuf;
+
 use clarity::types::StacksEpochId;
 use clarity::vm::{EvaluationResult, Value};
-use clarity_repl::repl::settings::{ApiUrl, RemoteDataSettings};
+use clarity_repl::repl::settings::{ApiUrl, RemoteDataSettings, Settings};
 use clarity_repl::repl::{Session, SessionSettings};
+
+// Use a deterministic shared cache directory so that contract metadata fetched
+// by one test process is reused by subsequent tests, reducing the total number
+// of Hiro API calls and rate-limit pressure. nextest runs each test in its own
+// process, so tempdir() would create isolated caches that can't be reused.
+fn shared_cache_dir() -> PathBuf {
+    std::env::temp_dir().join("clarinet-test-mxs-cache")
+}
 
 #[track_caller]
 fn eval_snippet(session: &mut Session, snippet: &str) -> Value {
@@ -13,27 +23,35 @@ fn eval_snippet(session: &mut Session, snippet: &str) -> Value {
 }
 
 fn init_testnet_session(initial_heigth: u32) -> Session {
-    let mut settings = SessionSettings::default();
-    let temp_dir = tempfile::tempdir().unwrap();
-    settings.cache_location = Some(temp_dir.path().to_path_buf());
-    settings.repl_settings.remote_data = RemoteDataSettings {
-        enabled: true,
-        api_url: ApiUrl("https://api.testnet.hiro.so".to_string()),
-        initial_height: Some(initial_heigth),
-        use_mainnet_wallets: false,
+    let settings = SessionSettings {
+        cache_location: Some(shared_cache_dir()),
+        repl_settings: Settings {
+            remote_data: RemoteDataSettings {
+                enabled: true,
+                api_url: ApiUrl("https://api.testnet.hiro.so".to_string()),
+                initial_height: Some(initial_heigth),
+                use_mainnet_wallets: false,
+            },
+            ..Default::default()
+        },
+        ..Default::default()
     };
     Session::new(settings)
 }
 
 fn init_mainnet_session(initial_heigth: u32) -> Session {
-    let mut settings = SessionSettings::default();
-    let temp_dir = tempfile::tempdir().unwrap();
-    settings.cache_location = Some(temp_dir.path().to_path_buf());
-    settings.repl_settings.remote_data = RemoteDataSettings {
-        enabled: true,
-        api_url: ApiUrl("https://api.hiro.so".to_string()),
-        initial_height: Some(initial_heigth),
-        use_mainnet_wallets: true,
+    let settings = SessionSettings {
+        cache_location: Some(shared_cache_dir()),
+        repl_settings: Settings {
+            remote_data: RemoteDataSettings {
+                enabled: true,
+                api_url: ApiUrl("https://api.hiro.so".to_string()),
+                initial_height: Some(initial_heigth),
+                use_mainnet_wallets: true,
+            },
+            ..Default::default()
+        },
+        ..Default::default()
     };
     Session::new(settings)
 }

--- a/components/clarity-repl/tests/empty_session_with_mxs.rs
+++ b/components/clarity-repl/tests/empty_session_with_mxs.rs
@@ -10,11 +10,11 @@ use clarity_repl::repl::{Session, SessionSettings};
 // calls and rate-limit pressure. nextest runs each test in its own process, so
 // tempdir() would create isolated caches that can't be reused.
 //
-// Namespaced by PID of the parent process (the nextest runner) so that
-// concurrent or repeated runs don't interfere with each other.
+// Namespaced by the nextest run ID (set by nextest) or a fallback timestamp so
+// that concurrent or repeated runs don't interfere with each other.
 fn shared_cache_dir() -> PathBuf {
-    let parent_pid = std::os::unix::process::parent_id();
-    std::env::temp_dir().join(format!("clarinet-test-mxs-cache-{parent_pid}"))
+    let run_id = std::env::var("NEXTEST_RUN_ID").unwrap_or_else(|_| "default".to_string());
+    std::env::temp_dir().join(format!("clarinet-test-mxs-cache-{run_id}"))
 }
 
 #[track_caller]


### PR DESCRIPTION
The api tests are notoriously flaky. This attempts to mitigate that.

- reuse contract metadata in a new cache for api specific tests
- tweak timeout windows

