### PR TITLE
ci: fix docker image release

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -66,8 +66,6 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   homebrew:
     name: Homebrew


### PR DESCRIPTION
I noticed the docker image build has been broken for a while (https://github.com/stx-labs/clarinet/actions/runs/25076526834/job/73470507864) 

It's because of the caching step. 
This action only copies the clarinet bin that is already built.
There is no expensive step to cache here
