### PR TITLE
chore: pnpm v11

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -72,6 +72,9 @@ jobs:
             cargo install wasm-pack
           fi
 
+      - name: Install dependencies (skip prepare scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Build Wasm packages
         run: pnpm run build:sdk-wasm
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ Wasm target.
 The SDK is divided between the Rust lib compiled to Wasm `./components/clarinet-sdk-wasm` and a TS
 wrapper around it: `./components/clarinet-sdk`.
 
+1. Install dependencies without prepare scripts: `pnpm install --ignore-scripts`
+   (the SDK packages' `prepare` hook needs the wasm build, which doesn't exist yet on a fresh clone)
 1. Compile the Wasm package with `pnpm run build:sdk-wasm`
+1. Install dependencies and run prepare scripts: `pnpm install`
 1. Compile the SDK with `pnpm run build:sdk`
 1. Test with `pnpm test`
 

--- a/components/clarinet-sdk/README.md
+++ b/components/clarinet-sdk/README.md
@@ -37,6 +37,10 @@ To work with these two packages locally, the first one needs to be built with
 wasm-pack (install [wasm-pack](https://wasm-bindgen.github.io/wasm-pack/installer)).
 
 ```sh
+# install dependencies without running prepare scripts
+# (the SDK packages' `prepare` hook depends on the wasm build,
+# which doesn't exist yet on a fresh clone)
+pnpm install --ignore-scripts
 # build the wasm package
 pnpm run build:sdk-wasm
 # install dependencies and build the node package

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Workspace hosting the Clarinet SDK for Node.js and Browser",
   "author": "Stacks Labs",
   "license": "GPL-3.0",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=24"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,7 @@ packages:
   - "components/clarinet-sdk/node"
   - "components/clarinet-sdk/browser"
 
-minimumReleaseAge: 1440 # 24 hours
+allowBuilds:
+  esbuild: true
+
+minimumReleaseAge: 432000 # 5 days in seconds


### PR DESCRIPTION
### Description

Upgrade to pnpm v11, it brings better security defaults (blockexoticsubdeps now defaults to true, it doesn't allow build scripts, unless the whitelisted ones, like esbuild in our case).

Also bumped `minimumReleaseAge` from 1 day to 5.
it's trade off, less likely to pull malicious dependencies, but slower to pull patches. 3 or 5 days sounds like a solid middle ground. And we don't upgrade our dependencies that often on this repo.

Additionally, pnpm v11 changed `verifyDepsBeforeRun` to default to install, so `pnpm run build:sdk-wasm`now auto-runs `pnpm install`, which fires the prepare script on @stacks/clarinet-sdk-browser before the wasm packages exist.
In the `build_wasm` CI job, run `pnpm install --frozen-lockfile --ignore-scripts` explicitly before building wasm, so the auto-check is satisfied without triggering prepare.