### PR TITLE
fix: avoid capacity overflow bug in static cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1462,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1497,7 +1497,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if 1.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2313,7 +2313,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3157,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -3628,7 +3628,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4231,7 +4231,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -4475,7 +4474,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5279,7 +5278,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -193,10 +193,6 @@ impl SummingExecutionCost {
         self.costs.push(cost);
     }
 
-    pub fn add_summing(&mut self, other: &SummingExecutionCost) {
-        self.costs.extend(other.costs.iter().cloned());
-    }
-
     /// minimum cost across all paths
     pub fn min(&self) -> ExecutionCost {
         self.costs
@@ -225,15 +221,6 @@ impl SummingExecutionCost {
                 read_count: acc.read_count.max(cost.read_count),
             })
             .unwrap_or(ExecutionCost::ZERO)
-    }
-
-    pub fn add_all(&self) -> ExecutionCost {
-        self.costs
-            .iter()
-            .fold(ExecutionCost::ZERO, |mut acc, cost| {
-                saturating_add_cost(&mut acc, cost);
-                acc
-            })
     }
 }
 

--- a/components/clarity-static-cost/src/static_cost/mod.rs
+++ b/components/clarity-static-cost/src/static_cost/mod.rs
@@ -173,34 +173,39 @@ pub(crate) fn calculate_total_cost_with_branching(node: &CostAnalysisNode) -> Su
                         calculate_total_cost_with_branching(&node.children[0]);
                     let condition_static: StaticCost = condition_branching.into();
 
-                    // Add the root cost + condition's worst-case cost to each branch.
+                    // Build separate min/max bases: root cost + condition cost.
                     // Each branch is mutually exclusive, so we add root+condition to each.
-                    let mut root_and_condition = node.cost.min.clone();
-                    saturating_add_cost(&mut root_and_condition, &condition_static.max);
+                    let mut root_and_condition_min = node.cost.min.clone();
+                    saturating_add_cost(&mut root_and_condition_min, &condition_static.min);
+                    let mut root_and_condition_max = node.cost.max.clone();
+                    saturating_add_cost(&mut root_and_condition_max, &condition_static.max);
 
                     for child_cost_node in node.children.iter().skip(1) {
                         // Use _branching to avoid cartesian product explosion.
                         let branch_cost = calculate_total_cost_with_branching(child_cost_node);
                         let branch_static: StaticCost = branch_cost.into();
                         // Add min path for this branch
-                        let mut min_path = root_and_condition.clone();
+                        let mut min_path = root_and_condition_min.clone();
                         saturating_add_cost(&mut min_path, &branch_static.min);
                         summing_cost.add_cost(min_path);
                         // Add max path for this branch
-                        let mut max_path = root_and_condition.clone();
+                        let mut max_path = root_and_condition_max.clone();
                         saturating_add_cost(&mut max_path, &branch_static.max);
                         summing_cost.add_cost(max_path);
                     }
                 }
             }
             _ => {
-                let mut total_cost = node.cost.min.clone();
+                let mut total_cost_min = node.cost.min.clone();
+                let mut total_cost_max = node.cost.max.clone();
                 for child_cost_node in &node.children {
                     let child_branching = calculate_total_cost_with_branching(child_cost_node);
                     let child_static: StaticCost = child_branching.into();
-                    saturating_add_cost(&mut total_cost, &child_static.max);
+                    saturating_add_cost(&mut total_cost_min, &child_static.min);
+                    saturating_add_cost(&mut total_cost_max, &child_static.max);
                 }
-                summing_cost.add_cost(total_cost);
+                summing_cost.add_cost(total_cost_min);
+                summing_cost.add_cost(total_cost_max);
             }
         }
     } else {

--- a/components/clarity-static-cost/src/static_cost/mod.rs
+++ b/components/clarity-static-cost/src/static_cost/mod.rs
@@ -156,43 +156,6 @@ pub(crate) fn calculate_function_cost_from_native_function(
     }
 }
 
