### PR TITLE
fix: lcov asserts and BRDA numbering

### DIFF
--- a/components/clarity-repl/src/analysis/coverage.rs
+++ b/components/clarity-repl/src/analysis/coverage.rs
@@ -318,8 +318,8 @@ fn retrieve_executable_lines_and_branches(
                         }
                         NativeFunctions::Asserts => {
                             // asserts!(condition, error-value)
-                            // Branch 0 (success/continue): the condition expression
-                            // Branch 1 (error): the error value expression
+                            // Branch 0 (condition evaluated): the condition expression (always evaluated)
+                            // Branch 1 (error path): the error value expression (evaluated when condition is false)
                             let (Some(cond), Some(error_value)) = (args.first(), args.get(1))
                             else {
                                 continue;

--- a/components/clarity-repl/src/analysis/coverage.rs
+++ b/components/clarity-repl/src/analysis/coverage.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use clarity::vm::ast::ContractAST;
 use clarity::vm::errors::VmExecutionError;
 use clarity::vm::functions::define::DefineFunctionsParsed;
-use clarity::vm::functions::NativeFunctions::{self, Filter, Fold, Map};
+use clarity::vm::functions::NativeFunctions;
 use clarity::vm::{EvalHook, SymbolicExpression};
 use clarity_types::types::QualifiedContractIdentifier;
 use serde::{Deserialize, Serialize};
@@ -218,11 +218,32 @@ impl EvalHook for CoverageHook {
     fn did_finish_eval<'a>(
         &mut self,
         _env: &mut clarity::vm::contexts::ExecutionState,
-        _invoke_ctx: &'a clarity::vm::contexts::InvocationContext,
+        invoke_ctx: &'a clarity::vm::contexts::InvocationContext,
         _context: &'a clarity::vm::LocalContext,
-        _expr: &SymbolicExpression,
-        _res: &Result<clarity::vm::ValueRef<'a>, VmExecutionError>,
+        expr: &SymbolicExpression,
+        res: &Result<clarity::vm::ValueRef<'a>, VmExecutionError>,
     ) {
+        // Record the error value's ID when asserts! fails (result is Err).
+        // This gives branch 1 (error) its hit count.
+        if res.is_err() {
+            if let Some(children) = expr.match_list() {
+                if let Some((func, args)) = try_parse_native_func(children) {
+                    if matches!(func, NativeFunctions::Asserts) {
+                        if let Some(error_value) = args.get(1) {
+                            let contract = &invoke_ctx.contract_context.contract_identifier;
+                            let mut contract_report =
+                                self.contracts_coverage.remove(contract).unwrap_or_default();
+                            // Record the error value's own ID for branch 1 tracking
+                            let count = contract_report.entry(error_value.id).or_insert(0);
+                            *count += 1;
+                            // Also recurse to count leaf expressions (like err keyword)
+                            report_eval(&mut contract_report, error_value);
+                            self.contracts_coverage.insert(contract.clone(), contract_report);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn did_complete(&mut self, _result: Result<&mut clarity::vm::ExecutionResult, String>) {
@@ -290,7 +311,7 @@ fn retrieve_executable_lines_and_branches(
                     // handle codes branches
                     // (if, asserts!, and, or, match)
                     match func {
-                        NativeFunctions::If | NativeFunctions::Asserts => {
+                        NativeFunctions::If => {
                             let (_cond, args) = args.split_first().unwrap();
                             branches.insert(
                                 cur_expr.id,
@@ -301,6 +322,26 @@ fn retrieve_executable_lines_and_branches(
                                     })
                                     .collect(),
                             );
+                        }
+                        NativeFunctions::Asserts => {
+                            // asserts!(condition, error-value)
+                            // Branch 0 (success/continue): the condition expression
+                            // Branch 1 (error): the error value expression
+                            let (Some(cond), Some(error_value)) =
+                                (args.first(), args.get(1))
+                            else {
+                                continue;
+                            };
+                            branches.insert(
+                                cur_expr.id,
+                                vec![
+                                    (cond.span.start_line, cond.id),
+                                    (error_value.span.start_line, error_value.id),
+                                ],
+                            );
+                            // Add condition and error value to frontier so they are tracked
+                            // in executable_lines, enabling their hit counts to be looked up
+                            frontier.extend_from_slice(&[cond, error_value]);
                         }
                         NativeFunctions::And | NativeFunctions::Or => {
                             branches.insert(
@@ -368,11 +409,30 @@ fn try_parse_native_func(
 fn report_eval(expr_coverage: &mut ExprCoverage, expr: &SymbolicExpression) {
     if let Some(children) = expr.match_list() {
         if let Some((func, args)) = try_parse_native_func(children) {
-            if matches!(func, Fold | Map | Filter) {
-                if let Some(iterator_func) = args.first() {
-                    report_eval(expr_coverage, iterator_func);
-                }
+            // All native function calls recurse on the function name expression
+            // to ensure it gets recorded in coverage
+            if let Some(func_expr) = children.first() {
+                report_eval(expr_coverage, func_expr);
             }
+
+            match func {
+                NativeFunctions::Fold | NativeFunctions::Map | NativeFunctions::Filter => {
+                    if let Some(iterator_func) = args.first() {
+                        report_eval(expr_coverage, iterator_func);
+                    }
+                }
+                NativeFunctions::Asserts => {
+                    // Record the condition expression's ID so branch 0 (success) gets a hit.
+                    // The condition is always evaluated, regardless of outcome.
+                    if let Some(cond) = args.first() {
+                        let count = expr_coverage.entry(cond.id).or_insert(0);
+                        *count += 1;
+                        report_eval(expr_coverage, cond);
+                    }
+                }
+                _ => {}
+            }
+            return;
         }
         if let Some(func_expr) = children.first() {
             report_eval(expr_coverage, func_expr);

--- a/components/clarity-repl/src/analysis/coverage.rs
+++ b/components/clarity-repl/src/analysis/coverage.rs
@@ -35,7 +35,7 @@ pub struct CoverageHook {
 // DA: line data: line number, hit count
 // BRF: number branches found
 // BRH: number branches hit
-// BRDA: branch data: line number, expr_id, branch_nb, hit count
+// BRDA: branch data: line number, block number, branch_nb, hit count
 
 impl CoverageHook {
     pub fn new() -> Self {
@@ -182,12 +182,26 @@ impl CoverageHook {
                     file_content.push_str(&format!("BRF:{}\n", branches.len()));
                     file_content.push_str(&format!("BRH:{}\n", branches_hits.len()));
 
-                    for ((line, block_id, branch_nb), count) in branch_execution_counts.iter() {
+                    // Renumber block IDs to be sequential per line (LCOV 2.x requirement)
+                    let mut current_line = 0u32;
+                    let mut current_expr_id = 0u64;
+                    let mut block_counter = 0usize;
+                    for ((line, expr_id, branch_nb), count) in branch_execution_counts.iter() {
                         // the ast can contain elements with a span starting at line 0 that we want to ignore
-                        if line > &&0 {
-                            file_content
-                                .push_str(&format!("BRDA:{line},{block_id},{branch_nb},{count}\n"));
+                        if line <= &&0 {
+                            continue;
                         }
+                        if **line != current_line {
+                            current_line = **line;
+                            current_expr_id = **expr_id;
+                            block_counter = 0;
+                        } else if **expr_id != current_expr_id {
+                            current_expr_id = **expr_id;
+                            block_counter += 1;
+                        }
+                        file_content.push_str(&format!(
+                            "BRDA:{line},{block_counter},{branch_nb},{count}\n"
+                        ));
                     }
                 }
                 file_content.push_str("end_of_record\n");
@@ -218,32 +232,11 @@ impl EvalHook for CoverageHook {
     fn did_finish_eval<'a>(
         &mut self,
         _env: &mut clarity::vm::contexts::ExecutionState,
-        invoke_ctx: &'a clarity::vm::contexts::InvocationContext,
+        _invoke_ctx: &'a clarity::vm::contexts::InvocationContext,
         _context: &'a clarity::vm::LocalContext,
-        expr: &SymbolicExpression,
-        res: &Result<clarity::vm::ValueRef<'a>, VmExecutionError>,
+        _expr: &SymbolicExpression,
+        _res: &Result<clarity::vm::ValueRef<'a>, VmExecutionError>,
     ) {
-        // Record the error value's ID when asserts! fails (result is Err).
-        // This gives branch 1 (error) its hit count.
-        if res.is_err() {
-            if let Some(children) = expr.match_list() {
-                if let Some((func, args)) = try_parse_native_func(children) {
-                    if matches!(func, NativeFunctions::Asserts) {
-                        if let Some(error_value) = args.get(1) {
-                            let contract = &invoke_ctx.contract_context.contract_identifier;
-                            let mut contract_report =
-                                self.contracts_coverage.remove(contract).unwrap_or_default();
-                            // Record the error value's own ID for branch 1 tracking
-                            let count = contract_report.entry(error_value.id).or_insert(0);
-                            *count += 1;
-                            // Also recurse to count leaf expressions (like err keyword)
-                            report_eval(&mut contract_report, error_value);
-                            self.contracts_coverage.insert(contract.clone(), contract_report);
-                        }
-                    }
-                }
-            }
-        }
     }
 
     fn did_complete(&mut self, _result: Result<&mut clarity::vm::ExecutionResult, String>) {
@@ -327,21 +320,19 @@ fn retrieve_executable_lines_and_branches(
                             // asserts!(condition, error-value)
                             // Branch 0 (success/continue): the condition expression
                             // Branch 1 (error): the error value expression
-                            let (Some(cond), Some(error_value)) =
-                                (args.first(), args.get(1))
+                            let (Some(cond), Some(error_value)) = (args.first(), args.get(1))
                             else {
                                 continue;
                             };
+                            let cond_expr = extract_expr_from_list(cond);
+                            let error_expr = extract_expr_from_list(error_value);
                             branches.insert(
                                 cur_expr.id,
                                 vec![
-                                    (cond.span.start_line, cond.id),
-                                    (error_value.span.start_line, error_value.id),
+                                    (cond_expr.span.start_line, cond_expr.id),
+                                    (error_expr.span.start_line, error_expr.id),
                                 ],
                             );
-                            // Add condition and error value to frontier so they are tracked
-                            // in executable_lines, enabling their hit counts to be looked up
-                            frontier.extend_from_slice(&[cond, error_value]);
                         }
                         NativeFunctions::And | NativeFunctions::Or => {
                             branches.insert(
@@ -419,15 +410,6 @@ fn report_eval(expr_coverage: &mut ExprCoverage, expr: &SymbolicExpression) {
                 NativeFunctions::Fold | NativeFunctions::Map | NativeFunctions::Filter => {
                     if let Some(iterator_func) = args.first() {
                         report_eval(expr_coverage, iterator_func);
-                    }
-                }
-                NativeFunctions::Asserts => {
-                    // Record the condition expression's ID so branch 0 (success) gets a hit.
-                    // The condition is always evaluated, regardless of outcome.
-                    if let Some(cond) = args.first() {
-                        let count = expr_coverage.entry(cond.id).or_insert(0);
-                        *count += 1;
-                        report_eval(expr_coverage, cond);
                     }
                 }
                 _ => {}

--- a/components/clarity-repl/src/analysis/coverage_tests.rs
+++ b/components/clarity-repl/src/analysis/coverage_tests.rs
@@ -209,7 +209,7 @@ fn simple_if_branching() {
     let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
-        [&expect_base[..], &["BRDA:2,8,0,1", "BRDA:2,8,1,0"]]
+        [&expect_base[..], &["BRDA:2,0,0,1", "BRDA:2,0,1,0"]]
             .concat()
             .join("\n"),
     );
@@ -220,7 +220,7 @@ fn simple_if_branching() {
     let cov = get_coverage_report(contract.as_str(), vec![snippet.into()]);
 
     let expect = get_expected_report(
-        [&expect_base[..], &["BRDA:2,8,0,0", "BRDA:2,8,1,1"]]
+        [&expect_base[..], &["BRDA:2,0,0,0", "BRDA:2,0,1,1"]]
             .concat()
             .join("\n"),
     );
@@ -248,8 +248,8 @@ fn simple_if_branches_with_exprs() {
             "DA:2,1",
             "BRF:2",
             "BRH:1",
-            "BRDA:2,8,0,1",
-            "BRDA:2,8,1,0",
+            "BRDA:2,0,0,1",
+            "BRDA:2,0,1,0",
         ]
         .join("\n"),
     );
@@ -285,8 +285,8 @@ fn hit_all_if_branches() {
             "DA:2,5",
             "BRF:2",
             "BRH:2",
-            "BRDA:2,8,0,3",
-            "BRDA:2,8,1,2",
+            "BRDA:2,0,0,3",
+            "BRDA:2,0,1,2",
         ]
         .join("\n"),
     );
@@ -313,11 +313,11 @@ fn simple_asserts_branching() {
             "FNF:1",
             "FNH:1",
             "DA:1,1",
-            "DA:2,2", // asserts! keyword + condition
+            "DA:2,1",
             "BRF:2",
             "BRH:1",
-            "BRDA:2,10,0,1", // condition hit
-            "BRDA:2,10,1,0", // error value not hit
+            "BRDA:2,0,0,1", // condition hit (success path)
+            "BRDA:2,0,1,0", // error value not hit
         ]
         .join("\n"),
     );
@@ -334,11 +334,143 @@ fn simple_asserts_branching() {
             "FNF:1",
             "FNH:1",
             "DA:1,1",
-            "DA:2,2", // asserts! keyword + condition (err keyword not counted in line coverage)
+            "DA:2,1",
             "BRF:2",
             "BRH:2",
-            "BRDA:2,10,0,1", // condition hit
-            "BRDA:2,10,1,1", // error value hit
+            "BRDA:2,0,0,1", // condition hit
+            "BRDA:2,0,1,1", // error value hit
+        ]
+        .join("\n"),
+    );
+    assert_eq!(cov, expect);
+}
+
+#[test]
+fn asserts_both_paths_hit() {
+    let contract = [
+        "(define-read-only (is-one (v int))",
+        "  (ok (asserts! (is-eq v 1) (err u1)))",
+        ")",
+    ]
+    .join("\n");
+
+    // hit success 2 times and error 1 time
+    let snippets: Vec<String> = vec![
+        "(contract-call? .contract-0 is-one 1)".into(),
+        "(contract-call? .contract-0 is-one 1)".into(),
+        "(contract-call? .contract-0 is-one 2)".into(),
+    ];
+    let cov = get_coverage_report(&contract, snippets);
+
+    let expect = get_expected_report(
+        [
+            "FN:1,is-one",
+            "FNDA:3,is-one",
+            "FNF:1",
+            "FNH:1",
+            "DA:1,1",
+            "DA:2,3",
+            "BRF:2",
+            "BRH:2",
+            "BRDA:2,0,0,3", // condition hit 3 times (always evaluated)
+            "BRDA:2,0,1,1", // error value hit 1 time
+        ]
+        .join("\n"),
+    );
+    assert_eq!(cov, expect);
+}
+
+#[test]
+fn asserts_multiline() {
+    let contract = [
+        "(define-read-only (is-one (v int))",
+        "  (ok (asserts!",
+        "    (is-eq v 1)",
+        "    (err u1)",
+        "  ))",
+        ")",
+    ]
+    .join("\n");
+
+    // success path
+    let snippets: Vec<String> = vec!["(contract-call? .contract-0 is-one 1)".into()];
+    let cov = get_coverage_report(&contract, snippets);
+
+    let expect = get_expected_report(
+        [
+            "FN:1,is-one",
+            "FNDA:1,is-one",
+            "FNF:1",
+            "FNH:1",
+            "DA:1,1",
+            "DA:2,1",
+            "DA:3,1",
+            "DA:4,0", // error value not evaluated
+            "BRF:2",
+            "BRH:1",
+            "BRDA:3,0,0,1", // condition hit
+            "BRDA:4,0,1,0", // error value not hit
+        ]
+        .join("\n"),
+    );
+    assert_eq!(cov, expect);
+
+    // failure path
+    let snippets: Vec<String> = vec!["(contract-call? .contract-0 is-one 2)".into()];
+    let cov = get_coverage_report(&contract, snippets);
+
+    let expect = get_expected_report(
+        [
+            "FN:1,is-one",
+            "FNDA:1,is-one",
+            "FNF:1",
+            "FNH:1",
+            "DA:1,1",
+            "DA:2,1",
+            "DA:3,1",
+            "DA:4,1", // error value evaluated
+            "BRF:2",
+            "BRH:2",
+            "BRDA:3,0,0,1", // condition hit
+            "BRDA:4,0,1,1", // error value hit
+        ]
+        .join("\n"),
+    );
+    assert_eq!(cov, expect);
+}
+
+// Reproduces the exact scenario from issue #2437:
+// asserts! in a begin block inside define-public
+#[test]
+fn asserts_in_begin_block() {
+    let contract = [
+        "(define-public (check (n uint))",
+        "  (begin",
+        "    (asserts! (> n u1) (err u501))",
+        "    (ok true)",
+        "  )",
+        ")",
+    ]
+    .join("\n");
+
+    // only success path hit — this was the failing case in the issue
+    let snippets: Vec<String> = vec!["(contract-call? .contract-0 check u10)".into()];
+    let cov = get_coverage_report(&contract, snippets);
+
+    let expect = get_expected_report(
+        [
+            "FN:1,check",
+            "FNDA:1,check",
+            "FNF:1",
+            "FNH:1",
+            "DA:1,1",
+            "DA:2,1",
+            "DA:3,1",
+            "DA:4,1",
+            "BRF:2",
+            "BRH:1",
+            "BRDA:3,0,0,1", // condition hit (success)
+            "BRDA:3,0,1,0", // error value not hit
         ]
         .join("\n"),
     );
@@ -372,12 +504,12 @@ fn branch_if_plus_and() {
             "DA:4,1", // right if path
             "BRF:6",
             "BRH:4",
-            "BRDA:2,10,0,1",
-            "BRDA:2,10,1,1",
-            "BRDA:2,10,2,1",
-            "BRDA:2,10,3,0", // (> v 3) not hit
-            "BRDA:3,8,0,0",  // left if path not hit
-            "BRDA:4,8,1,1",
+            "BRDA:2,0,0,1",
+            "BRDA:2,0,1,1",
+            "BRDA:2,0,2,1",
+            "BRDA:2,0,3,0", // (> v 3) not hit
+            "BRDA:3,0,0,0", // left if path not hit
+            "BRDA:4,0,1,1",
         ]
         .join("\n"),
     );
@@ -411,12 +543,12 @@ fn branch_if_plus_or() {
             "DA:4,0", // right if path
             "BRF:6",
             "BRH:3",
-            "BRDA:2,10,0,1",
-            "BRDA:2,10,1,1", // stop
-            "BRDA:2,10,2,0",
-            "BRDA:2,10,3,0",
-            "BRDA:3,8,0,1",
-            "BRDA:4,8,1,0",
+            "BRDA:2,0,0,1",
+            "BRDA:2,0,1,1", // stop
+            "BRDA:2,0,2,0",
+            "BRDA:2,0,3,0",
+            "BRDA:3,0,0,1",
+            "BRDA:4,0,1,0",
         ]
         .join("\n"),
     );
@@ -448,7 +580,7 @@ fn match_opt_oneline() {
     let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
-        [&expect_base[..], &["BRDA:2,10,0,1", "BRDA:2,10,1,0"]]
+        [&expect_base[..], &["BRDA:2,0,0,1", "BRDA:2,0,1,0"]]
             .concat()
             .join("\n"),
     );
@@ -459,7 +591,7 @@ fn match_opt_oneline() {
     let cov = get_coverage_report(&contract, snippets);
 
     let expect = get_expected_report(
-        [&expect_base[..], &["BRDA:2,10,0,0", "BRDA:2,10,1,1"]]
+        [&expect_base[..], &["BRDA:2,0,0,0", "BRDA:2,0,1,1"]]
             .concat()
             .join("\n"),
     );
@@ -500,8 +632,8 @@ fn match_opt_multiline() {
                 "DA:5,0",
                 "BRF:2",
                 "BRH:1",
-                "BRDA:4,10,0,1",
-                "BRDA:5,10,1,0",
+                "BRDA:4,0,0,1",
+                "BRDA:5,0,1,0",
             ],
         ]
         .concat()
@@ -521,8 +653,8 @@ fn match_opt_multiline() {
                 "DA:5,1",
                 "BRF:2",
                 "BRH:1",
-                "BRDA:4,10,0,0",
-                "BRDA:5,10,1,1",
+                "BRDA:4,0,0,0",
+                "BRDA:5,0,1,1",
             ],
         ]
         .concat()
@@ -560,8 +692,8 @@ fn match_res_oneline() {
             "DA:2,3",
             "BRF:2",
             "BRH:2",
-            "BRDA:2,11,0,2",
-            "BRDA:2,11,1,1",
+            "BRDA:2,0,0,2",
+            "BRDA:2,0,1,1",
         ]
         .join("\n"),
     );

--- a/components/clarity-repl/src/analysis/coverage_tests.rs
+++ b/components/clarity-repl/src/analysis/coverage_tests.rs
@@ -302,7 +302,7 @@ fn simple_asserts_branching() {
     ]
     .join("\n");
 
-    // no hit on (err u1)
+    // asserts! succeeds: condition hit, error value not hit
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 is-one 1)".into()];
     let cov = get_coverage_report(&contract, snippets);
 
@@ -313,16 +313,17 @@ fn simple_asserts_branching() {
             "FNF:1",
             "FNH:1",
             "DA:1,1",
-            "DA:2,1",
-            "BRF:1",
-            "BRH:0",
-            "BRDA:2,10,0,0",
+            "DA:2,2", // asserts! keyword + condition
+            "BRF:2",
+            "BRH:1",
+            "BRDA:2,10,0,1", // condition hit
+            "BRDA:2,10,1,0", // error value not hit
         ]
         .join("\n"),
     );
     assert_eq!(cov, expect);
 
-    // hit on (err u1)
+    // asserts! fails: both condition and error value hit
     let snippets: Vec<String> = vec!["(contract-call? .contract-0 is-one 2)".into()];
     let cov = get_coverage_report(&contract, snippets);
 
@@ -333,10 +334,11 @@ fn simple_asserts_branching() {
             "FNF:1",
             "FNH:1",
             "DA:1,1",
-            "DA:2,1",
-            "BRF:1",
-            "BRH:1",
-            "BRDA:2,10,0,1",
+            "DA:2,2", // asserts! keyword + condition (err keyword not counted in line coverage)
+            "BRF:2",
+            "BRH:2",
+            "BRDA:2,10,0,1", // condition hit
+            "BRDA:2,10,1,1", // error value hit
         ]
         .join("\n"),
     );


### PR DESCRIPTION
- closes #2437 

- BRDA uses sequential block ids (lcov 2.x)
- asserts work similar to other branching fns
- did_finish_Eval was double counting with new will_begin_eval counting
 