### PR TITLE
refactor: Clean up `generate_default_deployment_with_cache()`

### DIFF
--- a/components/clarinet-cli/src/deployments/mod.rs
+++ b/components/clarinet-cli/src/deployments/mod.rs
@@ -5,6 +5,7 @@ use std::fs::{self};
 use std::path::{Path, PathBuf};
 
 use clarinet_deployments::types::{DeploymentGenerationArtifacts, DeploymentSpecification};
+pub use clarinet_deployments::BatchingMode;
 use clarinet_files::{paths, ProjectManifest, StacksNetwork};
 use clarity_repl::utils::Environment;
 pub use ui::start_ui;
@@ -12,13 +13,13 @@ pub use ui::start_ui;
 pub fn generate_default_deployment(
     manifest: &ProjectManifest,
     network: &StacksNetwork,
-    _no_batch: bool,
+    batching: BatchingMode,
     environment: Environment,
 ) -> Result<(DeploymentSpecification, DeploymentGenerationArtifacts, bool), String> {
     let future = clarinet_deployments::generate_default_deployment(
         manifest,
         network,
-        false,
+        batching,
         None,
         None,
         environment,
@@ -31,7 +32,12 @@ pub fn generate_devnet_deployment(
     manifest: &ProjectManifest,
 ) -> Result<(DeploymentSpecification, DeploymentGenerationArtifacts, bool), String> {
     let network = StacksNetwork::Devnet;
-    generate_default_deployment(manifest, &network, false, network.deployment_environment())
+    generate_default_deployment(
+        manifest,
+        &network,
+        BatchingMode::Chunked,
+        network.deployment_environment(),
+    )
 }
 
 pub fn check_deployments(project_root: &Path) -> Result<(), String> {

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1841,8 +1841,12 @@ fn load_deployment_if_exists(
     }
 
     if !force_on_disk {
-        match generate_default_deployment(manifest, network, BatchingMode::Single, network.deployment_environment())
-        {
+        match generate_default_deployment(
+            manifest,
+            network,
+            BatchingMode::Single,
+            network.deployment_environment(),
+        ) {
             Ok((deployment, _, _)) => {
                 use similar::{ChangeTag, TextDiff};
 

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -53,7 +53,7 @@ use super::update_check;
 use crate::deployments::types::DeploymentSynthesis;
 use crate::deployments::{
     self, check_deployments, generate_default_deployment, generate_devnet_deployment,
-    write_deployment,
+    write_deployment, BatchingMode,
 };
 use crate::devnet::package::{self as Package, ConfigurationPackage};
 use crate::devnet::start::{start, StartConfig};
@@ -772,10 +772,15 @@ pub fn main() {
                     StacksNetwork::Simnet
                 };
 
+                let batching = if cmd.no_batch {
+                    BatchingMode::Single
+                } else {
+                    BatchingMode::Chunked
+                };
                 let (mut deployment, _, _) = match generate_default_deployment(
                     &manifest,
                     &network,
-                    cmd.no_batch,
+                    batching,
                     network.deployment_environment(),
                 ) {
                     Ok(result) => result,
@@ -887,7 +892,7 @@ pub fn main() {
                             None => {
                                 let default_deployment_path = project_root.join(get_default_deployment_path(network));
                                 let (deployment, _, _) =
-                                    generate_default_deployment(&manifest, network, false, network.deployment_environment())
+                                    generate_default_deployment(&manifest, network, BatchingMode::Chunked, network.deployment_environment())
                                         .unwrap_or_else(|message| {
                                             eprintln!("{}", red!(message));
                                             std::process::exit(1);
@@ -1720,7 +1725,7 @@ pub fn load_deployment_and_artifacts_or_exit(
                         generate_default_deployment(
                             manifest,
                             &StacksNetwork::Simnet,
-                            false,
+                            BatchingMode::Chunked,
                             environment,
                         )?;
                     found_env_simnet |= gen_found_env_simnet;
@@ -1836,7 +1841,7 @@ fn load_deployment_if_exists(
     }
 
     if !force_on_disk {
-        match generate_default_deployment(manifest, network, true, network.deployment_environment())
+        match generate_default_deployment(manifest, network, BatchingMode::Single, network.deployment_environment())
         {
             Ok((deployment, _, _)) => {
                 use similar::{ChangeTag, TextDiff};

--- a/components/clarinet-cli/src/frontend/dap.rs
+++ b/components/clarinet-cli/src/frontend/dap.rs
@@ -7,7 +7,7 @@ use clarity_repl::utils::Environment;
 
 #[cfg(feature = "telemetry")]
 use super::telemetry::{telemetry_report_event, DeveloperUsageDigest, DeveloperUsageEvent};
-use crate::deployments::generate_default_deployment;
+use crate::deployments::{generate_default_deployment, BatchingMode};
 
 pub fn run_dap() -> Result<(), String> {
     let mut dap = DAPDebugger::new();
@@ -18,7 +18,7 @@ pub fn run_dap() -> Result<(), String> {
             let (mut deployment, artifacts, _) = generate_default_deployment(
                 &project_manifest,
                 &StacksNetwork::Simnet,
-                false,
+                BatchingMode::Chunked,
                 Environment::Simnet,
             )?;
             let mut session = setup_session_with_deployment(

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -391,6 +391,38 @@ impl BatchingMode {
     }
 }
 
+/// Load every contract source listed in the manifest, keyed by
+/// absolute path (as a string). Uses the file accessor when supplied
+/// (LSP, SDK) and the local filesystem otherwise (CLI).
+async fn load_project_contract_sources(
+    manifest: &ProjectManifest,
+    file_accessor: Option<&dyn FileAccessor>,
+) -> Result<HashMap<String, String>, String> {
+    let project_root = &manifest.root_dir;
+    let contract_paths: Vec<String> = manifest
+        .contracts
+        .values()
+        .map(|cfg| {
+            project_root
+                .join(cfg.expect_contract_path_as_str())
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+
+    match file_accessor {
+        Some(accessor) => accessor.read_files(contract_paths).await,
+        None => contract_paths
+            .into_iter()
+            .map(|path| {
+                let source = paths::read_content_as_utf8(Path::new(&path))
+                    .map_err(|_| format!("unable to find contract at {path}"))?;
+                Ok((path, source))
+            })
+            .collect(),
+    }
+}
+
 /// Flatten the per-epoch transaction map into a list of batches,
 /// chunking each epoch's transactions by `batching.chain_limit()`.
 /// Batch ids are assigned in iteration order across epochs.
@@ -876,32 +908,7 @@ pub async fn generate_default_deployment_with_cache(
     let mut contracts_sources = HashMap::new();
 
     let project_root = &manifest.root_dir;
-    let sources: HashMap<String, String> = match file_accessor {
-        None => {
-            let mut sources = HashMap::new();
-            for (_, contract_config) in manifest.contracts.iter() {
-                let contract_location =
-                    project_root.join(contract_config.expect_contract_path_as_str());
-                let source = paths::read_content_as_utf8(&contract_location).map_err(|_| {
-                    format!("unable to find contract at {}", contract_location.display())
-                })?;
-                sources.insert(contract_location.to_string_lossy().into_owned(), source);
-            }
-            sources
-        }
-        Some(file_accessor) => {
-            let contracts_location = manifest
-                .contracts
-                .values()
-                .map(|contract_config| {
-                    let contract_location =
-                        project_root.join(contract_config.expect_contract_path_as_str());
-                    contract_location.to_string_lossy().into_owned()
-                })
-                .collect();
-            file_accessor.read_files(contracts_location).await?
-        }
-    };
+    let sources = load_project_contract_sources(manifest, file_accessor).await?;
 
     for (name, contract_config) in manifest.contracts.iter() {
         let Ok(contract_name) = ContractName::try_from(name.to_string()) else {

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -11,7 +11,8 @@ use std::path::{Path, PathBuf};
 
 use clarinet_defaults::DEFAULT_EPOCH;
 use clarinet_files::{
-    paths, AccountConfig, FileAccessor, NetworkManifest, ProjectManifest, StacksNetwork,
+    paths, AccountConfig, DevnetConfig, FileAccessor, NetworkConfig, NetworkManifest,
+    ProjectManifest, StacksNetwork,
 };
 use clarity::types::StacksEpochId;
 use clarity::util::hash::Sha256Sum;
@@ -866,7 +867,7 @@ fn build_project_contract_specs(
     manifest: &ProjectManifest,
     network: &StacksNetwork,
     environment: Environment,
-    network_manifest: &NetworkManifest,
+    accounts: &BTreeMap<String, AccountConfig>,
     default_deployer: &AccountConfig,
     deployment_fee_rate: u64,
     sources: &HashMap<String, String>,
@@ -883,8 +884,7 @@ fn build_project_contract_specs(
 
         let deployer = match &contract_config.deployer {
             ContractDeployer::DefaultDeployer => default_deployer,
-            ContractDeployer::LabeledDeployer(deployer) => network_manifest
-                .accounts
+            ContractDeployer::LabeledDeployer(deployer) => accounts
                 .get(deployer)
                 .ok_or_else(|| format!("unable to retrieve account '{deployer}'"))?,
             _ => unreachable!(),
@@ -1019,12 +1019,13 @@ fn chunk_transactions_into_batches(
 /// for simnet; otherwise the manifest value or a well-known default.
 fn resolve_node_endpoints(
     network: &StacksNetwork,
-    network_manifest: &mut NetworkManifest,
+    devnet: Option<&DevnetConfig>,
+    net: NetworkConfig,
 ) -> (Option<String>, Option<String>) {
     let (stacks_default, bitcoin_default) = match network {
         StacksNetwork::Simnet => return (None, None),
         StacksNetwork::Devnet => {
-            let (stacks, bitcoin) = match &network_manifest.devnet {
+            let (stacks, bitcoin) = match devnet {
                 Some(d) => (
                     format!("http://localhost:{}", d.stacks_node_rpc_port),
                     format!(
@@ -1048,16 +1049,13 @@ fn resolve_node_endpoints(
             "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332",
         ),
     };
-    let net = &mut network_manifest.network;
     (
         Some(
             net.stacks_node_rpc_address
-                .take()
                 .unwrap_or_else(|| stacks_default.to_string()),
         ),
         Some(
             net.bitcoin_node_rpc_address
-                .take()
                 .unwrap_or_else(|| bitcoin_default.to_string()),
         ),
     )
@@ -1097,13 +1095,16 @@ pub async fn generate_default_deployment_with_cache(
     cached_asts: Option<&mut HashMap<(PathBuf, Environment), CachedContractAST>>,
 ) -> Result<(DeploymentSpecification, DeploymentGenerationArtifacts, bool), String> {
     let mut found_env_simnet = false;
-    let mut network_manifest = load_network_manifest(manifest, network, file_accessor).await?;
+    let NetworkManifest {
+        network: net,
+        accounts,
+        devnet,
+    } = load_network_manifest(manifest, network, file_accessor).await?;
 
-    let (stacks_node, bitcoin_node) = resolve_node_endpoints(network, &mut network_manifest);
+    let deployment_fee_rate = net.deployment_fee_rate;
+    let (stacks_node, bitcoin_node) = resolve_node_endpoints(network, devnet.as_ref(), net);
 
-    let deployment_fee_rate = network_manifest.network.deployment_fee_rate;
-
-    let Some(default_deployer) = network_manifest.accounts.get("deployer") else {
+    let Some(default_deployer) = accounts.get("deployer") else {
         return Err("unable to retrieve default deployer account".to_string());
     };
     let Ok(default_deployer_address) =
@@ -1182,7 +1183,7 @@ pub async fn generate_default_deployment_with_cache(
         manifest,
         network,
         environment,
-        &network_manifest,
+        &accounts,
         default_deployer,
         deployment_fee_rate,
         &sources,
@@ -1249,7 +1250,7 @@ pub async fn generate_default_deployment_with_cache(
     let batches = chunk_transactions_into_batches(transactions, batching);
 
     let wallets = if matches!(network, StacksNetwork::Simnet) {
-        build_simnet_wallets(network_manifest.accounts)?
+        build_simnet_wallets(accounts)?
     } else {
         Vec::new()
     };

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -1122,36 +1122,6 @@ pub async fn generate_default_deployment_with_cache(
         contracts: contracts_map,
     };
 
-    // Check for custom boot contract validation errors and return error if any
-    if !asts_success && matches!(network, StacksNetwork::Simnet) {
-        let mut error_messages = Vec::new();
-        for (contract_id, diagnostics) in &contract_diags {
-            if !diagnostics.is_empty() {
-                let contract_name = contract_id.name.to_string();
-                let error_details: Vec<String> = diagnostics
-                    .iter()
-                    .map(|d| format!("  - {}", d.message))
-                    .collect();
-                if manifest
-                    .project
-                    .override_boot_contracts_source
-                    .contains_key(&contract_name)
-                {
-                    error_messages.push(format!(
-                        "Custom boot contract validation failed:\n{}",
-                        error_messages.join("\n\n")
-                    ));
-                } else {
-                    error_messages.push(format!(
-                        "'{}' has validation errors:\n{}",
-                        contract_name,
-                        error_details.join("\n")
-                    ));
-                }
-            }
-        }
-    }
-
     // Disarm the guard (if any) — we're committed to returning Ok, so
     // the accumulated entries belong in the artifacts, not back in the
     // caller's input cache. `None` carries through for cache-free callers

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -751,6 +751,33 @@ async fn validate_custom_boot_contracts(
     Ok(failures)
 }
 
+/// Load the network manifest via the accessor when one was supplied
+/// (LSP, SDK) and from the local filesystem otherwise (CLI).
+async fn load_network_manifest(
+    manifest: &ProjectManifest,
+    network: &StacksNetwork,
+    file_accessor: Option<&dyn FileAccessor>,
+) -> Result<NetworkManifest, String> {
+    match file_accessor {
+        None => NetworkManifest::from_project_root(
+            &manifest.root_dir,
+            &network.get_networks(),
+            manifest.use_mainnet_wallets(),
+            Some(&manifest.project.cache_location),
+            None,
+        ),
+        Some(accessor) => {
+            NetworkManifest::from_project_root_using_file_accessor(
+                &manifest.root_dir,
+                &network.get_networks(),
+                manifest.use_mainnet_wallets(),
+                accessor,
+            )
+            .await
+        }
+    }
+}
+
 /// For each contract in the manifest, build (a) the `ClarityContract` /
 /// location pair that the AST-cache loop consumes, and (b) the publish
 /// `TransactionSpecification` that ends up in the deployment plan.
@@ -1016,24 +1043,7 @@ pub async fn generate_default_deployment_with_cache(
     cached_asts: Option<&mut HashMap<(PathBuf, Environment), CachedContractAST>>,
 ) -> Result<(DeploymentSpecification, DeploymentGenerationArtifacts, bool), String> {
     let mut found_env_simnet = false;
-    let network_manifest = match file_accessor {
-        None => NetworkManifest::from_project_root(
-            &manifest.root_dir,
-            &network.get_networks(),
-            manifest.use_mainnet_wallets(),
-            Some(&manifest.project.cache_location),
-            None,
-        )?,
-        Some(file_accessor) => {
-            NetworkManifest::from_project_root_using_file_accessor(
-                &manifest.root_dir,
-                &network.get_networks(),
-                manifest.use_mainnet_wallets(),
-                file_accessor,
-            )
-            .await?
-        }
-    };
+    let network_manifest = load_network_manifest(manifest, network, file_accessor).await?;
 
     let (stacks_node, bitcoin_node) = resolve_node_endpoints(network, &network_manifest);
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -424,10 +424,12 @@ pub enum BatchingMode {
 }
 
 impl BatchingMode {
-    fn chain_limit(self) -> usize {
+    fn chunks<T>(self, items: &[T]) -> std::slice::Chunks<'_, T> {
         match self {
-            BatchingMode::Chunked => 25,
-            BatchingMode::Single => 100_000,
+            BatchingMode::Chunked => items.chunks(25),
+            // `.max(1)` avoids the `chunks(0)` panic on empty epochs;
+            // for non-empty input `chunks(len)` yields one chunk.
+            BatchingMode::Single => items.chunks(items.len().max(1)),
         }
     }
 }
@@ -975,17 +977,15 @@ async fn load_project_contract_sources(
     }
 }
 
-/// Flatten the per-epoch transaction map into a list of batches,
-/// chunking each epoch's transactions by `batching.chain_limit()`.
+/// Flatten the per-epoch transaction map into a list of batches.
 /// Batch ids are assigned in iteration order across epochs.
 fn chunk_transactions_into_batches(
     transactions: BTreeMap<EpochSpec, Vec<TransactionSpecification>>,
     batching: BatchingMode,
 ) -> Vec<TransactionsBatchSpecification> {
-    let chain_limit = batching.chain_limit();
     let mut batches = Vec::new();
     for (epoch, epoch_transactions) in transactions {
-        for txs in epoch_transactions.chunks(chain_limit) {
+        for txs in batching.chunks(&epoch_transactions) {
             batches.push(TransactionsBatchSpecification {
                 id: batches.len(),
                 transactions: txs.to_vec(),

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -751,6 +751,51 @@ async fn validate_custom_boot_contracts(
     Ok(failures)
 }
 
+/// Topologically order the project contracts by dependency and emit
+/// each as a publish transaction in the correct epoch bucket. Skips
+/// requirements (their transactions were already emitted by
+/// `resolve_requirements`). Populates `contracts_map` with the
+/// per-contract (source, location) pair the deployment needs.
+fn order_and_schedule_project_contracts(
+    dependencies: &BTreeMap<QualifiedContractIdentifier, DependencySet>,
+    contract_epochs: &HashMap<QualifiedContractIdentifier, StacksEpochId>,
+    requirements_data: &BTreeMap<QualifiedContractIdentifier, (ClarityVersion, ContractAST)>,
+    contracts: &mut HashMap<QualifiedContractIdentifier, TransactionSpecification>,
+    transactions: &mut BTreeMap<EpochSpec, Vec<TransactionSpecification>>,
+    contracts_map: &mut BTreeMap<QualifiedContractIdentifier, (String, PathBuf)>,
+) -> Result<(), String> {
+    let ordered_contracts_ids =
+        ASTDependencyDetector::order_contracts(dependencies, contract_epochs)
+            .map_err(|e| e.to_string())?;
+
+    for contract_id in ordered_contracts_ids.into_iter() {
+        if requirements_data.contains_key(contract_id) {
+            continue;
+        }
+        let tx = contracts
+            .remove(contract_id)
+            .expect("unable to retrieve contract");
+
+        // Both publish variants carry an equivalent (source, location)
+        // pair; pull whichever applies for the deployment manifest.
+        let (source, location) = match &tx {
+            TransactionSpecification::EmulatedContractPublish(data) => {
+                (data.source.clone(), data.location.clone())
+            }
+            TransactionSpecification::ContractPublish(data) => {
+                (data.source.clone(), data.location.clone())
+            }
+            _ => unreachable!(),
+        };
+        contracts_map.insert(contract_id.clone(), (source, location));
+        transactions
+            .entry(contract_epochs[contract_id].into())
+            .or_default()
+            .push(tx);
+    }
+    Ok(())
+}
+
 /// Load the network manifest via the accessor when one was supplied
 /// (LSP, SDK) and from the local filesystem otherwise (CLI).
 async fn load_network_manifest(
@@ -1220,40 +1265,14 @@ pub async fn generate_default_deployment_with_cache(
 
     // Post-loop errors are safe to `?` through: `cache_guard` is still
     // live and its `Drop` will restore `pending` into `cached_asts`.
-    let ordered_contracts_ids =
-        ASTDependencyDetector::order_contracts(&dependencies, &contract_epochs)
-            .map_err(|e| e.to_string())?;
-
-    // Track the latest epoch that a contract is deployed in, so that we can
-    // ensure that all contracts are deployed after their dependencies.
-    for contract_id in ordered_contracts_ids.into_iter() {
-        if requirements_data.contains_key(contract_id) {
-            continue;
-        }
-        let tx = contracts
-            .remove(contract_id)
-            .expect("unable to retrieve contract");
-
-        match tx {
-            TransactionSpecification::EmulatedContractPublish(ref data) => {
-                contracts_map.insert(
-                    contract_id.clone(),
-                    (data.source.clone(), data.location.clone()),
-                );
-            }
-            TransactionSpecification::ContractPublish(ref data) => {
-                contracts_map.insert(
-                    contract_id.clone(),
-                    (data.source.clone(), data.location.clone()),
-                );
-            }
-            _ => unreachable!(),
-        }
-        transactions
-            .entry(contract_epochs[contract_id].into())
-            .or_default()
-            .push(tx);
-    }
+    order_and_schedule_project_contracts(
+        &dependencies,
+        &contract_epochs,
+        &requirements_data,
+        &mut contracts,
+        &mut transactions,
+        &mut contracts_map,
+    )?;
 
     let batches = chunk_transactions_into_batches(transactions, batching);
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -374,18 +374,9 @@ impl Drop for AstCacheRestoreGuard<'_> {
     }
 }
 
-/// Build (or reuse from the cache) the AST for one project contract.
-/// Two paths: callers that opted into caching (LSP) vs callers that
-/// didn't (CLI, SDK). The cache-free path skips hashing, the
-/// `CachedContractAST` construction, and the entry insertion.
-///
-/// TODO: eliminate the `ContractAST.clone()` in the caching path. The
-/// same AST ends up owned in both the returned tuple (→ `artifacts.asts`)
-/// and the guard's pending entry, because both are returned as owned
-/// data in `DeploymentGenerationArtifacts`. ~20ms/build on a 20-contract
-/// project. Requires either wrapping the AST in `Arc`, changing
-/// `detect_dependencies` to accept `&ContractAST`, or collapsing the
-/// two output maps into one — each its own refactor across crates.
+/// Build the AST for one project contract, reusing a cached entry
+/// when present. Returns the same (ast, diags, success) shape on
+/// either path so the caller doesn't have to branch.
 #[allow(clippy::too_many_arguments)]
 fn build_or_reuse_project_ast(
     contract: &ClarityContract,
@@ -404,26 +395,12 @@ fn build_or_reuse_project_ast(
     let content_hash = compute_content_hash(source);
     let cache_key = (contract_location, environment);
 
-    // `try_reuse` removes + validates in one step; a hit transfers
-    // entry ownership straight into the guard (no clone). Anything
-    // left in the caller's input cache after the loop is either a
-    // removed-from-manifest contract or a `(path, env)` key no longer
-    // in use; those drop when the caller releases the map.
-    let cache_entry =
-        match guard.try_reuse(&cache_key, &content_hash, clarity_version, resolved_epoch) {
-            Some(entry) => entry,
-            None => {
-                let (ast, diags, ok) = interpreter.build_ast(contract);
-                CachedContractAST::new(
-                    source,
-                    ast,
-                    diags,
-                    ok,
-                    clarity_version,
-                    resolved_epoch,
-                )
-            }
-        };
+    let cache_entry = guard
+        .try_reuse(&cache_key, &content_hash, clarity_version, resolved_epoch)
+        .unwrap_or_else(|| {
+            let (ast, diags, ok) = interpreter.build_ast(contract);
+            CachedContractAST::new(source, ast, diags, ok, clarity_version, resolved_epoch)
+        });
 
     let ast = cache_entry.ast.clone();
     let diags = cache_entry.diags.clone();
@@ -432,13 +409,12 @@ fn build_or_reuse_project_ast(
     (ast, diags, ok)
 }
 
-/// Whether to chunk publish transactions into 25-tx batches (the
-/// chained-transaction limit per anchor) or pack them into a single
-/// batch. `Chunked` is the default; `Single` is for diffing against
-/// an on-disk plan where consumers want one canonical block per epoch.
+/// How to group publish transactions into batches.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BatchingMode {
+    /// 25-tx chunks (the chained-transaction limit per anchor).
     Chunked,
+    /// One batch per epoch — used for diffing against on-disk plans.
     Single,
 }
 
@@ -451,12 +427,9 @@ impl BatchingMode {
     }
 }
 
-/// Walk every requirement, pull its source (cached locally or fetched
-/// over HTTP), build the AST, infer transitive dependencies, and append
-/// publish transactions in dependency order. Mutates the four output
-/// collections in-place; `requirements_data` is expected to come in
-/// pre-populated with boot-contract ASTs so dependency detection can
-/// resolve references to them.
+/// Fetch + parse requirements, infer dependencies, and append publish
+/// transactions in dependency order. `requirements_data` must come in
+/// pre-seeded with boot-contract ASTs.
 #[allow(clippy::too_many_arguments)]
 async fn resolve_requirements(
     manifest: &ProjectManifest,
@@ -506,8 +479,7 @@ async fn resolve_requirements(
             continue;
         }
 
-        // If a prior cycle already parsed (or pre-loaded) this contract,
-        // we reuse the AST instead of re-fetching/re-parsing.
+        // Reuse a pre-loaded or prior-cycle AST instead of re-fetching.
         let (clarity_version, ast) = match requirements_data.remove(&contract_id) {
             Some(requirement_data) => requirement_data,
             None => {
@@ -555,9 +527,7 @@ async fn resolve_requirements(
                         );
                     }
                     StacksNetwork::Testnet => {
-                        // sBTC ships under a mainnet address; remap it to the
-                        // testnet principal so requirements that reference
-                        // sBTC resolve on testnet.
+                        // sBTC ships under a mainnet address; remap to testnet.
                         let (remap_sender, issuer_target) =
                             if contract_id.issuer.to_string() == SBTC_MAINNET_ADDRESS {
                                 (
@@ -601,8 +571,7 @@ async fn resolve_requirements(
             }
         };
 
-        // Detect dependencies for this AST. `detect_dependencies` takes
-        // a map; we feed it a one-element map and reclaim the AST after.
+        // `detect_dependencies` takes a map; wrap-then-unwrap our one AST.
         let mut contract_data = BTreeMap::new();
         contract_data.insert(contract_id.clone(), (clarity_version, ast));
         let dependencies =
@@ -627,9 +596,8 @@ async fn resolve_requirements(
                 }
             }
             Err((inferable_dependencies, non_inferable_dependencies)) => {
-                // Unknown deps: re-enqueue the current contract behind its
-                // unresolved deps and keep the source in memory to avoid
-                // re-downloading on the retry.
+                // Re-enqueue current contract behind its unresolved deps,
+                // keep source in memory to avoid re-downloading.
                 for (_, dependencies) in inferable_dependencies.iter() {
                     for dependency in dependencies.iter() {
                         queue.push_back(dependency.contract_id.clone());
@@ -645,8 +613,7 @@ async fn resolve_requirements(
         };
     }
 
-    // Mainnet doesn't list requirements as deployment transactions —
-    // they're already published. Same for simnet-with-remote-data.
+    // Mainnet and simnet-with-remote-data: requirements are already on-chain.
     if matches!(network, StacksNetwork::Mainnet) || simnet_remote_data {
         return Ok(());
     }
@@ -685,12 +652,9 @@ async fn resolve_requirements(
     Ok(())
 }
 
-/// Parse each custom boot-contract override and collect any parse-time
-/// diagnostics keyed by contract id. Non-boot names in
-/// `override_boot_contracts_source` are skipped silently — the override
-/// table can contain both replacements and additions, and only
-/// replacements need validation here. Successful parses produce no
-/// entries; an empty return is the success indicator.
+/// Parse custom boot-contract overrides; return per-id diagnostics for
+/// any that failed. Non-boot names in the override table are skipped
+/// (the table can also contain additions, which don't need validation).
 async fn validate_custom_boot_contracts(
     override_boot_contracts_source: &BTreeMap<String, String>,
     manifest: &ProjectManifest,
@@ -718,10 +682,9 @@ async fn validate_custom_boot_contracts(
                     .map_err(|e| {
                         format!("Failed to read boot contract file {resolved_path_string}: {e}")
                     })?;
-                sources
-                    .get(&resolved_path_string)
-                    .cloned()
-                    .ok_or_else(|| format!("Unable to read custom boot contract: {contract_name}"))?
+                sources.get(&resolved_path_string).cloned().ok_or_else(|| {
+                    format!("Unable to read custom boot contract: {contract_name}")
+                })?
             }
         };
 
@@ -771,10 +734,8 @@ fn build_simnet_wallets(
         .collect()
 }
 
-/// Build the `SessionSettings` for the ephemeral interpreter. Disables
-/// remote-data on the repl settings and filters
-/// `override_boot_contracts_source` to simnet (with a warning
-/// otherwise — custom boot contracts only work on simnet).
+/// `SessionSettings` for the ephemeral interpreter. Custom boot
+/// contracts only apply on simnet; warned-and-ignored otherwise.
 fn build_session_settings(manifest: &ProjectManifest, network: &StacksNetwork) -> SessionSettings {
     let mut repl_settings = manifest.repl_settings.clone();
     repl_settings.remote_data.enabled = false;
@@ -795,11 +756,8 @@ fn build_session_settings(manifest: &ProjectManifest, network: &StacksNetwork) -
     }
 }
 
-/// Seed `requirements_data` with the boot-contract ASTs so they can
-/// satisfy dependency lookups, and return the set of boot contract
-/// ids so the caller can filter them out where appropriate. Skipped
-/// entirely when simnet uses remote data (the remote node already
-/// has them).
+/// Seed `requirements_data` with boot-contract ASTs and return their
+/// id set. No-op under simnet-with-remote-data (the node has them).
 fn load_boot_contracts(
     settings: &SessionSettings,
     simnet_remote_data: bool,
@@ -825,11 +783,9 @@ fn load_boot_contracts(
     boot_contracts_ids
 }
 
-/// Topologically order the project contracts by dependency and emit
-/// each as a publish transaction in the correct epoch bucket. Skips
-/// requirements (their transactions were already emitted by
-/// `resolve_requirements`). Populates `contracts_map` with the
-/// per-contract (source, location) pair the deployment needs.
+/// Topologically order project contracts and emit each as a publish
+/// transaction in its epoch bucket. Requirements are skipped (already
+/// emitted by `resolve_requirements`).
 fn order_and_schedule_project_contracts(
     dependencies: &BTreeMap<QualifiedContractIdentifier, DependencySet>,
     contract_epochs: &HashMap<QualifiedContractIdentifier, StacksEpochId>,
@@ -850,8 +806,6 @@ fn order_and_schedule_project_contracts(
             .remove(contract_id)
             .expect("unable to retrieve contract");
 
-        // Both publish variants carry an equivalent (source, location)
-        // pair; pull whichever applies for the deployment manifest.
         let (source, location) = match &tx {
             TransactionSpecification::EmulatedContractPublish(data) => {
                 (data.source.clone(), data.location.clone())
@@ -897,12 +851,17 @@ async fn load_network_manifest(
     }
 }
 
-/// For each contract in the manifest, build (a) the `ClarityContract` /
-/// location pair that the AST-cache loop consumes, and (b) the publish
-/// `TransactionSpecification` that ends up in the deployment plan.
-/// Returns both maps plus a flag indicating whether `#[env(simnet)]`
-/// markers were stripped from any source (OnChain environment only).
-#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+struct ProjectContractSpecs {
+    /// Per-id (contract, path) pair consumed by the AST-cache loop.
+    contracts_sources: HashMap<QualifiedContractIdentifier, (ClarityContract, PathBuf)>,
+    /// Publish transactions that end up in the deployment plan.
+    contracts: HashMap<QualifiedContractIdentifier, TransactionSpecification>,
+    /// True if `#[env(simnet)]` markers were stripped from any source.
+    env_simnet_stripped: bool,
+}
+
+/// Builds the per-contract specs the AST-cache loop and deployment plan
+/// both consume.
 fn build_project_contract_specs(
     manifest: &ProjectManifest,
     network: &StacksNetwork,
@@ -911,14 +870,7 @@ fn build_project_contract_specs(
     default_deployer: &AccountConfig,
     deployment_fee_rate: u64,
     sources: &HashMap<String, String>,
-) -> Result<
-    (
-        HashMap<QualifiedContractIdentifier, (ClarityContract, PathBuf)>,
-        HashMap<QualifiedContractIdentifier, TransactionSpecification>,
-        bool,
-    ),
-    String,
-> {
+) -> Result<ProjectContractSpecs, String> {
     let project_root = &manifest.root_dir;
     let mut contracts_sources = HashMap::new();
     let mut contracts = HashMap::new();
@@ -1003,7 +955,11 @@ fn build_project_contract_specs(
         contracts.insert(contract_id, contract_spec);
     }
 
-    Ok((contracts_sources, contracts, env_simnet_stripped))
+    Ok(ProjectContractSpecs {
+        contracts_sources,
+        contracts,
+        env_simnet_stripped,
+    })
 }
 
 /// Load every contract source listed in the manifest, keyed by
@@ -1059,25 +1015,21 @@ fn chunk_transactions_into_batches(
     batches
 }
 
-/// Pick the (stacks-node, bitcoin-node) RPC URLs for `network`, using
-/// values from the network manifest when set and falling back to the
-/// public endpoints (or devnet localhost) otherwise. Simnet has no
-/// nodes, so both come back `None`.
+/// (stacks-node, bitcoin-node) RPC URLs for `network`. `(None, None)`
+/// for simnet; otherwise the manifest value or a well-known default.
 fn resolve_node_endpoints(
     network: &StacksNetwork,
-    network_manifest: &NetworkManifest,
+    network_manifest: &mut NetworkManifest,
 ) -> (Option<String>, Option<String>) {
-    match network {
-        StacksNetwork::Simnet => (None, None),
+    let (stacks_default, bitcoin_default) = match network {
+        StacksNetwork::Simnet => return (None, None),
         StacksNetwork::Devnet => {
-            let (stacks_node, bitcoin_node) = match &network_manifest.devnet {
-                Some(devnet) => (
-                    format!("http://localhost:{}", devnet.stacks_node_rpc_port),
+            let (stacks, bitcoin) = match &network_manifest.devnet {
+                Some(d) => (
+                    format!("http://localhost:{}", d.stacks_node_rpc_port),
                     format!(
                         "http://{}:{}@localhost:{}",
-                        devnet.bitcoin_node_username,
-                        devnet.bitcoin_node_password,
-                        devnet.bitcoin_node_rpc_port
+                        d.bitcoin_node_username, d.bitcoin_node_password, d.bitcoin_node_rpc_port
                     ),
                 ),
                 None => (
@@ -1085,47 +1037,30 @@ fn resolve_node_endpoints(
                     "http://devnet:devnet@localhost:18443".to_string(),
                 ),
             };
-            (Some(stacks_node), Some(bitcoin_node))
+            return (Some(stacks), Some(bitcoin));
         }
         StacksNetwork::Testnet => (
-            Some(
-                network_manifest
-                    .network
-                    .stacks_node_rpc_address
-                    .clone()
-                    .unwrap_or_else(|| "https://api.testnet.hiro.so".to_string()),
-            ),
-            Some(
-                network_manifest
-                    .network
-                    .bitcoin_node_rpc_address
-                    .clone()
-                    .unwrap_or_else(|| {
-                        "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332"
-                            .to_string()
-                    }),
-            ),
+            "https://api.testnet.hiro.so",
+            "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332",
         ),
         StacksNetwork::Mainnet => (
-            Some(
-                network_manifest
-                    .network
-                    .stacks_node_rpc_address
-                    .clone()
-                    .unwrap_or_else(|| "https://api.hiro.so".to_string()),
-            ),
-            Some(
-                network_manifest
-                    .network
-                    .bitcoin_node_rpc_address
-                    .clone()
-                    .unwrap_or_else(|| {
-                        "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332"
-                            .to_string()
-                    }),
-            ),
+            "https://api.hiro.so",
+            "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332",
         ),
-    }
+    };
+    let net = &mut network_manifest.network;
+    (
+        Some(
+            net.stacks_node_rpc_address
+                .take()
+                .unwrap_or_else(|| stacks_default.to_string()),
+        ),
+        Some(
+            net.bitcoin_node_rpc_address
+                .take()
+                .unwrap_or_else(|| bitcoin_default.to_string()),
+        ),
+    )
 }
 
 pub async fn generate_default_deployment(
@@ -1162,9 +1097,9 @@ pub async fn generate_default_deployment_with_cache(
     cached_asts: Option<&mut HashMap<(PathBuf, Environment), CachedContractAST>>,
 ) -> Result<(DeploymentSpecification, DeploymentGenerationArtifacts, bool), String> {
     let mut found_env_simnet = false;
-    let network_manifest = load_network_manifest(manifest, network, file_accessor).await?;
+    let mut network_manifest = load_network_manifest(manifest, network, file_accessor).await?;
 
-    let (stacks_node, bitcoin_node) = resolve_node_endpoints(network, &network_manifest);
+    let (stacks_node, bitcoin_node) = resolve_node_endpoints(network, &mut network_manifest);
 
     let deployment_fee_rate = network_manifest.network.deployment_fee_rate;
 
@@ -1219,7 +1154,6 @@ pub async fn generate_default_deployment_with_cache(
 
     let mut contract_epochs = HashMap::new();
 
-    // Build the ASTs / DependencySet for requirements (Simnet/Devnet/Testnet/Mainnet)
     if manifest.project.requirements.is_some() {
         resolve_requirements(
             manifest,
@@ -1240,7 +1174,11 @@ pub async fn generate_default_deployment_with_cache(
     }
 
     let sources = load_project_contract_sources(manifest, file_accessor).await?;
-    let (contracts_sources, mut contracts, env_simnet_stripped) = build_project_contract_specs(
+    let ProjectContractSpecs {
+        contracts_sources,
+        mut contracts,
+        env_simnet_stripped,
+    } = build_project_contract_specs(
         manifest,
         network,
         environment,
@@ -1292,11 +1230,9 @@ pub async fn generate_default_deployment_with_cache(
         .map(|(id, (_version, ast))| (id, ast))
         .collect();
 
-    dependencies.extend(
-        boot_contracts_ids
-            .into_iter()
-            .map(|id| (id, DependencySet::new())),
-    );
+    for contract_id in boot_contracts_ids {
+        dependencies.insert(contract_id, DependencySet::new());
+    }
     dependencies.extend(requirements_deps);
 
     // Post-loop errors are safe to `?` through: `cache_guard` is still

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -372,6 +372,64 @@ impl Drop for AstCacheRestoreGuard<'_> {
     }
 }
 
+/// Build (or reuse from the cache) the AST for one project contract.
+/// Two paths: callers that opted into caching (LSP) vs callers that
+/// didn't (CLI, SDK). The cache-free path skips hashing, the
+/// `CachedContractAST` construction, and the entry insertion.
+///
+/// TODO: eliminate the `ContractAST.clone()` in the caching path. The
+/// same AST ends up owned in both the returned tuple (→ `artifacts.asts`)
+/// and the guard's pending entry, because both are returned as owned
+/// data in `DeploymentGenerationArtifacts`. ~20ms/build on a 20-contract
+/// project. Requires either wrapping the AST in `Arc`, changing
+/// `detect_dependencies` to accept `&ContractAST`, or collapsing the
+/// two output maps into one — each its own refactor across crates.
+#[allow(clippy::too_many_arguments)]
+fn build_or_reuse_project_ast(
+    contract: &ClarityContract,
+    contract_location: PathBuf,
+    environment: Environment,
+    clarity_version: ClarityVersion,
+    resolved_epoch: StacksEpochId,
+    interpreter: &ClarityInterpreter,
+    cache_guard: Option<&mut AstCacheRestoreGuard<'_>>,
+) -> (ContractAST, Vec<Diagnostic>, bool) {
+    let Some(guard) = cache_guard else {
+        return interpreter.build_ast(contract);
+    };
+
+    let source = contract.expect_in_memory_code_source();
+    let content_hash = compute_content_hash(source);
+    let cache_key = (contract_location, environment);
+
+    // `try_reuse` removes + validates in one step; a hit transfers
+    // entry ownership straight into the guard (no clone). Anything
+    // left in the caller's input cache after the loop is either a
+    // removed-from-manifest contract or a `(path, env)` key no longer
+    // in use; those drop when the caller releases the map.
+    let cache_entry =
+        match guard.try_reuse(&cache_key, &content_hash, clarity_version, resolved_epoch) {
+            Some(entry) => entry,
+            None => {
+                let (ast, diags, ok) = interpreter.build_ast(contract);
+                CachedContractAST::new(
+                    source,
+                    ast,
+                    diags,
+                    ok,
+                    clarity_version,
+                    resolved_epoch,
+                )
+            }
+        };
+
+    let ast = cache_entry.ast.clone();
+    let diags = cache_entry.diags.clone();
+    let ok = cache_entry.ast_success;
+    guard.insert(cache_key, cache_entry);
+    (ast, diags, ok)
+}
+
 /// Whether to chunk publish transactions into 25-tx batches (the
 /// chained-transaction limit per anchor) or pack them into a single
 /// batch. `Chunked` is the default; `Single` is for diffing against
@@ -1079,69 +1137,18 @@ pub async fn generate_default_deployment_with_cache(
     for (contract_id, (contract, contract_location)) in contracts_sources {
         let resolved_epoch = contract.epoch.resolve();
         let clarity_version = contract.clarity_version;
-
-        // Two paths: callers that opted into caching (LSP) vs callers
-        // that didn't (CLI, SDK). The cache-free path skips hashing,
-        // `CachedContractAST` construction, cache accumulation, and —
-        // not least — the `ContractAST.clone()` into `contract_data`,
-        // since nothing else needs to own a copy.
-        let ast_for_data = if let Some(guard) = cache_guard.as_mut() {
-            let source = contract.expect_in_memory_code_source();
-            let content_hash = compute_content_hash(source);
-            let cache_key = (contract_location, environment);
-
-            // `try_reuse` removes + validates in one step; a hit transfers
-            // entry ownership straight into the guard (no clone). Anything
-            // left in the caller's input cache after the loop is either a
-            // removed-from-manifest contract or a `(path, env)` key no
-            // longer in use; those drop when the caller releases the map.
-            let cache_entry =
-                match guard.try_reuse(&cache_key, &content_hash, clarity_version, resolved_epoch) {
-                    Some(entry) => {
-                        // Re-emit the cached parser diagnostics + success
-                        // flag so downstream diagnostics and the overall
-                        // `asts_success` match what the first parse produced.
-                        contract_diags.insert(contract_id.clone(), entry.diags.clone());
-                        asts_success = asts_success && entry.ast_success;
-                        entry
-                    }
-                    None => {
-                        let (ast, diags, ast_success_for_contract) =
-                            session.interpreter.build_ast(&contract);
-                        contract_diags.insert(contract_id.clone(), diags.clone());
-                        asts_success = asts_success && ast_success_for_contract;
-                        CachedContractAST::new(
-                            source,
-                            ast,
-                            diags,
-                            ast_success_for_contract,
-                            clarity_version,
-                            resolved_epoch,
-                        )
-                    }
-                };
-
-            // TODO: eliminate this `ContractAST.clone()`. The same AST
-            // ends up owned in both `contract_data` (→ `artifacts.asts`)
-            // and the guard's pending entries, because both are returned
-            // as owned data in `DeploymentGenerationArtifacts`. ~20ms/build
-            // on a 20-contract project. Requires either wrapping the AST
-            // in `Arc`, changing `detect_dependencies` in `clarity-repl`
-            // to accept `&ContractAST`, or collapsing the two output
-            // maps into one — each is its own refactor across crates,
-            // so left for a follow-up PR.
-            let ast_for_data = cache_entry.ast.clone();
-            guard.insert(cache_key, cache_entry);
-            ast_for_data
-        } else {
-            // Cache-free path: move the AST straight into contract_data.
-            let (ast, diags, ast_success_for_contract) = session.interpreter.build_ast(&contract);
-            contract_diags.insert(contract_id.clone(), diags);
-            asts_success = asts_success && ast_success_for_contract;
-            ast
-        };
-
-        contract_data.insert(contract_id.clone(), (clarity_version, ast_for_data));
+        let (ast, diags, ok) = build_or_reuse_project_ast(
+            &contract,
+            contract_location,
+            environment,
+            clarity_version,
+            resolved_epoch,
+            &session.interpreter,
+            cache_guard.as_mut(),
+        );
+        contract_diags.insert(contract_id.clone(), diags);
+        asts_success = asts_success && ok;
+        contract_data.insert(contract_id.clone(), (clarity_version, ast));
         contract_epochs.insert(contract_id, resolved_epoch);
     }
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -378,13 +378,10 @@ impl Drop for AstCacheRestoreGuard<'_> {
 /// Build the AST for one project contract, reusing a cached entry
 /// when present. Returns the same (ast, diags, success) shape on
 /// either path so the caller doesn't have to branch.
-#[allow(clippy::too_many_arguments)]
 fn build_or_reuse_project_ast(
     contract: &ClarityContract,
     contract_location: PathBuf,
     environment: Environment,
-    clarity_version: ClarityVersion,
-    resolved_epoch: StacksEpochId,
     interpreter: &ClarityInterpreter,
     cache_guard: Option<&mut AstCacheRestoreGuard<'_>>,
 ) -> (ContractAST, Vec<Diagnostic>, bool) {
@@ -392,6 +389,8 @@ fn build_or_reuse_project_ast(
         return interpreter.build_ast(contract);
     };
 
+    let clarity_version = contract.clarity_version;
+    let resolved_epoch = contract.epoch.resolve();
     let source = contract.expect_in_memory_code_source();
     let content_hash = compute_content_hash(source);
     let cache_key = (contract_location, environment);
@@ -403,6 +402,11 @@ fn build_or_reuse_project_ast(
             CachedContractAST::new(source, ast, diags, ok, clarity_version, resolved_epoch)
         });
 
+    // TODO: drop these clones. The AST + diags end up owned in both the
+    // returned tuple and the guard's pending entry (~20ms/build on a
+    // 20-contract project). Needs `Arc<ContractAST>`, `&ContractAST` in
+    // `detect_dependencies`, or merging the two output maps — each a
+    // cross-crate refactor.
     let ast = cache_entry.ast.clone();
     let diags = cache_entry.diags.clone();
     let ok = cache_entry.ast_success;
@@ -509,45 +513,22 @@ async fn resolve_requirements(
                             },
                         );
                     }
-                    StacksNetwork::Devnet => {
-                        let remap_principals = BTreeMap::from([(
-                            contract_id.issuer.clone(),
-                            default_deployer_address.clone(),
-                        )]);
-                        requirements_publish.insert(
-                            contract_id.clone(),
-                            RequirementPublishSpecification {
-                                contract_id: contract_id.clone(),
-                                remap_sender: default_deployer_address.clone(),
-                                source: source.clone(),
-                                location: contract_location,
-                                cost: deployment_fee_rate * source.len() as u64,
-                                remap_principals,
-                                clarity_version,
-                            },
-                        );
-                    }
-                    StacksNetwork::Testnet => {
-                        // sBTC ships under a mainnet address; remap to testnet.
-                        let (remap_sender, issuer_target) =
-                            if contract_id.issuer.to_string() == SBTC_MAINNET_ADDRESS {
-                                (
-                                    SBTC_TESTNET_ADDRESS_PRINCIPAL.clone(),
-                                    SBTC_TESTNET_ADDRESS_PRINCIPAL.clone(),
-                                )
-                            } else {
-                                (
-                                    default_deployer_address.clone(),
-                                    default_deployer_address.clone(),
-                                )
-                            };
+                    StacksNetwork::Devnet | StacksNetwork::Testnet => {
+                        // sBTC ships under a mainnet address; remap to testnet on testnet.
+                        let remap_target = if matches!(network, StacksNetwork::Testnet)
+                            && contract_id.issuer.to_string() == SBTC_MAINNET_ADDRESS
+                        {
+                            SBTC_TESTNET_ADDRESS_PRINCIPAL.clone()
+                        } else {
+                            default_deployer_address.clone()
+                        };
                         let remap_principals =
-                            BTreeMap::from([(contract_id.issuer.clone(), issuer_target)]);
+                            BTreeMap::from([(contract_id.issuer.clone(), remap_target.clone())]);
                         requirements_publish.insert(
                             contract_id.clone(),
                             RequirementPublishSpecification {
                                 contract_id: contract_id.clone(),
-                                remap_sender,
+                                remap_sender: remap_target,
                                 source: source.clone(),
                                 location: contract_location,
                                 cost: deployment_fee_rate * source.len() as u64,
@@ -904,8 +885,8 @@ fn build_project_contract_specs(
             .clone();
 
         if environment == Environment::OnChain {
-            // Best effort: if the source can't be parsed, fall through to the
-            // analysis pass below which will surface the parse error.
+            // Best effort: parse errors fall through to the later AST
+            // build, which surfaces them with proper location info.
             if let Ok(Some(clean)) = remove_env_simnet(&source) {
                 source = clean;
                 env_simnet_stripped = true;
@@ -1201,14 +1182,12 @@ pub async fn generate_default_deployment_with_cache(
     let mut cache_guard = cached_asts.map(AstCacheRestoreGuard::new);
 
     for (contract_id, (contract, contract_location)) in contracts_sources {
-        let resolved_epoch = contract.epoch.resolve();
         let clarity_version = contract.clarity_version;
+        let resolved_epoch = contract.epoch.resolve();
         let (ast, diags, ok) = build_or_reuse_project_ast(
             &contract,
             contract_location,
             environment,
-            clarity_version,
-            resolved_epoch,
             &session.interpreter,
             cache_guard.as_mut(),
         );

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -391,6 +391,27 @@ impl BatchingMode {
     }
 }
 
+/// Flatten the per-epoch transaction map into a list of batches,
+/// chunking each epoch's transactions by `batching.chain_limit()`.
+/// Batch ids are assigned in iteration order across epochs.
+fn chunk_transactions_into_batches(
+    transactions: BTreeMap<EpochSpec, Vec<TransactionSpecification>>,
+    batching: BatchingMode,
+) -> Vec<TransactionsBatchSpecification> {
+    let chain_limit = batching.chain_limit();
+    let mut batches = Vec::new();
+    for (epoch, epoch_transactions) in transactions {
+        for txs in epoch_transactions.chunks(chain_limit) {
+            batches.push(TransactionsBatchSpecification {
+                id: batches.len(),
+                transactions: txs.to_vec(),
+                epoch: Some(epoch),
+            });
+        }
+    }
+    batches
+}
+
 /// Pick the (stacks-node, bitcoin-node) RPC URLs for `network`, using
 /// values from the network manifest when set and falling back to the
 /// public endpoints (or devnet localhost) otherwise. Simnet has no
@@ -1109,22 +1130,7 @@ pub async fn generate_default_deployment_with_cache(
             .push(tx);
     }
 
-    let tx_chain_limit = batching.chain_limit();
-
-    let mut batches = vec![];
-    let mut batch_count = 0;
-    for (epoch, epoch_transactions) in transactions {
-        for txs in epoch_transactions.chunks(tx_chain_limit) {
-            if !txs.is_empty() {
-                batches.push(TransactionsBatchSpecification {
-                    id: batch_count,
-                    transactions: txs.to_vec(),
-                    epoch: Some(epoch),
-                });
-                batch_count += 1;
-            }
-        }
-    }
+    let batches = chunk_transactions_into_batches(transactions, batching);
 
     let mut wallets = vec![];
     if matches!(network, StacksNetwork::Simnet) {

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -483,7 +483,7 @@ pub async fn generate_default_deployment_with_cache(
         ));
     };
 
-    let mut transactions = BTreeMap::new();
+    let mut transactions: BTreeMap<EpochSpec, Vec<TransactionSpecification>> = BTreeMap::new();
     let mut contracts_map = BTreeMap::new();
     let mut requirements_data = BTreeMap::new();
     let mut requirements_deps = BTreeMap::new();
@@ -785,11 +785,10 @@ pub async fn generate_default_deployment_with_cache(
                         .remove(contract_id)
                         .unwrap_or_else(|| panic!("unable to retrieve contract: {contract_id}"));
                     let tx = TransactionSpecification::EmulatedContractPublish(data);
-                    add_transaction_to_epoch(
-                        &mut transactions,
-                        tx,
-                        &contract_epochs[contract_id].into(),
-                    );
+                    transactions
+                        .entry(contract_epochs[contract_id].into())
+                        .or_default()
+                        .push(tx);
                 }
             } else if matches!(network, StacksNetwork::Devnet | StacksNetwork::Testnet) {
                 for contract_id in ordered_contracts_ids.iter() {
@@ -797,11 +796,10 @@ pub async fn generate_default_deployment_with_cache(
                         .remove(contract_id)
                         .unwrap_or_else(|| panic!("unable to retrieve contract: {contract_id}"));
                     let tx = TransactionSpecification::RequirementPublish(data);
-                    add_transaction_to_epoch(
-                        &mut transactions,
-                        tx,
-                        &contract_epochs[contract_id].into(),
-                    );
+                    transactions
+                        .entry(contract_epochs[contract_id].into())
+                        .or_default()
+                        .push(tx);
                 }
             }
         }
@@ -1059,7 +1057,10 @@ pub async fn generate_default_deployment_with_cache(
             }
             _ => unreachable!(),
         }
-        add_transaction_to_epoch(&mut transactions, tx, &contract_epochs[contract_id].into());
+        transactions
+            .entry(contract_epochs[contract_id].into())
+            .or_default()
+            .push(tx);
     }
 
     let tx_chain_limit = match no_batch {
@@ -1170,21 +1171,6 @@ pub async fn generate_default_deployment_with_cache(
     };
 
     Ok((deployment, artifacts, found_env_simnet))
-}
-
-fn add_transaction_to_epoch(
-    transactions: &mut BTreeMap<EpochSpec, Vec<TransactionSpecification>>,
-    transaction: TransactionSpecification,
-    epoch: &EpochSpec,
-) {
-    let epoch_transactions = match transactions.get_mut(epoch) {
-        Some(v) => v,
-        None => {
-            transactions.insert(*epoch, vec![]);
-            transactions.get_mut(epoch).unwrap()
-        }
-    };
-    epoch_transactions.push(transaction);
 }
 
 pub fn get_default_deployment_path(network: &StacksNetwork) -> &'static str {

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -10,7 +10,9 @@ pub mod types;
 use std::path::{Path, PathBuf};
 
 use clarinet_defaults::DEFAULT_EPOCH;
-use clarinet_files::{paths, FileAccessor, NetworkManifest, ProjectManifest, StacksNetwork};
+use clarinet_files::{
+    paths, AccountConfig, FileAccessor, NetworkManifest, ProjectManifest, StacksNetwork,
+};
 use clarity::types::StacksEpochId;
 use clarity::util::hash::Sha256Sum;
 use clarity::vm::ast::ContractAST;
@@ -749,6 +751,115 @@ async fn validate_custom_boot_contracts(
     Ok(failures)
 }
 
+/// For each contract in the manifest, build (a) the `ClarityContract` /
+/// location pair that the AST-cache loop consumes, and (b) the publish
+/// `TransactionSpecification` that ends up in the deployment plan.
+/// Returns both maps plus a flag indicating whether `#[env(simnet)]`
+/// markers were stripped from any source (OnChain environment only).
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn build_project_contract_specs(
+    manifest: &ProjectManifest,
+    network: &StacksNetwork,
+    environment: Environment,
+    network_manifest: &NetworkManifest,
+    default_deployer: &AccountConfig,
+    deployment_fee_rate: u64,
+    sources: &HashMap<String, String>,
+) -> Result<
+    (
+        HashMap<QualifiedContractIdentifier, (ClarityContract, PathBuf)>,
+        HashMap<QualifiedContractIdentifier, TransactionSpecification>,
+        bool,
+    ),
+    String,
+> {
+    let project_root = &manifest.root_dir;
+    let mut contracts_sources = HashMap::new();
+    let mut contracts = HashMap::new();
+    let mut env_simnet_stripped = false;
+
+    for (name, contract_config) in manifest.contracts.iter() {
+        let Ok(contract_name) = ContractName::try_from(name.to_string()) else {
+            return Err(format!("unable to use {name} as a valid contract name"));
+        };
+
+        let deployer = match &contract_config.deployer {
+            ContractDeployer::DefaultDeployer => default_deployer,
+            ContractDeployer::LabeledDeployer(deployer) => network_manifest
+                .accounts
+                .get(deployer)
+                .ok_or_else(|| format!("unable to retrieve account '{deployer}'"))?,
+            _ => unreachable!(),
+        };
+
+        let Ok(sender) = PrincipalData::parse_standard_principal(&deployer.stx_address) else {
+            return Err(format!(
+                "unable to turn emulated_sender {} as a valid Stacks address",
+                deployer.stx_address
+            ));
+        };
+
+        let contract_location = project_root.join(contract_config.expect_contract_path_as_str());
+        let mut source = sources
+            .get(contract_location.to_string_lossy().as_ref())
+            .ok_or_else(|| format!("Invalid Clarinet.toml, source file not found for: {name}"))?
+            .clone();
+
+        if environment == Environment::OnChain {
+            // Best effort: if the source can't be parsed, fall through to the
+            // analysis pass below which will surface the parse error.
+            if let Ok(Some(clean)) = remove_env_simnet(&source) {
+                source = clean;
+                env_simnet_stripped = true;
+            }
+        }
+
+        let contract_id = QualifiedContractIdentifier::new(sender.clone(), contract_name.clone());
+        let epoch = contract_config.epoch.resolve();
+
+        contracts_sources.insert(
+            contract_id.clone(),
+            (
+                ClarityContract {
+                    code_source: ClarityCodeSource::ContractInMemory(source.clone()),
+                    deployer: ContractDeployer::Address(sender.to_address()),
+                    name: contract_name.to_string(),
+                    clarity_version: contract_config.clarity_version,
+                    epoch: clarity_repl::repl::Epoch::Specific(epoch),
+                    skip_analysis: false,
+                },
+                contract_location.clone(),
+            ),
+        );
+
+        let contract_spec = if matches!(network, StacksNetwork::Simnet) {
+            TransactionSpecification::EmulatedContractPublish(
+                EmulatedContractPublishSpecification {
+                    contract_name,
+                    emulated_sender: sender,
+                    source,
+                    location: contract_location,
+                    clarity_version: contract_config.clarity_version,
+                    skip_analysis: false,
+                },
+            )
+        } else {
+            TransactionSpecification::ContractPublish(ContractPublishSpecification {
+                contract_name,
+                expected_sender: sender,
+                location: contract_location,
+                cost: deployment_fee_rate.saturating_mul(source.len().try_into().unwrap()),
+                source,
+                anchor_block_only: true,
+                clarity_version: contract_config.clarity_version,
+            })
+        };
+        contracts.insert(contract_id, contract_spec);
+    }
+
+    Ok((contracts_sources, contracts, env_simnet_stripped))
+}
+
 /// Load every contract source listed in the manifest, keyed by
 /// absolute path (as a string). Uses the file accessor when supplied
 /// (LSP, SDK) and the local filesystem otherwise (CLI).
@@ -1032,97 +1143,17 @@ pub async fn generate_default_deployment_with_cache(
         .await?;
     }
 
-    let mut contracts = HashMap::new();
-    let mut contracts_sources = HashMap::new();
-
-    let project_root = &manifest.root_dir;
     let sources = load_project_contract_sources(manifest, file_accessor).await?;
-
-    for (name, contract_config) in manifest.contracts.iter() {
-        let Ok(contract_name) = ContractName::try_from(name.to_string()) else {
-            return Err(format!("unable to use {name} as a valid contract name"));
-        };
-
-        let deployer = match &contract_config.deployer {
-            ContractDeployer::DefaultDeployer => default_deployer,
-            ContractDeployer::LabeledDeployer(deployer) => {
-                let Some(deployer) = network_manifest.accounts.get(deployer) else {
-                    return Err(format!("unable to retrieve account '{deployer}'"));
-                };
-                deployer
-            }
-            _ => unreachable!(),
-        };
-
-        let Ok(sender) = PrincipalData::parse_standard_principal(&deployer.stx_address) else {
-            return Err(format!(
-                "unable to turn emulated_sender {} as a valid Stacks address",
-                deployer.stx_address
-            ));
-        };
-
-        let contract_location = project_root.join(contract_config.expect_contract_path_as_str());
-        let mut source = sources
-            .get(contract_location.to_string_lossy().as_ref())
-            .ok_or(format!(
-                "Invalid Clarinet.toml, source file not found for: {}",
-                &name
-            ))?
-            .clone();
-
-        if environment == Environment::OnChain {
-            // Best effort: if the source can't be parsed, fall through to the
-            // analysis pass below which will surface the parse error.
-            if let Ok(Some(clean)) = remove_env_simnet(&source) {
-                source = clean;
-                found_env_simnet = true;
-            }
-        }
-
-        let contract_id = QualifiedContractIdentifier::new(sender.clone(), contract_name.clone());
-
-        let epoch = contract_config.epoch.resolve();
-
-        contracts_sources.insert(
-            contract_id.clone(),
-            (
-                ClarityContract {
-                    code_source: ClarityCodeSource::ContractInMemory(source.clone()),
-                    deployer: ContractDeployer::Address(sender.to_address()),
-                    name: contract_name.to_string(),
-                    clarity_version: contract_config.clarity_version,
-                    epoch: clarity_repl::repl::Epoch::Specific(epoch),
-                    skip_analysis: false,
-                },
-                contract_location.clone(),
-            ),
-        );
-
-        let contract_spec = if matches!(network, StacksNetwork::Simnet) {
-            TransactionSpecification::EmulatedContractPublish(
-                EmulatedContractPublishSpecification {
-                    contract_name,
-                    emulated_sender: sender,
-                    source,
-                    location: contract_location,
-                    clarity_version: contract_config.clarity_version,
-                    skip_analysis: false,
-                },
-            )
-        } else {
-            TransactionSpecification::ContractPublish(ContractPublishSpecification {
-                contract_name,
-                expected_sender: sender,
-                location: contract_location,
-                cost: deployment_fee_rate.saturating_mul(source.len().try_into().unwrap()),
-                source,
-                anchor_block_only: true,
-                clarity_version: contract_config.clarity_version,
-            })
-        };
-
-        contracts.insert(contract_id, contract_spec);
-    }
+    let (contracts_sources, mut contracts, env_simnet_stripped) = build_project_contract_specs(
+        manifest,
+        network,
+        environment,
+        &network_manifest,
+        default_deployer,
+        deployment_fee_rate,
+        &sources,
+    )?;
+    found_env_simnet |= env_simnet_stripped;
 
     let session = Session::new(settings);
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -15,7 +15,7 @@ use clarity::types::StacksEpochId;
 use clarity::util::hash::Sha256Sum;
 use clarity::vm::ast::ContractAST;
 use clarity::vm::diagnostic::Diagnostic;
-use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
+use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
 use clarity::vm::{
     ClarityVersion, ContractName, EvaluationResult, ExecutionResult, SymbolicExpression,
 };
@@ -391,6 +391,72 @@ impl BatchingMode {
     }
 }
 
+/// Parse each custom boot-contract override and collect any parse-time
+/// diagnostics keyed by contract id. Non-boot names in
+/// `override_boot_contracts_source` are skipped silently — the override
+/// table can contain both replacements and additions, and only
+/// replacements need validation here. Successful parses produce no
+/// entries; an empty return is the success indicator.
+async fn validate_custom_boot_contracts(
+    override_boot_contracts_source: &BTreeMap<String, String>,
+    manifest: &ProjectManifest,
+    file_accessor: Option<&dyn FileAccessor>,
+    interpreter: &ClarityInterpreter,
+    default_deployer_address: &StandardPrincipalData,
+) -> Result<HashMap<QualifiedContractIdentifier, Vec<Diagnostic>>, String> {
+    let mut failures = HashMap::new();
+    for (contract_name, file_path) in override_boot_contracts_source {
+        if !clarity_repl::repl::boot::BOOT_CONTRACTS_NAMES.contains(&contract_name.as_str()) {
+            continue;
+        }
+
+        let resolved_path = manifest.root_dir.join(file_path);
+        let resolved_path_string = resolved_path.to_string_lossy().into_owned();
+
+        let custom_source = match file_accessor {
+            None => std::fs::read_to_string(&resolved_path_string).map_err(|e| {
+                format!("Failed to read boot contract file {resolved_path_string}: {e}")
+            })?,
+            Some(file_accessor) => {
+                let sources = file_accessor
+                    .read_files(vec![resolved_path_string.clone()])
+                    .await
+                    .map_err(|e| {
+                        format!("Failed to read boot contract file {resolved_path_string}: {e}")
+                    })?;
+                sources
+                    .get(&resolved_path_string)
+                    .cloned()
+                    .ok_or_else(|| format!("Unable to read custom boot contract: {contract_name}"))?
+            }
+        };
+
+        let (epoch, clarity_version) =
+            get_boot_contract_epoch_and_clarity_version(contract_name.as_str());
+
+        let temp_contract = ClarityContract {
+            code_source: ClarityCodeSource::ContractInMemory(custom_source),
+            deployer: ContractDeployer::Address(default_deployer_address.to_address()),
+            name: contract_name.clone(),
+            clarity_version,
+            epoch: clarity_repl::repl::Epoch::Specific(epoch),
+            skip_analysis: false,
+        };
+
+        let (_, diagnostics, ast_success) = interpreter.build_ast(&temp_contract);
+
+        if !ast_success {
+            let contract_id = QualifiedContractIdentifier::new(
+                default_deployer_address.clone(),
+                ContractName::try_from(contract_name.clone())
+                    .unwrap_or_else(|_| ContractName::from_literal("unknown")),
+            );
+            failures.insert(contract_id, diagnostics);
+        }
+    }
+    Ok(failures)
+}
+
 /// Load every contract source listed in the manifest, keyed by
 /// absolute path (as a string). Uses the file accessor when supplied
 /// (LSP, SDK) and the local filesystem otherwise (CLI).
@@ -637,66 +703,18 @@ pub async fn generate_default_deployment_with_cache(
     let mut contract_diags: HashMap<QualifiedContractIdentifier, Vec<Diagnostic>> = HashMap::new();
     let mut asts_success = true;
 
-    // Validate custom boot contracts from override_boot_contracts_source
     if !settings.override_boot_contracts_source.is_empty() && !simnet_remote_data {
-        for (contract_name, file_path) in &settings.override_boot_contracts_source {
-            // Only validate existing boot contracts that are being overridden
-            if !clarity_repl::repl::boot::BOOT_CONTRACTS_NAMES.contains(&contract_name.as_str()) {
-                continue;
-            }
-
-            let resolved_path = manifest.root_dir.join(file_path);
-            let resolved_path_string = resolved_path.to_string_lossy().into_owned();
-
-            // Load and validate the custom boot contract
-            let custom_source = match file_accessor {
-                None => {
-                    // Fallback to file system when no file_accessor is provided
-                    std::fs::read_to_string(&resolved_path_string).map_err(|e| {
-                        format!("Failed to read boot contract file {resolved_path_string}: {e}")
-                    })
-                }
-                Some(file_accessor) => {
-                    let sources = file_accessor
-                        .read_files(vec![resolved_path_string.clone()])
-                        .await
-                        .map_err(|e| {
-                            format!("Failed to read boot contract file {resolved_path_string}: {e}")
-                        })?;
-                    sources
-                        .get(&resolved_path_string)
-                        .ok_or_else(|| {
-                            format!("Unable to read custom boot contract: {contract_name}")
-                        })
-                        .cloned()
-                }
-            }?;
-
-            let (epoch, clarity_version) =
-                get_boot_contract_epoch_and_clarity_version(contract_name.as_str());
-
-            let temp_contract = ClarityContract {
-                code_source: ClarityCodeSource::ContractInMemory(custom_source),
-                deployer: ContractDeployer::Address(default_deployer_address.to_address()),
-                name: contract_name.clone(),
-                clarity_version,
-                epoch: clarity_repl::repl::Epoch::Specific(epoch),
-                skip_analysis: false,
-            };
-
-            let (_, diagnostics, ast_success) = interpreter.build_ast(&temp_contract);
-
-            if !ast_success {
-                contract_diags.insert(
-                    QualifiedContractIdentifier::new(
-                        default_deployer_address.clone(),
-                        ContractName::try_from(contract_name.clone())
-                            .unwrap_or_else(|_| ContractName::from_literal("unknown")),
-                    ),
-                    diagnostics,
-                );
-                asts_success = false;
-            }
+        let failures = validate_custom_boot_contracts(
+            &settings.override_boot_contracts_source,
+            manifest,
+            file_accessor,
+            &interpreter,
+            &default_deployer_address,
+        )
+        .await?;
+        if !failures.is_empty() {
+            asts_success = false;
+            contract_diags.extend(failures);
         }
     }
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -391,6 +391,75 @@ impl BatchingMode {
     }
 }
 
+/// Pick the (stacks-node, bitcoin-node) RPC URLs for `network`, using
+/// values from the network manifest when set and falling back to the
+/// public endpoints (or devnet localhost) otherwise. Simnet has no
+/// nodes, so both come back `None`.
+fn resolve_node_endpoints(
+    network: &StacksNetwork,
+    network_manifest: &NetworkManifest,
+) -> (Option<String>, Option<String>) {
+    match network {
+        StacksNetwork::Simnet => (None, None),
+        StacksNetwork::Devnet => {
+            let (stacks_node, bitcoin_node) = match &network_manifest.devnet {
+                Some(devnet) => (
+                    format!("http://localhost:{}", devnet.stacks_node_rpc_port),
+                    format!(
+                        "http://{}:{}@localhost:{}",
+                        devnet.bitcoin_node_username,
+                        devnet.bitcoin_node_password,
+                        devnet.bitcoin_node_rpc_port
+                    ),
+                ),
+                None => (
+                    "http://localhost:20443".to_string(),
+                    "http://devnet:devnet@localhost:18443".to_string(),
+                ),
+            };
+            (Some(stacks_node), Some(bitcoin_node))
+        }
+        StacksNetwork::Testnet => (
+            Some(
+                network_manifest
+                    .network
+                    .stacks_node_rpc_address
+                    .clone()
+                    .unwrap_or_else(|| "https://api.testnet.hiro.so".to_string()),
+            ),
+            Some(
+                network_manifest
+                    .network
+                    .bitcoin_node_rpc_address
+                    .clone()
+                    .unwrap_or_else(|| {
+                        "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332"
+                            .to_string()
+                    }),
+            ),
+        ),
+        StacksNetwork::Mainnet => (
+            Some(
+                network_manifest
+                    .network
+                    .stacks_node_rpc_address
+                    .clone()
+                    .unwrap_or_else(|| "https://api.hiro.so".to_string()),
+            ),
+            Some(
+                network_manifest
+                    .network
+                    .bitcoin_node_rpc_address
+                    .clone()
+                    .unwrap_or_else(|| {
+                        "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332"
+                            .to_string()
+                    }),
+            ),
+        ),
+    }
+}
+
 pub async fn generate_default_deployment(
     manifest: &ProjectManifest,
     network: &StacksNetwork,
@@ -444,49 +513,7 @@ pub async fn generate_default_deployment_with_cache(
         }
     };
 
-    let (stacks_node, bitcoin_node) = match network {
-        StacksNetwork::Simnet => (None, None),
-        StacksNetwork::Devnet => {
-            let (stacks_node, bitcoin_node) = match network_manifest.devnet {
-                Some(ref devnet) => {
-                    let stacks_node = format!("http://localhost:{}", devnet.stacks_node_rpc_port);
-                    let bitcoin_node = format!(
-                        "http://{}:{}@localhost:{}",
-                        devnet.bitcoin_node_username,
-                        devnet.bitcoin_node_password,
-                        devnet.bitcoin_node_rpc_port
-                    );
-                    (stacks_node, bitcoin_node)
-                }
-                None => {
-                    let stacks_node = "http://localhost:20443".to_string();
-                    let bitcoin_node = "http://devnet:devnet@localhost:18443".to_string();
-                    (stacks_node, bitcoin_node)
-                }
-            };
-            (Some(stacks_node), Some(bitcoin_node))
-        }
-        StacksNetwork::Testnet => {
-            let stacks_node = network_manifest
-                .network
-                .stacks_node_rpc_address
-                .unwrap_or("https://api.testnet.hiro.so".to_string());
-            let bitcoin_node = network_manifest.network.bitcoin_node_rpc_address.unwrap_or(
-                "http://blockstack:blockstacksystem@bitcoind.testnet.stacks.co:18332".to_string(),
-            );
-            (Some(stacks_node), Some(bitcoin_node))
-        }
-        StacksNetwork::Mainnet => {
-            let stacks_node = network_manifest
-                .network
-                .stacks_node_rpc_address
-                .unwrap_or("https://api.hiro.so".to_string());
-            let bitcoin_node = network_manifest.network.bitcoin_node_rpc_address.unwrap_or(
-                "http://blockstack:blockstacksystem@bitcoin.blockstack.com:8332".to_string(),
-            );
-            (Some(stacks_node), Some(bitcoin_node))
-        }
-    };
+    let (stacks_node, bitcoin_node) = resolve_node_endpoints(network, &network_manifest);
 
     let deployment_fee_rate = network_manifest.network.deployment_fee_rate;
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -751,6 +751,26 @@ async fn validate_custom_boot_contracts(
     Ok(failures)
 }
 
+/// Turn the network-manifest accounts into wallet specs for the simnet
+/// genesis block.
+fn build_simnet_wallets(
+    accounts: BTreeMap<String, AccountConfig>,
+) -> Result<Vec<WalletSpecification>, String> {
+    accounts
+        .into_iter()
+        .map(|(name, account)| {
+            let address = PrincipalData::parse_standard_principal(&account.stx_address)
+                .map_err(|_| format!("unable to parse address {}", account.stx_address))?;
+            Ok(WalletSpecification {
+                name,
+                address,
+                balance: account.balance.into(),
+                sbtc_balance: account.sbtc_balance.into(),
+            })
+        })
+        .collect()
+}
+
 /// Build the `SessionSettings` for the ephemeral interpreter. Disables
 /// remote-data on the repl settings and filters
 /// `override_boot_contracts_source` to simnet (with a warning
@@ -1297,19 +1317,11 @@ pub async fn generate_default_deployment_with_cache(
 
     let batches = chunk_transactions_into_batches(transactions, batching);
 
-    let mut wallets = vec![];
-    if matches!(network, StacksNetwork::Simnet) {
-        for (name, account) in network_manifest.accounts {
-            let address = PrincipalData::parse_standard_principal(&account.stx_address)
-                .map_err(|_| format!("unable to parse address {}", account.stx_address))?;
-            wallets.push(WalletSpecification {
-                name,
-                address,
-                balance: account.balance.into(),
-                sbtc_balance: account.sbtc_balance.into(),
-            });
-        }
-    }
+    let wallets = if matches!(network, StacksNetwork::Simnet) {
+        build_simnet_wallets(network_manifest.accounts)?
+    } else {
+        Vec::new()
+    };
 
     let name = match network {
         StacksNetwork::Simnet => "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`".to_string(),

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -1279,17 +1279,11 @@ pub async fn generate_default_deployment_with_cache(
         contract_epochs.insert(contract_id, resolved_epoch);
     }
 
-    let dependencies =
-        ASTDependencyDetector::detect_dependencies(&contract_data, &requirements_data);
-
-    let mut dependencies = match dependencies {
-        Ok(dependencies) => dependencies,
-        Err((dependencies, _)) => {
-            // No need to report an error here, it will be caught and reported
-            // with proper location information by the later analyses.
-            dependencies
-        }
-    };
+    // Failures are intentionally not reported here — later analyses
+    // surface them with proper location information.
+    let mut dependencies =
+        ASTDependencyDetector::detect_dependencies(&contract_data, &requirements_data)
+            .unwrap_or_else(|(deps, _)| deps);
 
     // `contract_data` is no longer borrowed; consume it for the final
     // `asts` output so we don't clone each AST a second time.
@@ -1298,10 +1292,11 @@ pub async fn generate_default_deployment_with_cache(
         .map(|(id, (_version, ast))| (id, ast))
         .collect();
 
-    for contract_id in boot_contracts_ids.into_iter() {
-        dependencies.insert(contract_id.clone(), DependencySet::new());
-    }
-
+    dependencies.extend(
+        boot_contracts_ids
+            .into_iter()
+            .map(|id| (id, DependencySet::new())),
+    );
     dependencies.extend(requirements_deps);
 
     // Post-loop errors are safe to `?` through: `cache_guard` is still

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -372,10 +372,29 @@ impl Drop for AstCacheRestoreGuard<'_> {
     }
 }
 
+/// Whether to chunk publish transactions into 25-tx batches (the
+/// chained-transaction limit per anchor) or pack them into a single
+/// batch. `Chunked` is the default; `Single` is for diffing against
+/// an on-disk plan where consumers want one canonical block per epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BatchingMode {
+    Chunked,
+    Single,
+}
+
+impl BatchingMode {
+    fn chain_limit(self) -> usize {
+        match self {
+            BatchingMode::Chunked => 25,
+            BatchingMode::Single => 100_000,
+        }
+    }
+}
+
 pub async fn generate_default_deployment(
     manifest: &ProjectManifest,
     network: &StacksNetwork,
-    no_batch: bool,
+    batching: BatchingMode,
     file_accessor: Option<&dyn FileAccessor>,
     api_base_url: Option<&str>,
     environment: Environment,
@@ -383,7 +402,7 @@ pub async fn generate_default_deployment(
     generate_default_deployment_with_cache(
         manifest,
         network,
-        no_batch,
+        batching,
         file_accessor,
         api_base_url,
         environment,
@@ -395,7 +414,7 @@ pub async fn generate_default_deployment(
 pub async fn generate_default_deployment_with_cache(
     manifest: &ProjectManifest,
     network: &StacksNetwork,
-    no_batch: bool,
+    batching: BatchingMode,
     file_accessor: Option<&dyn FileAccessor>,
     api_base_url: Option<&str>,
     environment: Environment,
@@ -1063,10 +1082,7 @@ pub async fn generate_default_deployment_with_cache(
             .push(tx);
     }
 
-    let tx_chain_limit = match no_batch {
-        true => 100_000,
-        false => 25,
-    };
+    let tx_chain_limit = batching.chain_limit();
 
     let mut batches = vec![];
     let mut batch_count = 0;

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -391,6 +391,240 @@ impl BatchingMode {
     }
 }
 
+/// Walk every requirement, pull its source (cached locally or fetched
+/// over HTTP), build the AST, infer transitive dependencies, and append
+/// publish transactions in dependency order. Mutates the four output
+/// collections in-place; `requirements_data` is expected to come in
+/// pre-populated with boot-contract ASTs so dependency detection can
+/// resolve references to them.
+#[allow(clippy::too_many_arguments)]
+async fn resolve_requirements(
+    manifest: &ProjectManifest,
+    network: &StacksNetwork,
+    simnet_remote_data: bool,
+    file_accessor: Option<&dyn FileAccessor>,
+    api_base_url: Option<&str>,
+    interpreter: &ClarityInterpreter,
+    default_deployer_address: &StandardPrincipalData,
+    deployment_fee_rate: u64,
+    boot_contracts_ids: &BTreeSet<QualifiedContractIdentifier>,
+    requirements_data: &mut BTreeMap<QualifiedContractIdentifier, (ClarityVersion, ContractAST)>,
+    requirements_deps: &mut BTreeMap<QualifiedContractIdentifier, DependencySet>,
+    contract_epochs: &mut HashMap<QualifiedContractIdentifier, StacksEpochId>,
+    transactions: &mut BTreeMap<EpochSpec, Vec<TransactionSpecification>>,
+) -> Result<(), String> {
+    let Some(requirements) = manifest.project.requirements.as_ref() else {
+        return Ok(());
+    };
+
+    let mut emulated_contracts_publish = HashMap::new();
+    let mut requirements_publish = HashMap::new();
+    let mut queue = VecDeque::new();
+
+    // sbtc-deposit transitively depends on sbtc-token, so users tend to
+    // list only sbtc-token. Pull sbtc-deposit in too when that's the case.
+    if requirements
+        .iter()
+        .any(|r| r.contract_id == SBTC_TOKEN_MAINNET_ADDRESS.to_string())
+        && !requirements
+            .iter()
+            .any(|r| r.contract_id == SBTC_DEPOSIT_MAINNET_ADDRESS.to_string())
+    {
+        queue.push_front(
+            QualifiedContractIdentifier::parse(&SBTC_DEPOSIT_MAINNET_ADDRESS.to_string()).unwrap(),
+        );
+    }
+
+    for requirement in requirements.iter() {
+        let contract_id = QualifiedContractIdentifier::parse(&requirement.contract_id)
+            .map_err(|_e| format!("malformatted contract_id: {}", requirement.contract_id))?;
+        queue.push_front(contract_id);
+    }
+
+    while let Some(contract_id) = queue.pop_front() {
+        if requirements_deps.contains_key(&contract_id) {
+            continue;
+        }
+
+        // If a prior cycle already parsed (or pre-loaded) this contract,
+        // we reuse the AST instead of re-fetching/re-parsing.
+        let (clarity_version, ast) = match requirements_data.remove(&contract_id) {
+            Some(requirement_data) => requirement_data,
+            None => {
+                let (source, epoch, clarity_version, contract_location) =
+                    requirements::retrieve_contract(
+                        &contract_id,
+                        &manifest.project.cache_location,
+                        &file_accessor,
+                        api_base_url,
+                    )
+                    .await?;
+
+                contract_epochs.insert(contract_id.clone(), epoch);
+
+                match network {
+                    StacksNetwork::Simnet if !simnet_remote_data => {
+                        emulated_contracts_publish.insert(
+                            contract_id.clone(),
+                            EmulatedContractPublishSpecification {
+                                contract_name: contract_id.name.clone(),
+                                emulated_sender: contract_id.issuer.clone(),
+                                source: source.clone(),
+                                location: contract_location,
+                                clarity_version,
+                                skip_analysis: true,
+                            },
+                        );
+                    }
+                    StacksNetwork::Devnet => {
+                        let remap_principals = BTreeMap::from([(
+                            contract_id.issuer.clone(),
+                            default_deployer_address.clone(),
+                        )]);
+                        requirements_publish.insert(
+                            contract_id.clone(),
+                            RequirementPublishSpecification {
+                                contract_id: contract_id.clone(),
+                                remap_sender: default_deployer_address.clone(),
+                                source: source.clone(),
+                                location: contract_location,
+                                cost: deployment_fee_rate * source.len() as u64,
+                                remap_principals,
+                                clarity_version,
+                            },
+                        );
+                    }
+                    StacksNetwork::Testnet => {
+                        // sBTC ships under a mainnet address; remap it to the
+                        // testnet principal so requirements that reference
+                        // sBTC resolve on testnet.
+                        let (remap_sender, issuer_target) =
+                            if contract_id.issuer.to_string() == SBTC_MAINNET_ADDRESS {
+                                (
+                                    SBTC_TESTNET_ADDRESS_PRINCIPAL.clone(),
+                                    SBTC_TESTNET_ADDRESS_PRINCIPAL.clone(),
+                                )
+                            } else {
+                                (
+                                    default_deployer_address.clone(),
+                                    default_deployer_address.clone(),
+                                )
+                            };
+                        let remap_principals =
+                            BTreeMap::from([(contract_id.issuer.clone(), issuer_target)]);
+                        requirements_publish.insert(
+                            contract_id.clone(),
+                            RequirementPublishSpecification {
+                                contract_id: contract_id.clone(),
+                                remap_sender,
+                                source: source.clone(),
+                                location: contract_location,
+                                cost: deployment_fee_rate * source.len() as u64,
+                                remap_principals,
+                                clarity_version,
+                            },
+                        );
+                    }
+                    _ => {}
+                }
+
+                let contract = ClarityContract {
+                    code_source: ClarityCodeSource::ContractInMemory(source),
+                    name: contract_id.name.to_string(),
+                    deployer: ContractDeployer::ContractIdentifier(contract_id.clone()),
+                    clarity_version,
+                    epoch: clarity_repl::repl::Epoch::Specific(epoch),
+                    skip_analysis: true,
+                };
+                let (ast, _, _) = interpreter.build_ast(&contract);
+                (clarity_version, ast)
+            }
+        };
+
+        // Detect dependencies for this AST. `detect_dependencies` takes
+        // a map; we feed it a one-element map and reclaim the AST after.
+        let mut contract_data = BTreeMap::new();
+        contract_data.insert(contract_id.clone(), (clarity_version, ast));
+        let dependencies =
+            ASTDependencyDetector::detect_dependencies(&contract_data, requirements_data);
+        let (_, ast) = contract_data
+            .remove(&contract_id)
+            .expect("unable to retrieve ast");
+
+        match dependencies {
+            Ok(inferable_dependencies) => {
+                if inferable_dependencies.len() > 1 {
+                    println!("warning: inferable_dependencies contains more than one entry");
+                }
+                // We submitted one contract, so at most one result.
+                if let Some((contract_id, dependencies)) = inferable_dependencies.into_iter().next()
+                {
+                    for dependency in dependencies.iter() {
+                        queue.push_back(dependency.contract_id.clone());
+                    }
+                    requirements_deps.insert(contract_id.clone(), dependencies);
+                    requirements_data.insert(contract_id.clone(), (clarity_version, ast));
+                }
+            }
+            Err((inferable_dependencies, non_inferable_dependencies)) => {
+                // Unknown deps: re-enqueue the current contract behind its
+                // unresolved deps and keep the source in memory to avoid
+                // re-downloading on the retry.
+                for (_, dependencies) in inferable_dependencies.iter() {
+                    for dependency in dependencies.iter() {
+                        queue.push_back(dependency.contract_id.clone());
+                    }
+                }
+                requirements_data.insert(contract_id.clone(), (clarity_version, ast));
+                queue.push_front(contract_id);
+
+                for non_inferable_contract_id in non_inferable_dependencies.into_iter() {
+                    queue.push_front(non_inferable_contract_id);
+                }
+            }
+        };
+    }
+
+    // Mainnet doesn't list requirements as deployment transactions —
+    // they're already published. Same for simnet-with-remote-data.
+    if matches!(network, StacksNetwork::Mainnet) || simnet_remote_data {
+        return Ok(());
+    }
+
+    let mut ordered_contracts_ids =
+        ASTDependencyDetector::order_contracts(requirements_deps, contract_epochs)
+            .map_err(|e| format!("unable to order requirements {e}"))?;
+    ordered_contracts_ids.retain(|contract_id| !boot_contracts_ids.contains(contract_id));
+
+    match network {
+        StacksNetwork::Simnet => {
+            for contract_id in ordered_contracts_ids.iter() {
+                let data = emulated_contracts_publish
+                    .remove(contract_id)
+                    .unwrap_or_else(|| panic!("unable to retrieve contract: {contract_id}"));
+                transactions
+                    .entry(contract_epochs[contract_id].into())
+                    .or_default()
+                    .push(TransactionSpecification::EmulatedContractPublish(data));
+            }
+        }
+        StacksNetwork::Devnet | StacksNetwork::Testnet => {
+            for contract_id in ordered_contracts_ids.iter() {
+                let data = requirements_publish
+                    .remove(contract_id)
+                    .unwrap_or_else(|| panic!("unable to retrieve contract: {contract_id}"));
+                transactions
+                    .entry(contract_epochs[contract_id].into())
+                    .or_default()
+                    .push(TransactionSpecification::RequirementPublish(data));
+            }
+        }
+        StacksNetwork::Mainnet => unreachable!("returned above"),
+    }
+
+    Ok(())
+}
+
 /// Parse each custom boot-contract override and collect any parse-time
 /// diagnostics keyed by contract id. Non-boot names in
 /// `override_boot_contracts_source` are skipped silently — the override
@@ -718,208 +952,26 @@ pub async fn generate_default_deployment_with_cache(
         }
     }
 
-    let mut queue = VecDeque::new();
-
     let mut contract_epochs = HashMap::new();
 
-    // Build the ASTs / DependencySet for requirements - step required for Simnet/Devnet/Testnet/Mainnet
-    if let Some(ref requirements) = manifest.project.requirements {
-        let mut emulated_contracts_publish = HashMap::new();
-        let mut requirements_publish = HashMap::new();
-
-        // automatically add sbtc-deposit if only sbtc-token is present
-        if requirements
-            .iter()
-            .any(|r| r.contract_id == SBTC_TOKEN_MAINNET_ADDRESS.to_string())
-            && !requirements
-                .iter()
-                .any(|r| r.contract_id == SBTC_DEPOSIT_MAINNET_ADDRESS.to_string())
-        {
-            queue.push_front(
-                QualifiedContractIdentifier::parse(&SBTC_DEPOSIT_MAINNET_ADDRESS.to_string())
-                    .unwrap(),
-            );
-        }
-
-        // Load all the requirements
-        // Some requirements are explicitly listed, some are discovered as we compute the ASTs.
-        for requirement in requirements.iter() {
-            let contract_id = QualifiedContractIdentifier::parse(&requirement.contract_id)
-                .map_err(|_e| format!("malformatted contract_id: {}", requirement.contract_id))?;
-            queue.push_front(contract_id);
-        }
-
-        while let Some(contract_id) = queue.pop_front() {
-            if requirements_deps.contains_key(&contract_id) {
-                continue;
-            }
-
-            // Did we already get the source in a prior cycle?
-            let (clarity_version, ast) = match requirements_data.remove(&contract_id) {
-                Some(requirement_data) => requirement_data,
-                None => {
-                    // Download the code
-                    let (source, epoch, clarity_version, contract_location) =
-                        requirements::retrieve_contract(
-                            &contract_id,
-                            &manifest.project.cache_location,
-                            &file_accessor,
-                            api_base_url,
-                        )
-                        .await?;
-
-                    contract_epochs.insert(contract_id.clone(), epoch);
-
-                    // Build the struct representing the requirement in the deployment
-                    if matches!(network, StacksNetwork::Simnet) {
-                        if !simnet_remote_data {
-                            let data = EmulatedContractPublishSpecification {
-                                contract_name: contract_id.name.clone(),
-                                emulated_sender: contract_id.issuer.clone(),
-                                source: source.clone(),
-                                location: contract_location,
-                                clarity_version,
-                                skip_analysis: true,
-                            };
-
-                            emulated_contracts_publish.insert(contract_id.clone(), data);
-                        }
-                    } else if matches!(network, StacksNetwork::Devnet) {
-                        let mut remap_principals = BTreeMap::new();
-                        remap_principals
-                            .insert(contract_id.issuer.clone(), default_deployer_address.clone());
-
-                        let data = RequirementPublishSpecification {
-                            contract_id: contract_id.clone(),
-                            remap_sender: default_deployer_address.clone(),
-                            source: source.clone(),
-                            location: contract_location,
-                            cost: deployment_fee_rate * source.len() as u64,
-                            remap_principals,
-                            clarity_version,
-                        };
-                        requirements_publish.insert(contract_id.clone(), data);
-                    } else if matches!(network, StacksNetwork::Testnet) {
-                        let mut remap_sender = default_deployer_address.clone();
-                        let mut remap_principals = BTreeMap::new();
-                        remap_principals
-                            .insert(contract_id.issuer.clone(), default_deployer_address.clone());
-
-                        // Remap sBTC mainnet address to testnet address
-                        if contract_id.issuer.to_string() == SBTC_MAINNET_ADDRESS {
-                            remap_sender = SBTC_TESTNET_ADDRESS_PRINCIPAL.clone();
-                            remap_principals.insert(
-                                contract_id.issuer.clone(),
-                                SBTC_TESTNET_ADDRESS_PRINCIPAL.clone(),
-                            );
-                        }
-
-                        let data = RequirementPublishSpecification {
-                            contract_id: contract_id.clone(),
-                            remap_sender,
-                            source: source.clone(),
-                            location: contract_location,
-                            cost: deployment_fee_rate * source.len() as u64,
-                            remap_principals,
-                            clarity_version,
-                        };
-                        requirements_publish.insert(contract_id.clone(), data);
-                    }
-
-                    // Compute the AST
-                    let contract = ClarityContract {
-                        code_source: ClarityCodeSource::ContractInMemory(source),
-                        name: contract_id.name.to_string(),
-                        deployer: ContractDeployer::ContractIdentifier(contract_id.clone()),
-                        clarity_version,
-                        epoch: clarity_repl::repl::Epoch::Specific(epoch),
-                        skip_analysis: true,
-                    };
-                    let (ast, _, _) = interpreter.build_ast(&contract);
-                    (clarity_version, ast)
-                }
-            };
-
-            // Detect the eventual dependencies for this AST
-            let mut contract_data = BTreeMap::new();
-
-            contract_data.insert(contract_id.clone(), (clarity_version, ast));
-            let dependencies =
-                ASTDependencyDetector::detect_dependencies(&contract_data, &requirements_data);
-            let (_, ast) = contract_data
-                .remove(&contract_id)
-                .expect("unable to retrieve ast");
-
-            // Extract the known / unknown dependencies
-            match dependencies {
-                Ok(inferable_dependencies) => {
-                    if inferable_dependencies.len() > 1 {
-                        println!("warning: inferable_dependencies contains more than one entry");
-                    }
-                    // We submitted a HashMap with one contract, so we have at most one result in the `inferable_dependencies` map.
-                    // We will extract and keep the associated data (source, ast, deps).
-                    if let Some((contract_id, dependencies)) =
-                        inferable_dependencies.into_iter().next()
-                    {
-                        for dependency in dependencies.iter() {
-                            queue.push_back(dependency.contract_id.clone());
-                        }
-                        requirements_deps.insert(contract_id.clone(), dependencies);
-                        requirements_data.insert(contract_id.clone(), (clarity_version, ast));
-                    }
-                }
-                Err((inferable_dependencies, non_inferable_dependencies)) => {
-                    // In the case of unknown dependencies, we were unable to construct an exhaustive list of dependencies.
-                    // As such, we will re-enqueue the present (front) and push all the unknown contract_ids in front of it,
-                    // and we will keep the source in memory to avoid useless disk access.
-                    for (_, dependencies) in inferable_dependencies.iter() {
-                        for dependency in dependencies.iter() {
-                            queue.push_back(dependency.contract_id.clone());
-                        }
-                    }
-                    requirements_data.insert(contract_id.clone(), (clarity_version, ast));
-                    queue.push_front(contract_id);
-
-                    for non_inferable_contract_id in non_inferable_dependencies.into_iter() {
-                        queue.push_front(non_inferable_contract_id);
-                    }
-                }
-            };
-        }
-
-        // Avoid listing requirements as deployment transactions to the deployment specification on Mainnet
-        if !matches!(network, StacksNetwork::Mainnet) && !simnet_remote_data {
-            let mut ordered_contracts_ids =
-                ASTDependencyDetector::order_contracts(&requirements_deps, &contract_epochs)
-                    .map_err(|e| format!("unable to order requirements {e}"))?;
-
-            // Filter out boot contracts from requirement dependencies
-            ordered_contracts_ids.retain(|contract_id| !boot_contracts_ids.contains(contract_id));
-
-            if matches!(network, StacksNetwork::Simnet) {
-                for contract_id in ordered_contracts_ids.iter() {
-                    let data = emulated_contracts_publish
-                        .remove(contract_id)
-                        .unwrap_or_else(|| panic!("unable to retrieve contract: {contract_id}"));
-                    let tx = TransactionSpecification::EmulatedContractPublish(data);
-                    transactions
-                        .entry(contract_epochs[contract_id].into())
-                        .or_default()
-                        .push(tx);
-                }
-            } else if matches!(network, StacksNetwork::Devnet | StacksNetwork::Testnet) {
-                for contract_id in ordered_contracts_ids.iter() {
-                    let data = requirements_publish
-                        .remove(contract_id)
-                        .unwrap_or_else(|| panic!("unable to retrieve contract: {contract_id}"));
-                    let tx = TransactionSpecification::RequirementPublish(data);
-                    transactions
-                        .entry(contract_epochs[contract_id].into())
-                        .or_default()
-                        .push(tx);
-                }
-            }
-        }
+    // Build the ASTs / DependencySet for requirements (Simnet/Devnet/Testnet/Mainnet)
+    if manifest.project.requirements.is_some() {
+        resolve_requirements(
+            manifest,
+            network,
+            simnet_remote_data,
+            file_accessor,
+            api_base_url,
+            &interpreter,
+            &default_deployer_address,
+            deployment_fee_rate,
+            &boot_contracts_ids,
+            &mut requirements_data,
+            &mut requirements_deps,
+            &mut contract_epochs,
+            &mut transactions,
+        )
+        .await?;
     }
 
     let mut contracts = HashMap::new();

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -751,6 +751,60 @@ async fn validate_custom_boot_contracts(
     Ok(failures)
 }
 
+/// Build the `SessionSettings` for the ephemeral interpreter. Disables
+/// remote-data on the repl settings and filters
+/// `override_boot_contracts_source` to simnet (with a warning
+/// otherwise — custom boot contracts only work on simnet).
+fn build_session_settings(manifest: &ProjectManifest, network: &StacksNetwork) -> SessionSettings {
+    let mut repl_settings = manifest.repl_settings.clone();
+    repl_settings.remote_data.enabled = false;
+
+    let override_boot_contracts_source = if matches!(network, StacksNetwork::Simnet) {
+        manifest.project.override_boot_contracts_source.clone()
+    } else {
+        if !manifest.project.override_boot_contracts_source.is_empty() {
+            eprintln!("Warning: Custom boot contracts are only supported on simnet. Ignoring override_boot_contracts_source configuration for {network:?} network.");
+        }
+        BTreeMap::new()
+    };
+
+    SessionSettings {
+        repl_settings,
+        override_boot_contracts_source,
+        ..Default::default()
+    }
+}
+
+/// Seed `requirements_data` with the boot-contract ASTs so they can
+/// satisfy dependency lookups, and return the set of boot contract
+/// ids so the caller can filter them out where appropriate. Skipped
+/// entirely when simnet uses remote data (the remote node already
+/// has them).
+fn load_boot_contracts(
+    settings: &SessionSettings,
+    simnet_remote_data: bool,
+    requirements_data: &mut BTreeMap<QualifiedContractIdentifier, (ClarityVersion, ContractAST)>,
+) -> BTreeSet<QualifiedContractIdentifier> {
+    if simnet_remote_data {
+        return BTreeSet::new();
+    }
+
+    let boot_contracts_data = if settings.override_boot_contracts_source.is_empty() {
+        BOOT_CONTRACTS_DATA.clone()
+    } else {
+        clarity_repl::repl::boot::get_boot_contracts_data_with_overrides(
+            &settings.override_boot_contracts_source,
+        )
+    };
+
+    let mut boot_contracts_ids = BTreeSet::new();
+    for (id, (contract, ast)) in boot_contracts_data {
+        boot_contracts_ids.insert(id.clone());
+        requirements_data.insert(id, (contract.clarity_version, ast));
+    }
+    boot_contracts_ids
+}
+
 /// Topologically order the project contracts by dependency and emit
 /// each as a publish transaction in the correct epoch bucket. Skips
 /// requirements (their transactions were already emitted by
@@ -1111,44 +1165,11 @@ pub async fn generate_default_deployment_with_cache(
     let mut requirements_data = BTreeMap::new();
     let mut requirements_deps = BTreeMap::new();
 
-    let mut repl_settings = manifest.repl_settings.clone();
-    repl_settings.remote_data.enabled = false;
-
-    let override_boot_contracts_source = if matches!(network, StacksNetwork::Simnet) {
-        manifest.project.override_boot_contracts_source.clone()
-    } else {
-        if !manifest.project.override_boot_contracts_source.is_empty() {
-            eprintln!("Warning: Custom boot contracts are only supported on simnet. Ignoring override_boot_contracts_source configuration for {network:?} network.");
-        }
-        BTreeMap::new()
-    };
-
-    let settings = SessionSettings {
-        repl_settings,
-        override_boot_contracts_source,
-        ..Default::default()
-    };
-
+    let settings = build_session_settings(manifest, network);
     let simnet_remote_data =
         matches!(network, StacksNetwork::Simnet) && manifest.repl_settings.remote_data.enabled;
-
-    let mut boot_contracts_ids = BTreeSet::new();
-
-    if !simnet_remote_data {
-        let boot_contracts_data = if settings.override_boot_contracts_source.is_empty() {
-            BOOT_CONTRACTS_DATA.clone()
-        } else {
-            clarity_repl::repl::boot::get_boot_contracts_data_with_overrides(
-                &settings.override_boot_contracts_source,
-            )
-        };
-        let mut boot_contracts_asts = BTreeMap::new();
-        for (id, (contract, ast)) in boot_contracts_data {
-            boot_contracts_ids.insert(id.clone());
-            boot_contracts_asts.insert(id, (contract.clarity_version, ast));
-        }
-        requirements_data.append(&mut boot_contracts_asts);
-    }
+    let boot_contracts_ids =
+        load_boot_contracts(&settings, simnet_remote_data, &mut requirements_data);
 
     // this ephemeral interpreter is used to parse code and build ASTs
     let interpreter = ClarityInterpreter::new(

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -18,8 +18,8 @@ use std::path::PathBuf;
 use std::pin::Pin;
 
 pub use network_manifest::{
-    compute_addresses, AccountConfig, DevnetConfig, DevnetConfigFile, NetworkManifest,
-    NetworkManifestFile, PoxStackingOrder, DEFAULT_BITCOIN_EXPLORER_IMAGE,
+    compute_addresses, AccountConfig, DevnetConfig, DevnetConfigFile, NetworkConfig,
+    NetworkManifest, NetworkManifestFile, PoxStackingOrder, DEFAULT_BITCOIN_EXPLORER_IMAGE,
     DEFAULT_BITCOIN_NODE_IMAGE, DEFAULT_DERIVATION_PATH, DEFAULT_DOCKER_PLATFORM,
     DEFAULT_EPOCH_2_0, DEFAULT_EPOCH_2_05, DEFAULT_EPOCH_2_1, DEFAULT_EPOCH_2_2, DEFAULT_EPOCH_2_3,
     DEFAULT_EPOCH_2_4, DEFAULT_EPOCH_2_5, DEFAULT_EPOCH_3_0, DEFAULT_EPOCH_3_1, DEFAULT_EPOCH_3_2,

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -9,7 +9,7 @@ use clarinet_deployments::types::{
 };
 use clarinet_deployments::{
     generate_default_deployment, get_default_deployment_path, initiate_session_from_manifest,
-    update_session_with_deployment_plan,
+    update_session_with_deployment_plan, BatchingMode,
 };
 use clarinet_files::{paths, FileAccessor, ProjectManifest, StacksNetwork, WASMFileSystemAccessor};
 use clarity::types::chainstate::StacksAddress;
@@ -503,7 +503,7 @@ impl SDK {
         let (mut deployment, artifacts, _) = generate_default_deployment(
             &manifest,
             &StacksNetwork::Simnet,
-            false,
+            BatchingMode::Chunked,
             Some(&*self.file_accessor),
             self.api_base_url.as_deref(),
             Environment::Simnet,

--- a/components/clarity-lsp/benches/ast_cache.rs
+++ b/components/clarity-lsp/benches/ast_cache.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::hint::black_box;
 use std::path::PathBuf;
 
-use clarinet_deployments::{generate_default_deployment_with_cache, CachedContractAST};
+use clarinet_deployments::{generate_default_deployment_with_cache, BatchingMode, CachedContractAST};
 use clarinet_files::{FileAccessor, FileAccessorResult, ProjectManifest, StacksNetwork};
 use clarity_repl::utils::Environment;
 use divan::Bencher;
@@ -261,7 +261,7 @@ fn run(
         let (_, artifacts, _) = generate_default_deployment_with_cache(
             manifest,
             &StacksNetwork::Simnet,
-            false,
+            BatchingMode::Chunked,
             Some(accessor),
             None,
             Environment::OnChain,

--- a/components/clarity-lsp/benches/ast_cache.rs
+++ b/components/clarity-lsp/benches/ast_cache.rs
@@ -18,7 +18,9 @@ use std::collections::HashMap;
 use std::hint::black_box;
 use std::path::PathBuf;
 
-use clarinet_deployments::{generate_default_deployment_with_cache, BatchingMode, CachedContractAST};
+use clarinet_deployments::{
+    generate_default_deployment_with_cache, BatchingMode, CachedContractAST,
+};
 use clarinet_files::{FileAccessor, FileAccessorResult, ProjectManifest, StacksNetwork};
 use clarity_repl::utils::Environment;
 use divan::Bencher;

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -7,7 +7,7 @@ use clarinet_defaults::DEFAULT_CLARITY_VERSION;
 pub use clarinet_deployments::CachedContractAST;
 use clarinet_deployments::{
     generate_default_deployment_with_cache, initiate_session_from_manifest,
-    update_session_with_deployment_plan,
+    update_session_with_deployment_plan, BatchingMode,
 };
 use clarinet_files::{paths, FileAccessor, ProjectManifest, StacksNetwork};
 use clarity::types::StacksEpochId;
@@ -912,7 +912,7 @@ pub async fn build_state(
         let (deployment, mut artifacts, found_env_simnet) = generate_default_deployment_with_cache(
             &manifest,
             &StacksNetwork::Simnet,
-            false,
+            BatchingMode::Chunked,
             file_accessor,
             None,
             environment,


### PR DESCRIPTION
### Description

This PR takes the `generate_default_deployment_with_cache()` from an ~800 line monstrosity into a more manageable ~200 line function. Each change was made as a separate commit, so for further details, see the commit messages

> [!NOTE]
> **To reviewers:** This PR contains a lot of moved code, and the diff is hard to read. It will be much easier to see what was done by checking over each commit