-/// total cost handling branching
-/// For non-branching we combine all paths
-pub(crate) fn calculate_total_cost_with_summing(node: &CostAnalysisNode) -> SummingExecutionCost {
-    // If node has different min and max costs, create paths for both
-    // Otherwise, use a single path with the cost
-    let mut summing_cost = if node.cost.min.runtime != node.cost.max.runtime
-        || node.cost.min.write_length != node.cost.max.write_length
-        || node.cost.min.write_count != node.cost.max.write_count
-        || node.cost.min.read_length != node.cost.max.read_length
-        || node.cost.min.read_count != node.cost.max.read_count
-    {
-        // Node has a range, create paths for both min and max
-        let mut summing = SummingExecutionCost::new();
-        summing.add_cost(node.cost.min.clone());
-        summing.add_cost(node.cost.max.clone());
-        summing
-    } else {
-        // Node has fixed cost, use single path
-        SummingExecutionCost::from(node.cost.min.clone())
-    };
-
-    for child in &node.children {
-        let child_summing = calculate_total_cost_with_summing(child);
-        // Combine each existing path with each child path (cartesian product)
-        let current_paths = summing_cost.costs.clone();
-        summing_cost = SummingExecutionCost::new();
-        for current_path in current_paths {
-            for child_path in &child_summing.costs {
-                let mut combined_path = current_path.clone();
-                saturating_add_cost(&mut combined_path, child_path);
-                summing_cost.add_cost(combined_path);
-            }
-        }
-    }
-    summing_cost
-}
-
 pub(crate) fn calculate_total_cost_with_branching(node: &CostAnalysisNode) -> SummingExecutionCost {
     let mut summing_cost = SummingExecutionCost::new();
 
@@ -206,32 +169,36 @@ pub(crate) fn calculate_total_cost_with_branching(node: &CostAnalysisNode) -> Su
                 // Match expressions work similarly to If: evaluate condition, then evaluate matching branch
                 // The cost includes the condition evaluation plus the cost of the selected branch
                 if node.children.len() >= 2 {
-                    let condition_cost = calculate_total_cost_with_summing(&node.children[0]);
-                    let condition_total = condition_cost.add_all();
+                    let condition_branching =
+                        calculate_total_cost_with_branching(&node.children[0]);
+                    let condition_static: StaticCost = condition_branching.into();
 
-                    // Add the root cost + condition cost to each branch
+                    // Add the root cost + condition's worst-case cost to each branch.
+                    // Each branch is mutually exclusive, so we add root+condition to each.
                     let mut root_and_condition = node.cost.min.clone();
-                    saturating_add_cost(&mut root_and_condition, &condition_total);
+                    saturating_add_cost(&mut root_and_condition, &condition_static.max);
 
                     for child_cost_node in node.children.iter().skip(1) {
-                        let branch_cost = calculate_total_cost_with_summing(child_cost_node);
-                        // For each path in the branch, add root_and_condition to create a full path
-                        // This preserves all branch paths so we can correctly compute min/max
-                        for branch_path in &branch_cost.costs {
-                            let mut path_cost = root_and_condition.clone();
-                            saturating_add_cost(&mut path_cost, branch_path);
-                            summing_cost.add_cost(path_cost);
-                        }
+                        // Use _branching to avoid cartesian product explosion.
+                        let branch_cost = calculate_total_cost_with_branching(child_cost_node);
+                        let branch_static: StaticCost = branch_cost.into();
+                        // Add min path for this branch
+                        let mut min_path = root_and_condition.clone();
+                        saturating_add_cost(&mut min_path, &branch_static.min);
+                        summing_cost.add_cost(min_path);
+                        // Add max path for this branch
+                        let mut max_path = root_and_condition.clone();
+                        saturating_add_cost(&mut max_path, &branch_static.max);
+                        summing_cost.add_cost(max_path);
                     }
                 }
             }
             _ => {
-                // For other branching functions, fall back to sequential processing
                 let mut total_cost = node.cost.min.clone();
                 for child_cost_node in &node.children {
-                    let child_summing = calculate_total_cost_with_summing(child_cost_node);
-                    let combined_cost = child_summing.add_all();
-                    saturating_add_cost(&mut total_cost, &combined_cost);
+                    let child_branching = calculate_total_cost_with_branching(child_cost_node);
+                    let child_static: StaticCost = child_branching.into();
+                    saturating_add_cost(&mut total_cost, &child_static.max);
                 }
                 summing_cost.add_cost(total_cost);
             }
