### PR TITLE
fix: new epoch and clarity types

### DIFF
--- a/components/clarinet-sdk-wasm/src/ts_types.rs
+++ b/components/clarinet-sdk-wasm/src/ts_types.rs
@@ -14,7 +14,8 @@ const EPOCH_STRING: &'static str = r#"export type EpochString =
   | "3.1"
   | "3.2"
   | "3.3"
-  | "3.4";
+  | "3.4"
+  | "4.0";
 "#;
 
 // CONTRACT AST

--- a/components/clarinet-sdk/common/package.json
+++ b/components/clarinet-sdk/common/package.json
@@ -6,5 +6,8 @@
   "license": "GPL-3.0",
   "dependencies": {
     "@stacks/transactions": "7.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "24.0.14"
   }
 }

--- a/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
+++ b/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
@@ -1,4 +1,4 @@
-import { Cl, ClarityValue } from "@stacks/transactions";
+import { Cl, ClarityValue, ClarityVersion } from "@stacks/transactions";
 
 export type ClarityEvent = {
   event: string;
@@ -35,7 +35,7 @@ export type CallFn = (
 ) => ParsedTransactionResult;
 
 export type DeployContractOptions = {
-  clarityVersion: 1 | 2 | 3 | 4;
+  clarityVersion: ClarityVersion;
 };
 export type DeployContract = (
   name: string,

--- a/components/clarinet-sdk/common/tsconfig.json
+++ b/components/clarinet-sdk/common/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["es2022"]
+    "lib": ["es2022"],
+    "types": ["node"]
   },
   "include": ["./src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,10 @@ importers:
       '@stacks/transactions':
         specifier: 7.4.0
         version: 7.4.0
+    devDependencies:
+      '@types/node':
+        specifier: 24.0.14
+        version: 24.0.14
 
   components/clarinet-sdk/node:
     dependencies:


### PR DESCRIPTION
### Description

sdk:
- use @stacks/transaction ClarityVersion enum, one less place to maintain on new ClarityVersions
- Fix tsconfig and node types (similar to #2423, remaining work from the pnpm migration)

sdk-wasm:
- Add epoch 4.0 to the exported `EpochString` (used in `simnet.setEpoch`) 