### PR TITLE
chore: use epoch4 built-ins via pox-wf-integration

### DIFF
--- a/.github/workflows/ci-vscode.yaml
+++ b/.github/workflows/ci-vscode.yaml
@@ -78,7 +78,7 @@ jobs:
           WASM_PACK_VERSION: "0.14.0"
           WASM_PACK_SHA256: "278a8d668085821f4d1a637bd864f1713f872b0ae3a118c77562a308c0abfe8d"
         run: |
-          curl -fsSL "https://github.com/drager/wasm-pack/releases/download/v${WASM_PACK_VERSION}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o wasm-pack.tar.gz
+          curl -fsSL "https://github.com/wasm-bindgen/wasm-pack/releases/download/v${WASM_PACK_VERSION}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o wasm-pack.tar.gz
           echo "${WASM_PACK_SHA256}  wasm-pack.tar.gz" | sha256sum -c -
           tar xzf wasm-pack.tar.gz
           mv "wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack" /usr/local/bin/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 dependencies = [
  "clarity-types",
  "integer-sqrt",
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "libsigner"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 dependencies = [
  "clarity",
  "hashbrown 0.15.5",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 dependencies = [
  "clarity",
  "serde",
@@ -3057,7 +3057,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 dependencies = [
  "clarity",
  "slog",
@@ -4233,12 +4233,12 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=549b39f8ede50bf504c25ff1a31fe01e647cfedd#549b39f8ede50bf504c25ff1a31fe01e647cfedd"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
 dependencies = [
  "clarity",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ version = "3.17.0"
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]
 # stacks-core git dependencies
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "549b39f8ede50bf504c25ff1a31fe01e647cfedd", package = "clarity", default-features = false }
-clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "549b39f8ede50bf504c25ff1a31fe01e647cfedd", package = "clarity-types" }
-libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "549b39f8ede50bf504c25ff1a31fe01e647cfedd", package = "libsigner", default-features = false }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "549b39f8ede50bf504c25ff1a31fe01e647cfedd", package = "pox-locking", default-features = false }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "549b39f8ede50bf504c25ff1a31fe01e647cfedd", package = "stacks-common", default-features = false }
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "549b39f8ede50bf504c25ff1a31fe01e647cfedd", package = "stackslib", default-features = false }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "clarity", default-features = false }
+clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "clarity-types" }
+libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "libsigner", default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "pox-locking", default-features = false }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "stacks-common", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "stackslib", default-features = false }
 
 # Internal crates
 clarinet-defaults = { path = "components/clarinet-defaults" }

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -738,7 +738,7 @@ pub fn apply_on_chain_deployment(
                 EpochSpec::Epoch3_3 => devnet.epoch_3_3,
                 EpochSpec::Epoch3_4 => devnet.epoch_3_4,
                 // Clarinet always keeps optional support for a future epoch
-                EpochSpec::Epoch3_5 => devnet.epoch_3_5.unwrap_or(u64::MAX),
+                EpochSpec::Epoch4_0 => devnet.epoch_4_0.unwrap_or(u64::MAX),
             };
             let mut epoch_transition_successful =
                 current_bitcoin_block_height > after_bitcoin_block;

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -44,8 +44,8 @@ pub enum EpochSpec {
     Epoch3_3,
     #[serde(rename = "3.4")]
     Epoch3_4,
-    #[serde(rename = "3.5")]
-    Epoch3_5,
+    #[serde(rename = "4.0")]
+    Epoch4_0,
 }
 
 impl From<StacksEpochId> for EpochSpec {
@@ -63,6 +63,7 @@ impl From<StacksEpochId> for EpochSpec {
             StacksEpochId::Epoch32 => EpochSpec::Epoch3_2,
             StacksEpochId::Epoch33 => EpochSpec::Epoch3_3,
             StacksEpochId::Epoch34 => EpochSpec::Epoch3_4,
+            StacksEpochId::Epoch40 => EpochSpec::Epoch4_0,
             StacksEpochId::Epoch10 => unreachable!("epoch 1.0 is not supported"),
         }
     }
@@ -83,7 +84,7 @@ impl From<EpochSpec> for StacksEpochId {
             EpochSpec::Epoch3_2 => StacksEpochId::Epoch32,
             EpochSpec::Epoch3_3 => StacksEpochId::Epoch33,
             EpochSpec::Epoch3_4 => StacksEpochId::Epoch34,
-            EpochSpec::Epoch3_5 => unreachable!(),
+            EpochSpec::Epoch4_0 => StacksEpochId::Epoch40,
         }
     }
 }