@@ -256,8 +223,8 @@ pub(crate) fn calculate_total_cost_with_branching(node: &CostAnalysisNode) -> Su
                 CostExprNode::NativeFunction(NativeFunctions::Asserts)
             ) {
                 // "Fail" path: full Asserts cost (node + condition + error), then stop.
-                let asserts_full_summing = calculate_total_cost_with_summing(child_cost_node);
-                let asserts_full_static: StaticCost = asserts_full_summing.into();
+                let asserts_full_branching = calculate_total_cost_with_branching(child_cost_node);
+                let asserts_full_static: StaticCost = asserts_full_branching.into();
                 let mut fail_min = total_cost_min.clone();
                 saturating_add_cost(&mut fail_min, &asserts_full_static.min);
                 terminated_paths.push(fail_min);
@@ -270,8 +237,8 @@ pub(crate) fn calculate_total_cost_with_branching(node: &CostAnalysisNode) -> Su
                 saturating_add_cost(&mut total_cost_min, &child_cost_node.cost.min);
                 saturating_add_cost(&mut total_cost_max, &child_cost_node.cost.max);
                 if let Some(condition_node) = child_cost_node.children.first() {
-                    let cond_summing = calculate_total_cost_with_summing(condition_node);
-                    let cond_static: StaticCost = cond_summing.into();
+                    let cond_branching = calculate_total_cost_with_branching(condition_node);
+                    let cond_static: StaticCost = cond_branching.into();
                     saturating_add_cost(&mut total_cost_min, &cond_static.min);
                     saturating_add_cost(&mut total_cost_max, &cond_static.max);
                 }
@@ -280,8 +247,8 @@ pub(crate) fn calculate_total_cost_with_branching(node: &CostAnalysisNode) -> Su
                 // Branching children (If/Match) produce a range of costs; we fold
                 // their min/max into total_cost_min/max so that subsequent siblings
                 // are added on top of the full accumulated cost.
-                let child_summing = calculate_total_cost_with_branching(child_cost_node);
-                let child_static_cost: StaticCost = child_summing.into();
+                let child_branching = calculate_total_cost_with_branching(child_cost_node);
+                let child_static_cost: StaticCost = child_branching.into();
                 saturating_add_cost(&mut total_cost_min, &child_static_cost.min);
                 saturating_add_cost(&mut total_cost_max, &child_static_cost.max);
             }

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -2644,8 +2644,8 @@ fn test_deeply_nested_asserts_no_capacity_overflow() {
     "#};
 
     let contract_id = QualifiedContractIdentifier::transient();
-    let epoch = StacksEpochId::Epoch2_05;
-    let clarity_version = ClarityVersion::Clarity5;
+    let epoch = StacksEpochId::Epoch32;
+    let clarity_version = ClarityVersion::Clarity3;
     let ast = clarity::vm::ast::build_ast(&contract_id, src, &mut (), clarity_version, epoch)
         .expect("Failed to build AST");
 

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -2686,11 +2686,6 @@ fn test_deeply_nested_asserts_no_capacity_overflow() {
             .costs
             .get(fn_name)
             .expect(&format!("{} should exist", fn_name));
-        assert!(
-            cost.max.runtime > cost.min.runtime,
-            "{} cost should be bounded; got runtime={}",
-            fn_name,
-            cost.max.runtime
-        );
+        assert!(cost.max.runtime >= cost.min.runtime);
     }
 }

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -2685,7 +2685,7 @@ fn test_deeply_nested_asserts_no_capacity_overflow() {
         let (cost, _) = result
             .costs
             .get(fn_name)
-            .expect(&format!("{} should exist", fn_name));
+            .unwrap_or_else(|| panic!("{fn_name} should exist"));
         assert!(cost.max.runtime >= cost.min.runtime);
     }
 }

--- a/components/clarity-static-cost/tests/mod.rs
+++ b/components/clarity-static-cost/tests/mod.rs
@@ -2587,3 +2587,110 @@ fn test_static_cost_handles_mutual_trait_impl_cycle() {
         chain_cost.max.runtime
     );
 }
