### PR TITLE
fix: Replace broken VSCode badge in README with Open VSX badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://img.shields.io/github/v/release/stx-labs/clarinet)](https://github.com/stx-labs/clarinet/releases/latest)
 [![npm](https://img.shields.io/npm/v/@stacks/clarinet-sdk)](https://www.npmjs.com/package/@stacks/clarinet-sdk)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/stackslabs.clarity-stacks?label=VSCode)](https://marketplace.visualstudio.com/items?itemName=stackslabs.clarity-stacks)
+[![Open VSX](https://img.shields.io/open-vsx/v/stackslabs/clarity-stacks?label=Open%20VSX)](https://open-vsx.org/extension/stackslabs/clarity-stacks)
 
 Clarinet is the fastest way to build, test, and deploy smart contracts on the Stacks blockchain. It
 gives you a local devnet, REPL, testing framework, and debugging tools to ship high-quality Clarity


### PR DESCRIPTION
### Description

The VSCode badge in the README is currently showing "retired badge":

<img width="138" height="20" alt="vscode-badge" src="https://github.com/user-attachments/assets/40187f42-5f45-4a13-86de-00f45ce6cc82" />

I tried to fix it, by using a badge from vsmarketplacebadges.dev instead of sheilds.io, but that gives the wrong version since we accidentally pushed 15.16.0 once: 

<img width="112" height="20" alt="vscode-badge-fixed" src="https://github.com/user-attachments/assets/cae0a50f-504e-43ca-a43e-07381bf2f023" />

So instead I'm replacing it with the Open VSX badge, which links to the marketplace used by VSCoduim, Cursor, etc. instead, but at least works and has the right version

<img width="118" height="20" alt="open-vsx" src="https://github.com/user-attachments/assets/5fc2da5c-4781-40fe-a84d-ce8c5202e830" />


