### PR TITLE
fix: support override_boot_contract in sdk

### DIFF
--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -116,7 +116,12 @@ pub fn initiate_session_from_manifest(manifest: &ProjectManifest) -> Session {
         repl_settings: manifest.repl_settings.clone(),
         disk_cache_enabled: true,
         cache_location: Some(manifest.project.cache_location.clone()),
-        override_boot_contracts_source: manifest.project.override_boot_contracts_source.clone(),
+        override_boot_contracts_source: manifest
+            .project
+            .override_boot_contracts_source
+            .iter()
+            .map(|(name, entry)| (name.clone(), entry.source.clone()))
+            .collect(),
         ..Default::default()
     };
     Session::new(settings)
@@ -492,7 +497,12 @@ pub async fn generate_default_deployment_with_cache(
     repl_settings.remote_data.enabled = false;
 
     let override_boot_contracts_source = if matches!(network, StacksNetwork::Simnet) {
-        manifest.project.override_boot_contracts_source.clone()
+        manifest
+            .project
+            .override_boot_contracts_source
+            .iter()
+            .map(|(name, entry)| (name.clone(), entry.source.clone()))
+            .collect()
     } else {
         if !manifest.project.override_boot_contracts_source.is_empty() {
             eprintln!("Warning: Custom boot contracts are only supported on simnet. Ignoring override_boot_contracts_source configuration for {network:?} network.");

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -538,46 +538,19 @@ pub async fn generate_default_deployment_with_cache(
     let mut contract_diags: HashMap<QualifiedContractIdentifier, Vec<Diagnostic>> = HashMap::new();
     let mut asts_success = true;
 
-    // Validate custom boot contracts from override_boot_contracts_source
+    // AST-check overrides for diagnostic reporting; sources are pre-loaded
+    // upstream by the manifest layer.
     if !settings.override_boot_contracts_source.is_empty() && !simnet_remote_data {
-        for (contract_name, file_path) in &settings.override_boot_contracts_source {
-            // Only validate existing boot contracts that are being overridden
+        for (contract_name, custom_source) in &settings.override_boot_contracts_source {
             if !clarity_repl::repl::boot::BOOT_CONTRACTS_NAMES.contains(&contract_name.as_str()) {
                 continue;
             }
-
-            let resolved_path = manifest.root_dir.join(file_path);
-            let resolved_path_string = resolved_path.to_string_lossy().into_owned();
-
-            // Load and validate the custom boot contract
-            let custom_source = match file_accessor {
-                None => {
-                    // Fallback to file system when no file_accessor is provided
-                    std::fs::read_to_string(&resolved_path_string).map_err(|e| {
-                        format!("Failed to read boot contract file {resolved_path_string}: {e}")
-                    })
-                }
-                Some(file_accessor) => {
-                    let sources = file_accessor
-                        .read_files(vec![resolved_path_string.clone()])
-                        .await
-                        .map_err(|e| {
-                            format!("Failed to read boot contract file {resolved_path_string}: {e}")
-                        })?;
-                    sources
-                        .get(&resolved_path_string)
-                        .ok_or_else(|| {
-                            format!("Unable to read custom boot contract: {contract_name}")
-                        })
-                        .cloned()
-                }
-            }?;
 
             let (epoch, clarity_version) =
                 get_boot_contract_epoch_and_clarity_version(contract_name.as_str());
 
             let temp_contract = ClarityContract {
-                code_source: ClarityCodeSource::ContractInMemory(custom_source),
+                code_source: ClarityCodeSource::ContractInMemory(custom_source.clone()),
                 deployer: ContractDeployer::Address(default_deployer_address.to_address()),
                 name: contract_name.clone(),
                 clarity_version,

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -250,24 +250,26 @@ impl ProjectManifest {
             allow_remote_data_fetching,
         )?;
 
-        let paths: Vec<String> = manifest
+        let resolved_paths: BTreeMap<String, String> = manifest
             .project
             .override_boot_contracts_source
-            .values()
-            .map(|entry| {
-                entry
-                    .resolve_path(&manifest.root_dir)
-                    .to_string_lossy()
-                    .into_owned()
+            .iter()
+            .map(|(name, entry)| {
+                (
+                    name.clone(),
+                    entry
+                        .resolve_path(&manifest.root_dir)
+                        .to_string_lossy()
+                        .into_owned(),
+                )
             })
             .collect();
-        let sources = file_accessor.read_files(paths).await?;
+        let sources = file_accessor
+            .read_files(resolved_paths.values().cloned().collect())
+            .await?;
         for (name, entry) in manifest.project.override_boot_contracts_source.iter_mut() {
-            let path = entry
-                .resolve_path(&manifest.root_dir)
-                .to_string_lossy()
-                .into_owned();
-            entry.source = sources.get(&path).cloned().ok_or_else(|| {
+            let path = &resolved_paths[name];
+            entry.source = sources.get(path).cloned().ok_or_else(|| {
                 format!("Unable to read override boot contract '{name}' at {path}")
             })?;
         }

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -202,7 +202,11 @@ pub struct ProjectConfig {
     pub cache_location: PathBuf,
     #[serde(skip_deserializing)]
     pub boot_contracts: Vec<String>,
-    #[serde(default)]
+    // Populated by `from_location` / `from_file_accessor`. The custom `Serialize`
+    // impl emits paths as a `BTreeMap<String, String>` for inspection, which is
+    // shape-incompatible with the in-memory struct — so JSON unpack ignores it
+    // and the manifest is always reloaded from disk.
+    #[serde(skip_deserializing)]
     pub override_boot_contracts_source: BTreeMap<String, OverrideBootContract>,
 }
 
@@ -219,6 +223,14 @@ impl Serialize for ProjectConfig {
         map.serialize_entry("cache_dir", &self.cache_location.to_string_lossy())?;
         if self.requirements.is_some() {
             map.serialize_entry("requirements", &self.requirements)?;
+        }
+        if !self.override_boot_contracts_source.is_empty() {
+            let paths: BTreeMap<&str, &str> = self
+                .override_boot_contracts_source
+                .iter()
+                .map(|(name, entry)| (name.as_str(), entry.path.as_str()))
+                .collect();
+            map.serialize_entry("override_boot_contracts_source", &paths)?;
         }
         map.end()
     }

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -240,7 +240,11 @@ impl ProjectManifest {
             .override_boot_contracts_source
             .iter()
             .map(|(name, rel_path)| {
-                let path = manifest.root_dir.join(rel_path).to_string_lossy().into_owned();
+                let path = manifest
+                    .root_dir
+                    .join(rel_path)
+                    .to_string_lossy()
+                    .into_owned();
                 (name.clone(), path)
             })
             .collect();

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -181,6 +181,7 @@ pub struct OverrideBootContract {
     pub path: String,
     /// Pre-loaded Clarity source. Populated by `from_location` / `from_file_accessor`
     /// so consumers don't need filesystem access.
+    #[serde(skip_deserializing)]
     pub source: String,
 }
 
@@ -201,6 +202,7 @@ pub struct ProjectConfig {
     pub cache_location: PathBuf,
     #[serde(skip_deserializing)]
     pub boot_contracts: Vec<String>,
+    #[serde(default)]
     pub override_boot_contracts_source: BTreeMap<String, OverrideBootContract>,
 }
 

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -186,6 +186,8 @@ pub struct ProjectConfig {
     pub cache_location: PathBuf,
     #[serde(skip_deserializing)]
     pub boot_contracts: Vec<String>,
+    /// Boot contract name → Clarity source code. Pre-loaded by `from_location` /
+    /// `from_file_accessor` so consumers don't need filesystem access.
     pub override_boot_contracts_source: BTreeMap<String, String>,
 }
 
@@ -227,11 +229,35 @@ impl ProjectManifest {
         let project_manifest_file: ProjectManifestFile = toml::from_slice(content.as_bytes())
             .map_err(|e| format!("Clarinet.toml file malformatted {e:?}"))?;
 
-        ProjectManifest::from_project_manifest_file(
+        let mut manifest = ProjectManifest::from_project_manifest_file(
             project_manifest_file,
             location,
             allow_remote_data_fetching,
-        )
+        )?;
+
+        let resolved: Vec<(String, String)> = manifest
+            .project
+            .override_boot_contracts_source
+            .iter()
+            .map(|(name, rel_path)| {
+                let path = manifest.root_dir.join(rel_path).to_string_lossy().into_owned();
+                (name.clone(), path)
+            })
+            .collect();
+        let sources = file_accessor
+            .read_files(resolved.iter().map(|(_, p)| p.clone()).collect())
+            .await?;
+        manifest.project.override_boot_contracts_source = resolved
+            .into_iter()
+            .map(|(name, path)| {
+                let source = sources.get(&path).cloned().ok_or_else(|| {
+                    format!("Unable to read override boot contract '{name}' at {path}")
+                })?;
+                Ok((name, source))
+            })
+            .collect::<Result<_, String>>()?;
+
+        Ok(manifest)
     }
 
     pub fn from_location(
@@ -243,11 +269,23 @@ impl ProjectManifest {
             toml::from_slice(&project_manifest_file_content[..])
                 .map_err(|e| format!("Clarinet.toml file malformatted {e:?}"))?;
 
-        ProjectManifest::from_project_manifest_file(
+        let mut manifest = ProjectManifest::from_project_manifest_file(
             project_manifest_file,
             location,
             allow_remote_data_fetching,
-        )
+        )?;
+
+        manifest.project.override_boot_contracts_source = manifest
+            .project
+            .override_boot_contracts_source
+            .iter()
+            .map(|(name, rel_path)| {
+                let path = manifest.root_dir.join(rel_path);
+                Ok((name.clone(), paths::read_content_as_utf8(&path)?))
+            })
+            .collect::<Result<_, String>>()?;
+
+        Ok(manifest)
     }
 
     // process a contract and add it to the configuration

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -176,6 +176,21 @@ where
 }
 
 #[derive(Deserialize, Debug, Clone)]
+pub struct OverrideBootContract {
+    /// Path as written in `Clarinet.toml`, relative to the manifest root.
+    pub path: String,
+    /// Pre-loaded Clarity source. Populated by `from_location` / `from_file_accessor`
+    /// so consumers don't need filesystem access.
+    pub source: String,
+}
+
+impl OverrideBootContract {
+    pub fn resolve_path(&self, root: &Path) -> PathBuf {
+        root.join(&self.path)
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct ProjectConfig {
     pub name: String,
     pub authors: Vec<String>,
@@ -186,9 +201,7 @@ pub struct ProjectConfig {
     pub cache_location: PathBuf,
     #[serde(skip_deserializing)]
     pub boot_contracts: Vec<String>,
-    /// Boot contract name → Clarity source code. Pre-loaded by `from_location` /
-    /// `from_file_accessor` so consumers don't need filesystem access.
-    pub override_boot_contracts_source: BTreeMap<String, String>,
+    pub override_boot_contracts_source: BTreeMap<String, OverrideBootContract>,
 }
 
 impl Serialize for ProjectConfig {
@@ -235,31 +248,27 @@ impl ProjectManifest {
             allow_remote_data_fetching,
         )?;
 
-        let resolved: Vec<(String, String)> = manifest
+        let paths: Vec<String> = manifest
             .project
             .override_boot_contracts_source
-            .iter()
-            .map(|(name, rel_path)| {
-                let path = manifest
-                    .root_dir
-                    .join(rel_path)
+            .values()
+            .map(|entry| {
+                entry
+                    .resolve_path(&manifest.root_dir)
                     .to_string_lossy()
-                    .into_owned();
-                (name.clone(), path)
+                    .into_owned()
             })
             .collect();
-        let sources = file_accessor
-            .read_files(resolved.iter().map(|(_, p)| p.clone()).collect())
-            .await?;
-        manifest.project.override_boot_contracts_source = resolved
-            .into_iter()
-            .map(|(name, path)| {
-                let source = sources.get(&path).cloned().ok_or_else(|| {
-                    format!("Unable to read override boot contract '{name}' at {path}")
-                })?;
-                Ok((name, source))
-            })
-            .collect::<Result<_, String>>()?;
+        let sources = file_accessor.read_files(paths).await?;
+        for (name, entry) in manifest.project.override_boot_contracts_source.iter_mut() {
+            let path = entry
+                .resolve_path(&manifest.root_dir)
+                .to_string_lossy()
+                .into_owned();
+            entry.source = sources.get(&path).cloned().ok_or_else(|| {
+                format!("Unable to read override boot contract '{name}' at {path}")
+            })?;
+        }
 
         Ok(manifest)
     }
@@ -279,15 +288,9 @@ impl ProjectManifest {
             allow_remote_data_fetching,
         )?;
 
-        manifest.project.override_boot_contracts_source = manifest
-            .project
-            .override_boot_contracts_source
-            .iter()
-            .map(|(name, rel_path)| {
-                let path = manifest.root_dir.join(rel_path);
-                Ok((name.clone(), paths::read_content_as_utf8(&path)?))
-            })
-            .collect::<Result<_, String>>()?;
+        for entry in manifest.project.override_boot_contracts_source.values_mut() {
+            entry.source = paths::read_content_as_utf8(&entry.resolve_path(&manifest.root_dir))?;
+        }
 
         Ok(manifest)
     }
@@ -370,27 +373,28 @@ impl ProjectManifest {
         let cache_location = paths::try_parse_path(&cache_dir, Some(root_path))
             .ok_or_else(|| format!("unable to parse path {cache_dir}"))?;
 
-        let mut override_boot_contracts_source = BTreeMap::new();
-        if let Some(overrides) = project_manifest_file.project.override_boot_contracts_source {
-            for (contract_name, contract_path) in overrides.iter() {
-                override_boot_contracts_source.insert(contract_name.clone(), contract_path.clone());
-            }
-        }
-
         let boot_contracts = BOOT_CONTRACTS_NAMES
             .iter()
             .map(|n| n.to_string())
             .collect::<Vec<_>>();
 
         // if an override doesn't correspond with one of the boot contracts, we warn and discard that override
-        let mut valid_override_boot_contracts_source = BTreeMap::new();
-        for (contract_name, contract_path) in override_boot_contracts_source.iter() {
-            if !boot_contracts.contains(contract_name) {
-                eprintln!("Warning: {contract_name} custom boot contract was not included because it's not part of the set of default boot contracts");
-                eprintln!("Available boot contracts: {boot_contracts:?}");
-            } else {
-                valid_override_boot_contracts_source
-                    .insert(contract_name.clone(), contract_path.clone());
+        let mut override_boot_contracts_source: BTreeMap<String, OverrideBootContract> =
+            BTreeMap::new();
+        if let Some(overrides) = project_manifest_file.project.override_boot_contracts_source {
+            for (contract_name, contract_path) in overrides {
+                if !boot_contracts.contains(&contract_name) {
+                    eprintln!("Warning: {contract_name} custom boot contract was not included because it's not part of the set of default boot contracts");
+                    eprintln!("Available boot contracts: {boot_contracts:?}");
+                    continue;
+                }
+                override_boot_contracts_source.insert(
+                    contract_name,
+                    OverrideBootContract {
+                        path: contract_path,
+                        source: String::new(),
+                    },
+                );
             }
         }
 
@@ -405,7 +409,7 @@ impl ProjectManifest {
             telemetry: project_manifest_file.project.telemetry.unwrap_or(false),
             cache_location,
             boot_contracts,
-            override_boot_contracts_source: valid_override_boot_contracts_source,
+            override_boot_contracts_source,
         };
 
         let mut config = ProjectManifest {
@@ -674,12 +678,20 @@ mod tests {
 
         assert_eq!(manifest.project.override_boot_contracts_source.len(), 2);
         assert_eq!(
-            manifest.project.override_boot_contracts_source.get("pox-4"),
-            Some(&"./custom-boot-contracts/pox-4.clar".to_string())
+            manifest
+                .project
+                .override_boot_contracts_source
+                .get("pox-4")
+                .map(|e| e.path.as_str()),
+            Some("./custom-boot-contracts/pox-4.clar")
         );
         assert_eq!(
-            manifest.project.override_boot_contracts_source.get("costs"),
-            Some(&"./custom-boot-contracts/costs.clar".to_string())
+            manifest
+                .project
+                .override_boot_contracts_source
+                .get("costs")
+                .map(|e| e.path.as_str()),
+            Some("./custom-boot-contracts/costs.clar")
         );
     }
 
@@ -703,18 +715,26 @@ mod tests {
         // Only valid contracts should be included
         assert_eq!(manifest.project.override_boot_contracts_source.len(), 2);
         assert_eq!(
-            manifest.project.override_boot_contracts_source.get("pox-4"),
-            Some(&"./custom-boot-contracts/pox-4.clar".to_string())
+            manifest
+                .project
+                .override_boot_contracts_source
+                .get("pox-4")
+                .map(|e| e.path.as_str()),
+            Some("./custom-boot-contracts/pox-4.clar")
         );
         assert_eq!(
-            manifest.project.override_boot_contracts_source.get("costs"),
-            Some(&"./custom-boot-contracts/costs.clar".to_string())
+            manifest
+                .project
+                .override_boot_contracts_source
+                .get("costs")
+                .map(|e| e.path.as_str()),
+            Some("./custom-boot-contracts/costs.clar")
         );
         // Invalid contract should not be included
-        assert_eq!(
-            manifest.project.override_boot_contracts_source.get("pox-x"),
-            None
-        );
+        assert!(!manifest
+            .project
+            .override_boot_contracts_source
+            .contains_key("pox-x"));
     }
 
     #[test]
@@ -734,9 +754,9 @@ mod tests {
 
         // Verify that the invalid contract was filtered out
         assert_eq!(manifest.project.override_boot_contracts_source.len(), 0);
-        assert_eq!(
-            manifest.project.override_boot_contracts_source.get("pox-x"),
-            None
-        );
+        assert!(!manifest
+            .project
+            .override_boot_contracts_source
+            .contains_key("pox-x"));
     }
 }

--- a/components/clarinet-sdk/node/tests/custom-boot-contracts.test.ts
+++ b/components/clarinet-sdk/node/tests/custom-boot-contracts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { Cl } from "@stacks/transactions";
+
+import { Simnet, initSimnet } from "..";
+
+const poxDeployer = "ST000000000000000000002AMW42H";
+
+let simnet: Simnet;
+
+describe("override_boot_contracts_source under the wasm SDK", () => {
+  beforeEach(async () => {
+    simnet = await initSimnet("tests/fixtures/ManifestCustomBootContracts.toml");
+  });
+
+  it("replaces pox-4 with the source pointed to by the manifest", () => {
+    const result = simnet.callReadOnlyFn(`${poxDeployer}.pox-4`, "sentinel", [], poxDeployer);
+    expect(result.result).toStrictEqual(Cl.ok(Cl.stringAscii("override-active")));
+  });
+});

--- a/components/clarinet-sdk/node/tests/fixtures/ManifestCustomBootContracts.toml
+++ b/components/clarinet-sdk/node/tests/fixtures/ManifestCustomBootContracts.toml
@@ -1,0 +1,9 @@
+[project]
+name = 'custom-boot-contracts-fixture'
+description = 'fixture to verify override_boot_contracts_source works under the wasm SDK'
+telemetry = false
+cache_dir = './.cache'
+requirements = []
+
+[project.override_boot_contracts_source]
+pox-4 = './custom-boot-contracts/pox-4-override.clar'

--- a/components/clarinet-sdk/node/tests/fixtures/custom-boot-contracts/pox-4-override.clar
+++ b/components/clarinet-sdk/node/tests/fixtures/custom-boot-contracts/pox-4-override.clar
@@ -1,0 +1,3 @@
+;; `sentinel` does not exist on the default pox-4 — calling it succeeds
+;; only when this override has actually replaced the boot source.
+(define-read-only (sentinel) (ok "override-active"))

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -244,11 +244,10 @@ pub async fn process_notification(
                             // boot contracts path checking
                             let mut found_boot_contract = None;
 
-                            for (contract_name, contract_path) in
+                            for (contract_name, entry) in
                                 &manifest.project.override_boot_contracts_source
                             {
-                                let resolved_path = manifest.root_dir.join(contract_path);
-                                if resolved_path == contract_location {
+                                if entry.resolve_path(&manifest.root_dir) == contract_location {
                                     found_boot_contract = Some(contract_name);
                                     break;
                                 }

--- a/components/clarity-repl/src/repl/boot/mod.rs
+++ b/components/clarity-repl/src/repl/boot/mod.rs
@@ -58,7 +58,6 @@ pub static SBTC_TOKEN_MAINNET_ADDRESS: LazyLock<QualifiedContractIdentifier> =
     });
 
 use std::collections::BTreeMap;
-use std::fs;
 use std::sync::LazyLock;
 
 use clarity::types::StacksEpochId;
@@ -195,11 +194,9 @@ pub static BOOT_CONTRACTS_DATA: LazyLock<
     result
 });
 
-pub fn load_custom_boot_contract(path: &str) -> Result<String, String> {
-    fs::read_to_string(path).map_err(|e| format!("Failed to read boot contract file {path}: {e}"))
-}
-
-/// Get boot contracts data with optional overrides (only existing boot contracts can be overridden)
+/// `overrides` maps boot contract name → Clarity source code. File I/O is the
+/// caller's responsibility so this stays runtime-agnostic — `wasm32-unknown-unknown`
+/// has no working `std::fs`.
 pub fn get_boot_contracts_data_with_overrides(
     overrides: &BTreeMap<String, String>,
 ) -> BTreeMap<QualifiedContractIdentifier, (ClarityContract, ContractAST)> {
@@ -211,21 +208,12 @@ pub fn get_boot_contracts_data_with_overrides(
         None,
     );
 
-    for (contract_name, file_path) in overrides {
+    for (contract_name, custom_source) in overrides {
         if !BOOT_CONTRACTS_NAMES.contains(&contract_name.as_str()) {
             eprintln!("Warning: Skipping custom boot contract '{contract_name}' - only existing boot contracts can be overridden. Valid boot contracts are: {BOOT_CONTRACTS_NAMES:?}");
             continue;
         }
 
-        let custom_source = match load_custom_boot_contract(file_path) {
-            Ok(source) => source,
-            Err(e) => {
-                eprintln!("Warning: Failed to load custom boot contract {contract_name}: {e}");
-                continue;
-            }
-        };
-
-        // Use standard epoch/version mapping for known boot contracts
         let (epoch, clarity_version) =
             get_boot_contract_epoch_and_clarity_version(contract_name.as_str());
 
@@ -241,8 +229,6 @@ pub fn get_boot_contracts_data_with_overrides(
 
             let (ast, _, _) = interpreter.build_ast(&boot_contract);
             let contract_id = boot_contract.expect_resolved_contract_identifier(None);
-
-            // Insert the contract (this will replace the existing boot contract)
             result.insert(contract_id, (boot_contract, ast));
         }
     }

--- a/components/clarity-repl/src/repl/settings.rs
+++ b/components/clarity-repl/src/repl/settings.rs
@@ -55,6 +55,8 @@ pub struct SessionSettings {
     pub repl_settings: Settings,
     pub cache_location: Option<PathBuf>,
     pub epoch_id: Option<StacksEpochId>,
+    /// Boot contract name → Clarity source code. Loaded upstream so this crate
+    /// stays runtime-agnostic (`wasm32-unknown-unknown` has no `std::fs`).
     pub override_boot_contracts_source: BTreeMap<String, String>,
 }
 

--- a/components/stacks-network/src/main.rs
+++ b/components/stacks-network/src/main.rs
@@ -33,11 +33,8 @@ fn main() {
     let network_manifest_path = get_config_location_from_path_or_exit(&args.network_manifest_path);
     let deployment_location = get_config_location_from_path_or_exit(&args.deployment_plan_path);
 
-    let project_manifest_file_content = paths::read_content(&manifest_location)
-        .unwrap_or_else(|e| panic!("failed to read manifest data {e:?}"));
-
-    let manifest: ProjectManifest = yaml_serde::from_slice(&project_manifest_file_content[..])
-        .unwrap_or_else(|e| panic!("Clarinet.toml file malformatted {e:?}"));
+    let manifest = ProjectManifest::from_location(&manifest_location, false)
+        .unwrap_or_else(|e| panic!("failed to load Clarinet.toml: {e}"));
 
     let network_manifest_file_content = paths::read_content(&network_manifest_path)
         .unwrap_or_else(|e| panic!("failed to read network manifest data {e:?}"));


### PR DESCRIPTION
### Description

`override_boot_contracts_source` silently no-op'd under the wasm SDK because `clarity-repl` read override files via `std::fs`, which doesn't work on `wasm32-unknown-unknown`.

- Move file I/O out of `clarity-repl` into the manifest layer (CLI uses `std::fs`, SDK uses `FileAccessor`).
- Errors now propagate instead of being swallowed.
- New SDK test overrides `pox-4` with a `sentinel` function and asserts the call hits the override.