+
+/// Regression test for "capacity overflow" panic in static cost analysis.
+/// Checks that deeply nested clarity doesn't cause Vec capacity overflow.
+/// code adapted from pyth-lazer-decoder contract
+#[test]
+fn test_deeply_nested_asserts_no_capacity_overflow() {
+    let src = indoc! {r#"
+        (define-constant ERR_SHORT (err u2101))
+        (define-constant ERR_MAGIC (err u2102))
+        (define-constant EVM_MAGIC u706910618)
+        (define-constant SIG_OFFSET u4)
+        (define-constant LEN_OFFSET u69)
+        (define-constant PAYLOAD_OFFSET u71)
+        (define-constant FORMAT_MAGIC u2479346549)
+        (define-constant FEEDS_OFFSET u14)
+        (define-constant MAX_FEEDS u16)
+
+        (define-private (read-uint-be? (bytes (buff 8192)) (pos uint) (size uint))
+            (match (slice? bytes pos (+ pos size))
+                b (some (buff-to-uint-be (unwrap-panic (as-max-len? b u16))))
+                none))
+
+        (define-read-only (recover-signer (update (buff 8192)))
+            (let ((update-len (len update)))
+                (asserts! (>= update-len PAYLOAD_OFFSET) ERR_SHORT)
+                (asserts! (is-eq (unwrap! (read-uint-be? update u0 u4) ERR_SHORT) EVM_MAGIC) ERR_MAGIC)
+                (let ((signature-bytes (unwrap! (slice? update SIG_OFFSET LEN_OFFSET) ERR_SHORT))
+                        (signature (unwrap! (as-max-len? signature-bytes u65) ERR_SHORT))
+                        (payload-len (unwrap! (read-uint-be? update LEN_OFFSET u2) ERR_SHORT))
+                        (payload-end (+ PAYLOAD_OFFSET payload-len))
+                        (payload (unwrap! (slice? update PAYLOAD_OFFSET payload-end) ERR_SHORT)))
+                    (asserts! (is-eq update-len payload-end) ERR_SHORT)
+                    (ok {
+                        signer: (some 0x0102030405060708091011121314151617181920212223242526272829303132ff),
+                        payload: payload
+                    }))))
+
+        (define-read-only (decode-payload (payload (buff 8192)))
+            (begin
+                (asserts! (>= (len payload) FEEDS_OFFSET) ERR_SHORT)
+                (asserts! (is-eq (unwrap! (read-uint-be? payload u0 u4) ERR_SHORT) FORMAT_MAGIC) ERR_MAGIC)
+                (let ((timestamp (unwrap! (read-uint-be? payload u4 u8) ERR_SHORT))
+                        (channel (unwrap! (read-uint-be? payload u12 u1) ERR_SHORT))
+                        (feeds-len (unwrap! (read-uint-be? payload u13 u1) ERR_SHORT)))
+                    (asserts! (<= feeds-len MAX_FEEDS) ERR_SHORT)
+                    (ok {
+                        timestamp: timestamp,
+                        channel: channel,
+                        price-feeds: (list)
+                    }))))
+
+        (define-public (decode-and-verify-price-feeds (update (buff 8192)))
+            (let ((verified (try! (recover-signer update))))
+                (decode-payload (get payload verified))))
+    "#};
+
+    let contract_id = QualifiedContractIdentifier::transient();
+    let epoch = StacksEpochId::Epoch2_05;
+    let clarity_version = ClarityVersion::Clarity5;
+    let ast = clarity::vm::ast::build_ast(&contract_id, src, &mut (), clarity_version, epoch)
+        .expect("Failed to build AST");
+
+    let mut memory_store = MemoryBackingStore::new();
+    let db = memory_store.as_clarity_db();
+    let mut owned_env = OwnedEnvironment::new(db, epoch);
+
+    // This must NOT panic with "capacity overflow"
+    let result = with_cost_analysis_environment(
+        &mut owned_env,
+        &contract_id,
+        clarity_version,
+        |env, invoke_ctx| {
+            static_cost_from_ast(&ast, &clarity_version, epoch, None, env, invoke_ctx)
+        },
+    )
+    .expect("static_cost must not panic with capacity overflow");
+
+    // Verify the costs don't blow up
+    let (decode_cost, _) = result
+        .costs
+        .get("decode-and-verify-price-feeds")
+        .expect("decode-and-verify-price-feeds should be in cost map");
+
+    assert!(
+        decode_cost.max.runtime < u64::MAX / 2,
+        "Cost should be bounded; got runtime={}",
+        decode_cost.max.runtime
+    );
+
+    // pick 3 random fns. If it doesn't blow up with "capacity overflow", the cost is fine
+    for fn_name in [
+        "recover-signer",
+        "decode-payload",
+        "decode-and-verify-price-feeds",
+    ] {
+        let (cost, _) = result
+            .costs
+            .get(fn_name)
+            .expect(&format!("{} should exist", fn_name));
+        assert!(
+            cost.max.runtime > cost.min.runtime,
+            "{} cost should be bounded; got runtime={}",
+            fn_name,
+            cost.max.runtime
+        );
+    }
+}


### PR DESCRIPTION
The `calculate_total_cost_with_summing` had a bug that resulted in the "capacity overflow" bug that popped up from the pyth-lazer-decoder contract. This removes that function in favor of the branching function that doesn't have a summing explosion on deeply nested clarity

### screenshot showing static costs on the pyth decode contract working

<img width="854" height="347" alt="Screenshot 2026-06-23 at 2 23 13 PM" src="https://github.com/user-attachments/assets/e784007c-5d71-44f4-8b33-a63bed00236c" />

Also fixes a vuln exposed by `cargo audit` - quinn-proto transitive dep for reqwest

