### PR TITLE
fix: include suggestion text in lsp diagnostics

### DIFF
--- a/components/clarity-lsp/src/utils/mod.rs
+++ b/components/clarity-lsp/src/utils/mod.rs
@@ -57,7 +57,10 @@ pub fn clarity_diagnostic_to_lsp_type(
         code,
         code_description: None,
         source: Some("clarity".to_string()),
-        message: diagnostic.message.clone(),
+        message: match &diagnostic.suggestion {
+            Some(suggestion) => format!("{}\n{suggestion}", diagnostic.message),
+            None => diagnostic.message.clone(),
+        },
         related_information: None,
         tags: None,
         data: None,

--- a/components/clarity-lsp/src/utils/mod.rs
+++ b/components/clarity-lsp/src/utils/mod.rs
@@ -58,7 +58,7 @@ pub fn clarity_diagnostic_to_lsp_type(
         code_description: None,
         source: Some("clarity".to_string()),
         message: match &diagnostic.suggestion {
-            Some(suggestion) => format!("{}\n{suggestion}", diagnostic.message),
+            Some(suggestion) => format!("{}\n\n{suggestion}", diagnostic.message),
             None => diagnostic.message.clone(),
         },
         related_information: None,

--- a/components/clarity-repl/src/analysis/lints/flatten_variadic.rs
+++ b/components/clarity-repl/src/analysis/lints/flatten_variadic.rs
@@ -78,13 +78,13 @@ impl<'a> FlattenVariadic<'a> {
 
         for operand in operands {
             if Self::is_nested_call(operand, func_name) {
-                let suggestion = if let Some(note) = note {
-                    let styled_note = yellow!("Note: {note}");
-                    format!(
-                        "Merge the inner `{func_name}` arguments into the outer call\n{styled_note}"
-                    )
-                } else {
-                    format!("Merge the inner `{func_name}` arguments into the outer call")
+                let suggestion = match note {
+                    Some(note) => format!(
+                        "Merge the inner `{func_name}` arguments into the outer call\nNote: {note}"
+                    ),
+                    None => {
+                        format!("Merge the inner `{func_name}` arguments into the outer call")
+                    }
                 };
                 self.diagnostics.push(Diagnostic {
                     level: self.level.clone(),

--- a/components/clarity-repl/src/repl/diagnostic.rs
+++ b/components/clarity-repl/src/repl/diagnostic.rs
@@ -57,10 +57,26 @@ pub fn output_diagnostic(
     output.append(&mut output_code(diagnostic, lines));
 
     if let Some(ref suggestion) = diagnostic.suggestion {
-        output.push(suggestion.to_string());
+        output.push(colorize_suggestion(suggestion));
     }
 
     output
+}
+
+/// Apply terminal colors to a suggestion string.
+/// Lines starting with "Note:" are highlighted in yellow.
+fn colorize_suggestion(suggestion: &str) -> String {
+    suggestion
+        .lines()
+        .map(|line| {
+            if let Some(rest) = line.strip_prefix("Note:") {
+                yellow!("Note:{rest}").to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 pub fn output_code(diagnostic: &Diagnostic, lines: &[String]) -> Vec<String> {


### PR DESCRIPTION
Previously the suggestion text was only displayed in `clarinet check`

<img width="442" height="144" alt="Screenshot 2026-06-17 at 9 14 47 AM" src="https://github.com/user-attachments/assets/6dab355e-a691-4877-bf36-8fb21428f2ea" />


