### PR TITLE
chore: release v3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+# [3.17.0](https://github.com/stx-labs/clarinet/compare/v3.16.0...v3.17.0) (2026-05-15)
+
+##### New Features
+
+* Upgrade clarity vm (#2397) (e296a43c)
+* Use codelens live-range to avoid flashing (#2385) (5057c617)
+* **static-cost:**
+  * Add external trait resolution (#2384) (cbe36702)
+  * Add warnings and resolving for local traits (#2375) (dc655d0e)
+
+##### Chores
+
+* **vscode-ext:**  Upgrade pnpm and dependencies (#2398) (e61872f9)
+* Use epoch4 built-ins via pox-wf-integration (#2389) (176d53d6)
+* Bump rng, nixpkgs, rust-overlay (#2383) (079db313)
+
+##### Continuous Integration
+
+* Fix docker image release (#2388) (67be209a)
+
+##### Other Changes
+
+* Reduce calls to Hiro API and improve retry logic (#2386) (966e855f)
+
+##### Performance Improvements
+
+*  Cache contract ASTs and only re-parse files which have changed (#2174) (6bdcab55)
+*  Remove temp allocations and double conversions (#2390) (6080ab46)
+
 # [3.17.0](https://github.com/stx-labs/clarinet/compare/v3.16.0...v3.17.0) (2026-04-28)
 
 ##### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [3.17.0](https://github.com/stx-labs/clarinet/compare/v3.16.0...v3.17.0) (2026-05-15)
+# [3.18.0](https://github.com/stx-labs/clarinet/compare/v3.17.0...v3.18.0) (2026-05-19)
 
 ##### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ##### New Features
 
-* Upgrade clarity vm (#2397) (e296a43c)
-* Use codelens live-range to avoid flashing (#2385) (5057c617)
+* Upgrade clarity vm (Clarity 6 preview) (#2397) (e296a43c)
 * **static-cost:**
   * Add external trait resolution (#2384) (cbe36702)
   * Add warnings and resolving for local traits (#2375) (dc655d0e)
@@ -13,6 +12,10 @@
 * **vscode-ext:**  Upgrade pnpm and dependencies (#2398) (e61872f9)
 * Use epoch4 built-ins via pox-wf-integration (#2389) (176d53d6)
 * Bump rng, nixpkgs, rust-overlay (#2383) (079db313)
+
+##### Bug fixes
+
+* Use codelens live-range to avoid flashing (#2385) (5057c617)
 
 ##### Continuous Integration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "chrono",
  "clap",
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "clarinet-defaults"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "clarity",
 ]
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "bitcoin",
  "clarinet-defaults",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-static-cost"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "clarity",
  "clarity-types",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "observer"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "axum",
  "base58",
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.17.0"
+version = "3.18.0"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["components/clarinet-cli"]
 opt-level = 3
 
 [workspace.package]
-version = "3.17.0"
+version = "3.18.0"
 
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",


### PR DESCRIPTION
# [3.18.0](https://github.com/stx-labs/clarinet/compare/v3.17.0...v3.18.0) (2026-05-19)

##### New Features

* Upgrade clarity vm (Clarity 6 preview) (#2397) (e296a43c)
* **static-cost:**
  * Add external trait resolution (#2384) (cbe36702)
  * Add warnings and resolving for local traits (#2375) (dc655d0e)

##### Chores

* **vscode-ext:**  Upgrade pnpm and dependencies (#2398) (e61872f9)
* Use epoch4 built-ins via pox-wf-integration (#2389) (176d53d6)
* Bump rng, nixpkgs, rust-overlay (#2383) (079db313)

##### Bug fixes

* Use codelens live-range to avoid flashing (#2385) (5057c617)

##### Continuous Integration

* Fix docker image release (#2388) (67be209a)

##### Other Changes

* Reduce calls to Hiro API and improve retry logic (#2386) (966e855f)

##### Performance Improvements

*  Cache contract ASTs and only re-parse files which have changed (#2174) (6bdcab55)
*  Remove temp allocations and double conversions (#2390) (6080ab46)