@@ -121,7 +122,7 @@ impl From<&DevnetConfig> for BurnchainEpochConfig {
                     EpochSpec::Epoch3_2 => Some(config.epoch_3_2),
                     EpochSpec::Epoch3_3 => Some(config.epoch_3_3),
                     EpochSpec::Epoch3_4 => Some(config.epoch_3_4),
-                    EpochSpec::Epoch3_5 => config.epoch_3_5,
+                    EpochSpec::Epoch4_0 => config.epoch_4_0,
                 };
                 start_height.map(|start_height| EpochConfig {
                     epoch_name: epoch,
@@ -1646,7 +1647,7 @@ mod tests {
             epoch_3_2: 10,
             epoch_3_3: 11,
             epoch_3_4: 12,
-            epoch_3_5: Some(13),
+            epoch_4_0: Some(13),
             ..Default::default()
         };
 
@@ -1705,7 +1706,7 @@ mod tests {
                 start_height = 12
 
                 [[burnchain.epochs]]
-                epoch_name = "3.5"
+                epoch_name = "4.0"
                 start_height = 13
                 "#
             }

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -205,7 +205,7 @@ pub struct DevnetConfigFile {
     pub epoch_3_2: Option<u64>,
     pub epoch_3_3: Option<u64>,
     pub epoch_3_4: Option<u64>,
-    pub epoch_3_5: Option<u64>,
+    pub epoch_4_0: Option<u64>,
     pub use_docker_gateway_routing: Option<bool>,
     pub docker_platform: Option<String>,
 }
@@ -345,7 +345,7 @@ pub struct DevnetConfig {
     pub epoch_3_2: u64,
     pub epoch_3_3: u64,
     pub epoch_3_4: u64,
-    pub epoch_3_5: Option<u64>,
+    pub epoch_4_0: Option<u64>,
     pub use_docker_gateway_routing: bool,
     pub docker_platform: Option<String>,
 }
@@ -1013,7 +1013,7 @@ impl NetworkManifest {
                 epoch_3_2: devnet_config.epoch_3_2.unwrap_or(DEFAULT_EPOCH_3_2),
                 epoch_3_3: devnet_config.epoch_3_3.unwrap_or(DEFAULT_EPOCH_3_3),
                 epoch_3_4: devnet_config.epoch_3_4.unwrap_or(DEFAULT_EPOCH_3_4),
-                epoch_3_5: devnet_config.epoch_3_5,
+                epoch_4_0: devnet_config.epoch_4_0,
                 stacks_node_env_vars: devnet_config
                     .stacks_node_env_vars
                     .take()
@@ -1143,7 +1143,7 @@ impl Default for DevnetConfig {
             epoch_3_2: DEFAULT_EPOCH_3_2,
             epoch_3_3: DEFAULT_EPOCH_3_3,
             epoch_3_4: DEFAULT_EPOCH_3_4,
-            epoch_3_5: None,
+            epoch_4_0: None,
             use_docker_gateway_routing: false,
             docker_platform: None,
         }

--- a/components/clarinet-sdk-wasm/src/ts_types.rs
+++ b/components/clarinet-sdk-wasm/src/ts_types.rs
@@ -160,10 +160,11 @@ const STACKS_EPOCH_ID_STRING: &'static str = r#"export type StacksEpochId =
   | "Epoch31"
   | "Epoch32"
   | "Epoch33"
-  | "Epoch34";"#;
+  | "Epoch34"
+  | "Epoch40";"#;
 
 #[wasm_bindgen(typescript_custom_section)]
-const CLARITY_VERSION_STRING: &'static str = r#"export type ClarityVersionString = "Clarity1" | "Clarity2" | "Clarity3"| "Clarity4" | "Clarity5";"#;
+const CLARITY_VERSION_STRING: &'static str = r#"export type ClarityVersionString = "Clarity1" | "Clarity2" | "Clarity3"| "Clarity4" | "Clarity5" | "Clarity6";"#;
 
 // To avoid collision with the Rust type ContractAST, prefix with the conventional typescript I
 #[wasm_bindgen(typescript_custom_section)]

--- a/components/clarity-lsp/src/common/requests/api_ref.rs
+++ b/components/clarity-lsp/src/common/requests/api_ref.rs
@@ -23,7 +23,8 @@ fn format_removed_in(max_version: Option<ClarityVersion>) -> String {
                     ClarityVersion::Clarity2 => ClarityVersion::Clarity3,
                     ClarityVersion::Clarity3 => ClarityVersion::Clarity4,
                     ClarityVersion::Clarity4 => ClarityVersion::Clarity5,
-                    ClarityVersion::Clarity5 => unreachable!(),
+                    ClarityVersion::Clarity5 => ClarityVersion::Clarity6,
+                    ClarityVersion::Clarity6 => unreachable!(),
                 }
             )
         })

--- a/components/clarity-lsp/src/common/requests/completion.rs
+++ b/components/clarity-lsp/src/common/requests/completion.rs
@@ -26,11 +26,13 @@ const fn version_to_index(version: ClarityVersion) -> usize {
         ClarityVersion::Clarity3 => 2,
         ClarityVersion::Clarity4 => 3,
         ClarityVersion::Clarity5 => 4,
+        ClarityVersion::Clarity6 => 5,
     }
 }
 
 fn get_native_completions(version: ClarityVersion) -> &'static Vec<CompletionItem> {
