### PR TITLE
fix: surface getContractAST errors as JsError with descriptive messages

### DIFF
--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -674,14 +674,16 @@ impl SDK {
     }
 
     #[wasm_bindgen(js_name=getContractAST)]
-    pub fn get_contract_ast(&self, contract: &str) -> Result<IContractAST, String> {
+    pub fn get_contract_ast(&self, contract: &str) -> Result<IContractAST, JsError> {
         let session = self.get_session();
-        let contract_id = Session::desugar_contract_id(&self.deployer, contract)?;
-        let contract = session.contracts.get(&contract_id).ok_or("err")?;
+        let contract_id = Session::desugar_contract_id(&self.deployer, contract)
+            .map_err(|e| JsError::new(e.as_str()))?;
+        let contract = session
+            .contracts
+            .get(&contract_id)
+            .ok_or_else(|| JsError::new(&format!("contract {contract_id} not found")))?;
 
-        Ok(encode_to_js(&contract.ast)
-            .map_err(|e| e.to_string())?
-            .unchecked_into::<IContractAST>())
+        Ok(encode_to_js(&contract.ast)?.unchecked_into::<IContractAST>())
     }
 
     #[wasm_bindgen(js_name=getAssetsMap)]


### PR DESCRIPTION
### Description

- Return proper JsError
- Return actual "not found" error instead of "err"

###  Test it

In `remote-data.test.ts` add
```ts
  it.only("can get remote contracts ast", async () => {
    await simnet.initEmptySession({
      enabled: true,
      api_url,
      // the counter contract is deployed at 41613
      initial_height: 800000,
    });
    simnet.getContractAST("ST1S5ZGRZV5K4S9205RWPRTX9RGS9JV40KQMR4G1J.dia-oracle");
  });
```

Build the sdk with and run the test
```sh
$ pnpm run build:sdk-wasm:dev # get clean stack traces
# or 
$ pnpm run build:sdk-wasm

$ pnpm --filter ./components/clarinet-sdk/node t tests/remote-data.test.ts 
```