### PR TITLE
ci: fix sdk release

### DIFF
--- a/.github/workflows/release-sdk.yaml
+++ b/.github/workflows/release-sdk.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Install wasm-pack
         run: cargo install wasm-pack
 
+      - name: Install dependencies (skip prepare scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
       - name: Build Wasm packages
         run: pnpm run build:sdk-wasm
 


### PR DESCRIPTION
### Description

Same fix as in https://github.com/stx-labs/clarinet/pull/2394
-> pnpm v11 changed verifyDepsBeforeRun to default to install, so pnpm run build:sdk-wasmnow auto-runs pnpm install, which fires the prepare script on @stacks/clarinet-sdk-browser before the wasm packages exist.
In the build_wasm CI job, run pnpm install --frozen-lockfile --ignore-scripts explicitly before building wasm, so the auto-check is satisfied without triggering prepare.