-    static CELLS: [OnceLock<Vec<CompletionItem>>; 5] = [
+    static CELLS: [OnceLock<Vec<CompletionItem>>; 6] = [
+        OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),
@@ -80,7 +82,8 @@ static ITERATOR_FUNCTIONS: LazyLock<Vec<String>> = LazyLock::new(|| {
 });
 
 fn get_map_cb_completions(version: ClarityVersion) -> &'static Vec<CompletionItem> {
-    static CELLS: [OnceLock<Vec<CompletionItem>>; 5] = [
+    static CELLS: [OnceLock<Vec<CompletionItem>>; 6] = [
+        OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),
@@ -91,7 +94,8 @@ fn get_map_cb_completions(version: ClarityVersion) -> &'static Vec<CompletionIte
 }
 
 fn get_filter_cb_completions(version: ClarityVersion) -> &'static Vec<CompletionItem> {
-    static CELLS: [OnceLock<Vec<CompletionItem>>; 5] = [
+    static CELLS: [OnceLock<Vec<CompletionItem>>; 6] = [
+        OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),
@@ -102,7 +106,8 @@ fn get_filter_cb_completions(version: ClarityVersion) -> &'static Vec<Completion
 }
 
 fn get_fold_cb_completions(version: ClarityVersion) -> &'static Vec<CompletionItem> {
-    static CELLS: [OnceLock<Vec<CompletionItem>>; 5] = [
+    static CELLS: [OnceLock<Vec<CompletionItem>>; 6] = [
+        OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),
         OnceLock::new(),

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -54,6 +54,7 @@ fn epoch_to_peer_version(epoch: StacksEpochId) -> u8 {
         StacksEpochId::Epoch32 => PEER_VERSION_EPOCH_3_2,
         StacksEpochId::Epoch33 => PEER_VERSION_EPOCH_3_3,
         StacksEpochId::Epoch34 => PEER_VERSION_EPOCH_3_4,
+        StacksEpochId::Epoch40 => PEER_VERSION_EPOCH_4_0,
     }
 }
 
@@ -1273,7 +1274,9 @@ impl BurnStateDB for Datastore {
                     .map(|block| block.burn_block_height)
             }
             // Note: at-block removed at 3.4+
-            Epoch30 | Epoch31 | Epoch32 | Epoch33 | Epoch34 => Some(self.burn_chain_height),
+            Epoch30 | Epoch31 | Epoch32 | Epoch33 | Epoch34 | Epoch40 => {
+                Some(self.burn_chain_height)
+            }
         }
     }
 

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -34,6 +34,7 @@ pub fn clarity_version_to_u8(version: ClarityVersion) -> u8 {
         ClarityVersion::Clarity3 => 3,
         ClarityVersion::Clarity4 => 4,
         ClarityVersion::Clarity5 => 5,
+        ClarityVersion::Clarity6 => 6,
     }
 }
 
@@ -45,6 +46,7 @@ pub fn clarity_version_from_u8(value: u8) -> Option<ClarityVersion> {
         3 => Some(ClarityVersion::Clarity3),
         4 => Some(ClarityVersion::Clarity4),
         5 => Some(ClarityVersion::Clarity5),
+        6 => Some(ClarityVersion::Clarity6),
         _ => None,
     }
 }
@@ -65,6 +67,7 @@ pub fn epoch_from_str(s: &str) -> Option<StacksEpochId> {
         "3.2" => Some(StacksEpochId::Epoch32),
         "3.3" => Some(StacksEpochId::Epoch33),
         "3.4" => Some(StacksEpochId::Epoch34),
+        "4" | "4.0" => Some(StacksEpochId::Epoch40),
         _ => None,
     }
 }
@@ -153,6 +156,7 @@ impl<'de> serde::Deserialize<'de> for Epoch {
                     3.2 => StacksEpochId::Epoch32,
                     3.3 => StacksEpochId::Epoch33,
                     3.4 => StacksEpochId::Epoch34,
+                    4.0 => StacksEpochId::Epoch40,
                     _ => {
                         return Err(serde::de::Error::custom(format!(
                             "unknown epoch value: {value}"

--- a/components/clarity-static-cost/src/static_cost/cost_functions.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_functions.rs
@@ -36,7 +36,7 @@ impl ClarityCostFunctionExt for ClarityCostFunction {
             | StacksEpochId::Epoch31
             | StacksEpochId::Epoch32 => self.eval::<Costs3>(n),
             StacksEpochId::Epoch33 => self.eval::<Costs4>(n),
-            StacksEpochId::Epoch34 => self.eval::<Costs4>(n),
+            StacksEpochId::Epoch34 | StacksEpochId::Epoch40 => self.eval::<Costs4>(n),
         }
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
         # Hash for clarity git dependency - update this when Cargo.lock changes
         # Run `nix run .#check-git-dependencies-hash` to verify or get the new hash
-        clarityHash = "sha256-ZNFqlKunBnU0hlETBM6mlvWmYPePf5SCea7Ims8n9Po=";
+        clarityHash = "sha256-ziVf3epIybqiLt1pWnHImJiFiuIw1uwUzHC2SdvXmVI=";
 
         clarinet = rustPlatform.buildRustPackage {
           inherit pname version;


### PR DESCRIPTION
Prepare for pox-5 with a stacks-core update from [pox-wf-integration](https://github.com/stacks-network/stacks-core/tree/pox-wf-integration)

