### PR TITLE
chore: release 3.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [3.21.0](https://github.com/stx-labs/clarinet/compare/v3.20.0...v3.21.0) (2026-06-25)
+
+##### New Features
+
+*  Pox-5 devnet capabilities (#2428) (23473c07)
+*  Add logger hook filters (all, project-only, none) (#2442) (3a3e35ab)
+*  Replace curl shellout with worker-thread sync HTTP in Node WASM (#2408) (eebe5bba)
+
+##### Bug Fixes
+
+*  Include suggestion text in lsp diagnostics (#2440) (39d26190)
+*  Avoid capacity overflow bug in static cost (#2445) (c673a831)
+*  LCOV asserts and BRDA numbering (#2439) (c4f19dc3)
+
+##### Chores
+
+*  Update syntax with new clarity 6 functions (#2443) (98ac956b)
+
 # [3.20.0](https://github.com/stx-labs/clarinet/compare/v3.19.0...v3.20.0) (2026-06-11)
 
 ##### New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "chrono",
  "clap",
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "clarinet-defaults"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "clarity",
 ]
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "bitcoin",
  "clarinet-defaults",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-static-cost"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "clarity",
  "clarity-types",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "observer"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "axum",
  "base58",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.20.0"
+version = "3.21.0"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["components/clarinet-cli"]
 opt-level = 3
 
 [workspace.package]
-version = "3.20.0"
+version = "3.21.0"
 
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",


### PR DESCRIPTION
##### New Features

*  Pox-5 devnet capabilities (#2428) (23473c07)
*  Add logger hook filters (all, project-only, none) (#2442) (3a3e35ab)
*  Replace curl shellout with worker-thread sync HTTP in Node WASM (#2408) (eebe5bba)

##### Bug Fixes

*  Include suggestion text in lsp diagnostics (#2440) (39d26190)
*  Avoid capacity overflow bug in static cost (#2445) (c673a831)
*  LCOV asserts and BRDA numbering (#2439) (c4f19dc3)

##### Chores

*  Update syntax with new clarity 6 functions (#2443) (98ac956b)

