### PR TITLE
perf: Remove temp allocations and double conversions

### DIFF
--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1352,7 +1352,7 @@ pub fn main() {
                             let Some((_, path)) = deployment.contracts.get(&contract_id) else {
                                 continue;
                             };
-                            let key = path.to_string_lossy().to_string();
+                            let key = path.to_string_lossy().into_owned();
                             let entry = diagnostics.entry(key).or_default();
                             entry.extend(diags.into_iter().map(LintDiagnostic::from));
                             if let Some(lds) = artifacts.lint_diags.remove(&contract_id) {
@@ -1761,7 +1761,7 @@ pub fn load_deployment_and_artifacts_or_exit(
                     );
                     (
                         deployment,
-                        Some(deployment_location.to_string_lossy().to_string()),
+                        Some(deployment_location.to_string_lossy().into_owned()),
                         artifacts,
                     )
                 })

--- a/components/clarinet-cli/src/generate/contract.rs
+++ b/components/clarinet-cli/src/generate/contract.rs
@@ -43,7 +43,7 @@ impl GetChangesForRmContract {
         }
         let change = FileDeletion {
             comment: format!("{} tests/{}", red!("Deleted file"), name),
-            path: f.to_string_lossy().to_string(),
+            path: f.to_string_lossy().into_owned(),
         };
         self.changes.push(Changes::RemoveFile(change));
         Ok(())
@@ -57,7 +57,7 @@ impl GetChangesForRmContract {
         }
         let change = FileDeletion {
             comment: format!("{} contracts/{}", red!("Deleted file"), name),
-            path: f.to_string_lossy().to_string(),
+            path: f.to_string_lossy().into_owned(),
         };
         self.changes.push(Changes::RemoveFile(change));
         Ok(())
