### PR TITLE
chore: release 3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [3.20.0](https://github.com/stx-labs/clarinet/compare/v3.19.0...v3.20.0) (2026-06-11)
+
+##### New Features
+
+* **linter:**  Flatten variadic functions (#2426) (c3dc1c71)
+
+##### Bug Fixes
+
+*  Remote_data fetch getContractAST (#2431) (ec353a0e)
+*  Surface getContractAST errors as JsError with descriptive messages (#2429) (ecfebc1b)
+*  New epoch and clarity types (#2425) (afc08794)
+
+##### Chores
+
+*  Rename `flatten_nested_variadic` to `flatten_variadic` (#2432) (c479ce13)
+*  Update `vitest` (#2427) (531034e2)
+*  Use TS 6 in sdk (#2423) (2afc6515)
+
 # [3.19.0](https://github.com/stx-labs/clarinet/compare/v3.18.1...v3.19.0) (2026-06-04)
 
 ##### New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "chrono",
  "clap",
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "clarinet-defaults"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "clarity",
 ]
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "bitcoin",
  "clarinet-defaults",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-static-cost"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "clarity",
  "clarity-types",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "observer"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "axum",
  "base58",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.19.0"
+version = "3.20.0"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["components/clarinet-cli"]
 opt-level = 3
 
 [workspace.package]
-version = "3.19.0"
+version = "3.20.0"
 
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",


### PR DESCRIPTION
### New Features

* **linter:**  Flatten variadic functions (#2426) (c3dc1c71)

### Bug Fixes

*  Remote_data fetch getContractAST (#2431) (ec353a0e)
*  Surface getContractAST errors as JsError with descriptive messages (#2429) (ecfebc1b)
*  New epoch and clarity types (#2425) (afc08794)

### Chores

*  Rename `flatten_nested_variadic` to `flatten_variadic` (#2432) (c479ce13)
*  Update `vitest` (#2427) (531034e2)
*  Use TS 6 in sdk (#2423) (2afc6515)

