### PR TITLE
ci: build for linux arm64 and generate checksum

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,11 @@ jobs:
             platform: darwin
             target: aarch64-apple-darwin
             architecture: arm64
+          - os: ubuntu-24.04-arm
+            platform: linux
+            target: aarch64-unknown-linux-musl
+            architecture: arm64
+            libc: musl
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -139,13 +144,19 @@ jobs:
         with:
           tool: cargo-llvm-cov,nextest
 
+      - name: Install musl-gcc
+        if: endsWith(matrix.target, 'unknown-linux-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - name: Run unit test
         if: matrix.target != 'x86_64-unknown-linux-gnu'
         env:
           HIRO_API_KEY: ${{ secrets.HIRO_API_KEY }}
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
-        run: cargo tst
+        run: cargo tst ${{ endsWith(matrix.target, 'unknown-linux-musl') && format('--target {0}', matrix.target) || '' }}
 
       - name: Install llvm-cov
         if: matrix.target == 'x86_64-unknown-linux-gnu'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,6 +176,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -201,6 +202,16 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-musl
             architecture: x64
+            libc: musl
+          - os: ubuntu-24.04-arm
+            platform: linux
+            target: aarch64-unknown-linux-gnu
+            architecture: arm64
+            libc: glibc
+          - os: ubuntu-24.04-arm
+            platform: linux
+            target: aarch64-unknown-linux-musl
+            architecture: arm64
             libc: musl
 
     steps:
@@ -253,7 +264,7 @@ jobs:
           echo "PRE_GYP_TARGET_NAME=${PLATFORM}-${ARCHITECTURE}-unknown" >> $GITHUB_ENV
 
       - name: Install musl-gcc
-        if: matrix.target == 'x86_64-unknown-linux-musl'
+        if: endsWith(matrix.target, 'unknown-linux-musl')
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
@@ -291,6 +302,12 @@ jobs:
         run: |
           Compress-Archive -Path "./signed/clarinet.exe" -DestinationPath "clarinet-$env:SHORT_TARGET_NAME.zip"
 
+      - name: Attest build provenance
+        if: startsWith(github.ref, 'refs/heads/main') && needs.get_release_info.outputs.tag != ''
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: clarinet-${{ env.SHORT_TARGET_NAME }}.*
+
       - name: Upload cargo artifacts (Linux and macOS)
         if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -325,6 +342,15 @@ jobs:
 
       - name: Download pre-built dists
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums.txt
+        working-directory: dist
+        run: |
+          sha256sum clarinet-*.tar.gz clarinet-*.zip > checksums.txt
+          cat checksums.txt
 
       - name: Tag and Release
         uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
@@ -338,8 +364,9 @@ jobs:
           target_commitish: ${{ env.GITHUB_SHA }}
           generate_release_notes: false
           files: |
-            **/*.tar.gz
-            **/*.zip
+            dist/clarinet-*.tar.gz
+            dist/clarinet-*.zip
+            dist/checksums.txt
 
       - name: Trigger pkg-version-bump workflow
         uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4 # v1

--- a/components/clarinet-cli/Cargo.toml
+++ b/components/clarinet-cli/Cargo.toml
@@ -51,7 +51,7 @@ segment = { version = "0.2.4", optional = true }
 mac_address = { version = "1.1.8", optional = true }
 
 # Must match condition in bin.rs EXACTLY
-[target.'cfg(not(any(target_env = "msvc", target_os = "macos")))'.dependencies]
+[target.'cfg(not(any(target_env = "msvc", target_os = "macos", all(target_arch = "aarch64", target_env = "musl"))))'.dependencies]
 tikv-jemallocator = { workspace = true }
 
 [dev-dependencies]

--- a/components/clarinet-cli/src/bin.rs
+++ b/components/clarinet-cli/src/bin.rs
@@ -1,12 +1,22 @@
 use clarinet_lib::frontend::cli;
-#[cfg(not(any(target_env = "msvc", target_os = "macos")))]
+#[cfg(not(any(
+    target_env = "msvc",
+    target_os = "macos",
+    all(target_arch = "aarch64", target_env = "musl")
+)))]
 use tikv_jemallocator::Jemalloc;
 
 /// Enable jemalloc as the global allocator
 /// Disable for...
 ///  - MSVC compiler: Not supported by `jemalloc`
 ///  - MacOS: System allocator already based on jemalloc
-#[cfg(not(any(target_env = "msvc", target_os = "macos")))]
+///  - aarch64-musl: `jemalloc` upstream has no atomics implementation for this
+///    target combo, alls back to musl's system allocator.
+#[cfg(not(any(
+    target_env = "msvc",
+    target_os = "macos",
+    all(target_arch = "aarch64", target_env = "musl")
+)))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/components/clarinet-cli/src/bin.rs
+++ b/components/clarinet-cli/src/bin.rs
@@ -11,7 +11,7 @@ use tikv_jemallocator::Jemalloc;
 ///  - MSVC compiler: Not supported by `jemalloc`
 ///  - MacOS: System allocator already based on jemalloc
 ///  - aarch64-musl: `jemalloc` upstream has no atomics implementation for this
-///    target combo, alls back to musl's system allocator.
+///    target combo, falls back to musl's system allocator.
 #[cfg(not(any(
     target_env = "msvc",
     target_os = "macos",


### PR DESCRIPTION
## Summary

**1. Linux ARM64 builds.** Two new matrix entries: `aarch64-unknown-linux-gnu` and `aarch64-unknown-linux-musl` producing `clarinet-linux-arm64-{glibc,musl}.tar.gz` with the same naming convention, tar flags, and binary layout as existing assets. Unblocks GitHub's free `ubuntu-24.04-arm` runners, and ARM64 Linux containers on Apple Silicon among other things

**2. Build provenance.** `actions/attest-build-provenance` attests each Cargo-produced archive. Verifiable via `gh attestation verify <file> --repo stx-labs/clarinet`. Excludes `devnet_default_snapshot.tar.gz` since it isn't a build output of this repo.

**3. `checksums.txt`.** Generated in the existing release job from the 7 archives in standard `sha256sum` format. Same exclusion as above.


### Test after the next release

- verify `checksums.txt`
- `sha256sum -c checksums.txt` passes
- `gh attestation verify clarinet-linux-arm64-glibc.tar.gz --repo stx-labs/clarinet` passes
- `./clarinet --version` runs inside `arm64v8/ubuntu:24.04` (glibc) and `arm64v8/alpine:latest` (musl)

### Motivation for this PR

This is standard release process, also, I'd like users to be able to install clarinet using [mise](https://mise.jdx.dev/). Currently, its `github` backend would hard-fails on Linux ARM64, and its default `github_attestations = true` silently no-ops because we publish none