### PR TITLE
feat: upgrade clarity vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 dependencies = [
  "clarity-types",
  "integer-sqrt",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2487,7 +2487,7 @@ dependencies = [
 [[package]]
 name = "libsigner"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 dependencies = [
  "clarity",
  "hashbrown 0.15.5",
@@ -2517,7 +2517,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 dependencies = [
  "clarity",
  "serde",
@@ -3060,7 +3060,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 dependencies = [
  "clarity",
  "slog",
@@ -4236,12 +4236,12 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4330,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=f8683bffa1a42de5b1485cade81b6255809dda3e#f8683bffa1a42de5b1485cade81b6255809dda3e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7#9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7"
 dependencies = [
  "clarity",
  "ed25519-dalek",
@@ -4346,6 +4346,7 @@ dependencies = [
  "regex",
  "ripemd",
  "rusqlite",
+ "secp256k1 0.24.3",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ version = "3.17.0"
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]
 # stacks-core git dependencies
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "clarity", default-features = false }
-clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "clarity-types" }
-libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "libsigner", default-features = false }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "pox-locking", default-features = false }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "stacks-common", default-features = false }
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "f8683bffa1a42de5b1485cade81b6255809dda3e", package = "stackslib", default-features = false }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7", package = "clarity", default-features = false }
+clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7", package = "clarity-types" }
+libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7", package = "libsigner", default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7", package = "pox-locking", default-features = false }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7", package = "stacks-common", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "9791d29cd4dd865b7e9d9a893b2ae7fe93bbc8c7", package = "stackslib", default-features = false }
 
 # Internal crates
 clarinet-defaults = { path = "components/clarinet-defaults" }

--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -511,7 +511,9 @@ impl<'a> Aggregator<'a> {
                             | NativeFunctions::AllowanceWithNft
                             | NativeFunctions::Secp256r1Verify
                             | NativeFunctions::ContractHash
-                            | NativeFunctions::ToAscii => {
+                            | NativeFunctions::ToAscii
+                            | NativeFunctions::VerifyMerkleProof
+                            | NativeFunctions::GetBitcoinTxOutput => {
                                 let inner_content =
                                     self.to_inner_content(list, previous_indentation);
 

--- a/components/clarity-repl/src/analysis/ast_visitor.rs
+++ b/components/clarity-repl/src/analysis/ast_visitor.rs
@@ -713,6 +713,19 @@ pub trait ASTVisitor<'a> {
                         | AllowanceAll => {
                             self.traverse_allowance(expr, args.get(0).unwrap_or(&DEFAULT_EXPR))
                         }
+                        VerifyMerkleProof => self.traverse_verify_merkle_proof(
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                            args.get(1).unwrap_or(&DEFAULT_EXPR),
+                            args.get(2).unwrap_or(&DEFAULT_EXPR),
+                            args.get(3).unwrap_or(&DEFAULT_EXPR),
+                            args.get(4).unwrap_or(&DEFAULT_EXPR),
+                        ),
+                        GetBitcoinTxOutput => self.traverse_get_bitcoin_tx_output(
+                            expr,
+                            args.get(0).unwrap_or(&DEFAULT_EXPR),
+                            args.get(1).unwrap_or(&DEFAULT_EXPR),
+                        ),
                     };
                 } else {
                     rv = self.traverse_call_user_defined(expr, function_name, args);
@@ -2722,6 +2735,62 @@ pub trait ASTVisitor<'a> {
         message_hash: &'a SymbolicExpression,
         signature: &'a SymbolicExpression,
         public_key: &'a SymbolicExpression,
+    ) -> bool {
+        true
+    }
+
+    fn traverse_verify_merkle_proof(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        leaf_hash: &'a SymbolicExpression,
+        root_hash: &'a SymbolicExpression,
+        tx_index: &'a SymbolicExpression,
+        tx_count: &'a SymbolicExpression,
+        sibling_hashes: &'a SymbolicExpression,
+    ) -> bool {
+        self.traverse_expr(leaf_hash)
+            && self.traverse_expr(root_hash)
+            && self.traverse_expr(tx_index)
+            && self.traverse_expr(tx_count)
+            && self.traverse_expr(sibling_hashes)
+            && self.visit_verify_merkle_proof(
+                expr,
+                leaf_hash,
+                root_hash,
+                tx_index,
+                tx_count,
+                sibling_hashes,
+            )
+    }
+
+    fn visit_verify_merkle_proof(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        leaf_hash: &'a SymbolicExpression,
+        root_hash: &'a SymbolicExpression,
+        tx_index: &'a SymbolicExpression,
+        tx_count: &'a SymbolicExpression,
+        sibling_hashes: &'a SymbolicExpression,
+    ) -> bool {
+        true
+    }
+
+    fn traverse_get_bitcoin_tx_output(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        tx_bytes: &'a SymbolicExpression,
+        vout: &'a SymbolicExpression,
+    ) -> bool {
+        self.traverse_expr(tx_bytes)
+            && self.traverse_expr(vout)
+            && self.visit_get_bitcoin_tx_output(expr, tx_bytes, vout)
+    }
+
+    fn visit_get_bitcoin_tx_output(
+        &mut self,
+        expr: &'a SymbolicExpression,
+        tx_bytes: &'a SymbolicExpression,
+        vout: &'a SymbolicExpression,
     ) -> bool {
         true
     }

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -1259,6 +1259,10 @@ impl BurnStateDB for Datastore {
         0
     }
 
+    fn get_pox_5_activation_height(&self) -> u32 {
+        0
+    }
+
     fn get_tip_burn_block_height(&self) -> Option<u32> {
         use StacksEpochId::*;
         match self.current_epoch {

--- a/components/clarity-static-cost/src/static_cost/cost_functions.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_functions.rs
@@ -163,5 +163,7 @@ pub fn from_native_function(native_function: NativeFunctions) -> ClarityCostFunc
         NativeFunctions::AllowanceWithNft => ClarityCostFunction::Unimplemented,
         NativeFunctions::AllowanceWithStacking => ClarityCostFunction::Unimplemented,
         NativeFunctions::AllowanceAll => ClarityCostFunction::Unimplemented,
+        NativeFunctions::VerifyMerkleProof => ClarityCostFunction::VerifyMerkleProof,
+        NativeFunctions::GetBitcoinTxOutput => ClarityCostFunction::GetBitcoinTxOutput,
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
         # Hash for clarity git dependency - update this when Cargo.lock changes
         # Run `nix run .#check-git-dependencies-hash` to verify or get the new hash
-        clarityHash = "sha256-ziVf3epIybqiLt1pWnHImJiFiuIw1uwUzHC2SdvXmVI=";
+        clarityHash = "sha256-DYO6tR+sPcdEpgR9/FGvEdiCCWxZixPhh8hfkAJLpc4=";
 
         clarinet = rustPlatform.buildRustPackage {
           inherit pname version;


### PR DESCRIPTION
### Description

Add support for new clarity 6 functions.

This is based on the branch of the WIP PR: https://github.com/stacks-network/stacks-core/pull/7197
`pox-wf-integration`

Clarinet is moving ahead of develop so that pox-5 can be built with clarity 6