@@ -146,7 +146,7 @@ impl GetChangesForNewContract {
         let change = FileCreation {
             comment: format!("{} contracts/{}", green!("Created file"), name),
             content,
-            path: new_file.to_string_lossy().to_string(),
+            path: new_file.to_string_lossy().into_owned(),
         };
         self.changes.push(Changes::AddFile(change));
         Ok(())
@@ -186,7 +186,7 @@ impl GetChangesForNewContract {
         let change = FileCreation {
             comment: format!("{} tests/{}", green!("Created file"), name),
             content,
-            path: new_file.to_string_lossy().to_string(),
+            path: new_file.to_string_lossy().into_owned(),
         };
         self.changes.push(Changes::AddFile(change));
         Ok(())

--- a/components/clarinet-deployments/src/diagnostic_digest.rs
+++ b/components/clarinet-deployments/src/diagnostic_digest.rs
@@ -45,7 +45,7 @@ impl DiagnosticsDigest {
             }
 
             let formatted_lines: Vec<String> = source.lines().map(|l| l.to_string()).collect();
-            let contract_path = contract_location.to_string_lossy().to_string();
+            let contract_path = contract_location.to_string_lossy().into_owned();
 
             for ld in diags
                 .iter()

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -451,7 +451,7 @@ pub async fn generate_default_deployment(
             }
 
             let resolved_path = manifest.root_dir.join(file_path);
-            let resolved_path_string = resolved_path.to_string_lossy().to_string();
+            let resolved_path_string = resolved_path.to_string_lossy().into_owned();
 
             // Load and validate the custom boot contract
             let custom_source = match file_accessor {
@@ -724,7 +724,7 @@ pub async fn generate_default_deployment(
                 let source = paths::read_content_as_utf8(&contract_location).map_err(|_| {
                     format!("unable to find contract at {}", contract_location.display())
                 })?;
-                sources.insert(contract_location.to_string_lossy().to_string(), source);
+                sources.insert(contract_location.to_string_lossy().into_owned(), source);
             }
             sources
         }
@@ -735,7 +735,7 @@ pub async fn generate_default_deployment(
                 .map(|contract_config| {
                     let contract_location =
                         project_root.join(contract_config.expect_contract_path_as_str());
-                    contract_location.to_string_lossy().to_string()
+                    contract_location.to_string_lossy().into_owned()
                 })
                 .collect();
             file_accessor.read_files(contracts_location).await?
@@ -767,7 +767,7 @@ pub async fn generate_default_deployment(
 
         let contract_location = project_root.join(contract_config.expect_contract_path_as_str());
         let mut source = sources
-            .get(&contract_location.to_string_lossy().to_string())
+            .get(contract_location.to_string_lossy().as_ref())
             .ok_or(format!(
                 "Invalid Clarinet.toml, source file not found for: {}",
                 &name

--- a/components/clarinet-deployments/src/requirements.rs
+++ b/components/clarinet-deployments/src/requirements.rs
@@ -48,10 +48,10 @@ pub async fn retrieve_contract(
         ),
         Some(file_accessor) => (
             file_accessor
-                .read_file(contract_location.to_string_lossy().to_string())
+                .read_file(contract_location.to_string_lossy().into_owned())
                 .await,
             file_accessor
-                .read_file(metadata_location.to_string_lossy().to_string())
+                .read_file(metadata_location.to_string_lossy().into_owned())
                 .await,
         ),
     };
@@ -99,13 +99,13 @@ pub async fn retrieve_contract(
         Some(file_accessor) => {
             file_accessor
                 .write_file(
-                    contract_location.to_string_lossy().to_string(),
+                    contract_location.to_string_lossy().into_owned(),
                     contract.source_code.as_bytes(),
                 )
                 .await?;
             file_accessor
                 .write_file(
-                    metadata_location.to_string_lossy().to_string(),
+                    metadata_location.to_string_lossy().into_owned(),
                     serde_json::to_string_pretty(&ContractMetadata {
                         epoch,
                         clarity_version,

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -973,7 +973,7 @@ pub mod contracts_serde {
             let mut map = BTreeMap::new();
             map.insert("contract_id", contract_id.to_string());
             map.insert("source", encoded);
-            map.insert("path", path.to_string_lossy().to_string());
+            map.insert("path", path.to_string_lossy().into_owned());
             out.serialize_element(&map)?;
         }
         out.end()
@@ -1074,7 +1074,7 @@ impl DeploymentSpecification {
                                     let source = contracts_sources.as_ref().map(|contracts_sources| {
                                         let contract_path = paths::try_parse_path(&spec.path, Some(project_root))
                                             .expect("failed to get contract path");
-                                        let contract_path_str = contract_path.to_string_lossy().to_string();
+                                        let contract_path_str = contract_path.to_string_lossy().into_owned();
                                         contracts_sources
                                             .get(&contract_path_str)
                                             .cloned()
@@ -1332,7 +1332,7 @@ impl DeploymentSpecificationFile {
         file_accesor: &dyn FileAccessor,
     ) -> Result<DeploymentSpecificationFile, String> {
         let spec_file_content = file_accesor
-            .read_file(path.to_string_lossy().to_string())
+            .read_file(path.to_string_lossy().into_owned())
             .await?;
 
         yaml_serde::from_str(&spec_file_content).map_err(|msg| format!("unable to read file {msg}"))

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -399,7 +399,7 @@ impl NetworkManifest {
     ) -> Result<NetworkManifest, String> {
         let network_manifest_location = project_root.join("settings/Devnet.toml");
         let content = file_accessor
-            .read_file(network_manifest_location.to_string_lossy().to_string())
+            .read_file(network_manifest_location.to_string_lossy().into_owned())
             .await?;
 
         let mut network_manifest_file: NetworkManifestFile =

--- a/components/clarinet-files/src/paths.rs
+++ b/components/clarinet-files/src/paths.rs
@@ -95,7 +95,7 @@ pub async fn find_manifest_location_async(
     while let Some(ref dir) = current {
         let candidate = dir.join("Clarinet.toml");
         if let Ok(true) = file_accessor
-            .file_exists(candidate.to_string_lossy().to_string())
+            .file_exists(candidate.to_string_lossy().into_owned())
             .await
         {
             return Ok(candidate);

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -199,10 +199,7 @@ impl Serialize for ProjectConfig {
         map.serialize_entry("description", &self.description)?;
         map.serialize_entry("authors", &self.authors)?;
         map.serialize_entry("telemetry", &self.telemetry)?;
-        map.serialize_entry(
-            "cache_dir",
-            &self.cache_location.to_string_lossy().to_string(),
-        )?;
+        map.serialize_entry("cache_dir", &self.cache_location.to_string_lossy())?;
         if self.requirements.is_some() {
             map.serialize_entry("requirements", &self.requirements)?;
         }
@@ -224,7 +221,7 @@ impl ProjectManifest {
         file_accessor: &dyn FileAccessor,
     ) -> Result<ProjectManifest, String> {
         let content = file_accessor
-            .read_file(location.to_string_lossy().to_string())
+            .read_file(location.to_string_lossy().into_owned())
             .await?;
 
         let project_manifest_file: ProjectManifestFile = toml::from_slice(content.as_bytes())

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -520,12 +520,12 @@ impl SDK {
 
         if self
             .file_accessor
-            .file_exists(deployment_plan_location.to_string_lossy().to_string())
+            .file_exists(deployment_plan_location.to_string_lossy().into_owned())
             .await?
         {
             let spec_file_content = self
                 .file_accessor
-                .read_file(deployment_plan_location.to_string_lossy().to_string())
+                .read_file(deployment_plan_location.to_string_lossy().into_owned())
                 .await?;
 
             let mut spec_file = DeploymentSpecificationFile::from_file_content(&spec_file_content)?;
@@ -596,7 +596,7 @@ impl SDK {
 
         self.file_accessor
             .write_file(
-                deployment_plan_location.to_string_lossy().to_string(),
+                deployment_plan_location.to_string_lossy().into_owned(),
                 &deployment_file,
             )
             .await?;
@@ -1193,7 +1193,7 @@ impl SDK {
         for (contract_id, contract_location) in contracts_locations.iter() {
             contract_paths.insert(
                 contract_id.name.to_string(),
-                contract_location.to_string_lossy().to_string(),
+                contract_location.to_string_lossy().into_owned(),
             );
         }
 

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -161,7 +161,7 @@ pub async fn process_notification(
                     None => paths::read_content_as_utf8(&contract_location),
                     Some(file_accessor) => {
                         file_accessor
-                            .read_file(contract_location.to_string_lossy().to_string())
+                            .read_file(contract_location.to_string_lossy().into_owned())
                             .await
                     }
                 }?;

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -1054,7 +1054,7 @@ mod lsp_tests {
                 .expect("Failed to process notification");
 
         let response_json = json!(response);
-        println!("full respeonse: {response_json}");
+        println!("full response: {response_json}");
 
         let aggregated_diagnostics = response_json
             .get("aggregated_diagnostics")

--- a/components/clarity-lsp/src/common/requests/hover.rs
+++ b/components/clarity-lsp/src/common/requests/hover.rs
@@ -11,6 +11,6 @@ pub fn get_expression_documentation(
     let expression_name = get_expression_name_at_position(position, expressions)?;
 
     API_REF
-        .get(&expression_name.to_string())
+        .get(expression_name.as_str())
         .map(|(documentation, _)| documentation.to_owned())
 }

--- a/components/clarity-lsp/src/common/requests/signature_help.rs
+++ b/components/clarity-lsp/src/common/requests/signature_help.rs
@@ -28,7 +28,7 @@ pub fn get_signatures(
         return None;
     }
 
-    let (_, reference) = API_REF.get(&function_name.to_string())?;
+    let (_, reference) = API_REF.get(function_name.as_str())?;
     let FunctionAPI {
         signature,
         output_type,

--- a/components/clarity-repl/src/analysis/check_checker/mod.rs
+++ b/components/clarity-repl/src/analysis/check_checker/mod.rs
@@ -607,7 +607,7 @@ impl<'a> ASTVisitor<'a> for CheckChecker<'a> {
         // tainted.
         for child in list {
             if let Some(tainted) = self.tainted_nodes.get(&Node::Expr(child.id)) {
-                sources.extend(tainted.sources.clone());
+                sources.extend(tainted.sources.iter().copied());
             }
         }
         if !sources.is_empty() {

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -187,7 +187,7 @@ impl SummingExecutionCost {
     }
 
     pub fn add_summing(&mut self, other: &SummingExecutionCost) {
-        self.costs.extend(other.costs.clone());
+        self.costs.extend(other.costs.iter().cloned());
     }
 
     /// minimum cost across all paths


### PR DESCRIPTION
### Description

Remove several temporary allocations and unnecessary conversions. In particular, replace:

```rust
path.to_string_lossy().to_string();
```

with

```rust
path.to_string_lossy().into_owned();
```

Which constructs a `String` by consuming the the `Cow` type returned by `to_string_lossy()`, rather than allocating a new buffer