### PR TITLE
feat: include/exclude lint filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "debug_types",
  "divan",
  "futures",
+ "glob",
  "hiro-system-kit",
  "httparse",
  "indexmap 2.13.0",

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1254,13 +1254,11 @@ pub fn main() {
                 contract.clarity_version,
             );
             let mut analysis_db = AnalysisDatabase::new(&mut session.interpreter.clarity_datastore);
-            let skip_lints = !settings.repl_settings.analysis.should_lint(&file);
             let lint_diagnostics = match analysis::run_analysis(
                 &mut contract_analysis,
                 &mut analysis_db,
                 &annotations,
                 &settings.repl_settings.analysis,
-                skip_lints,
             ) {
                 Ok(lint_diags) => lint_diags,
                 Err(lint_diags) => {
@@ -1600,10 +1598,10 @@ fn print_available_lints(settings: &analysis::Settings) {
     println!();
     println!("{}", "Configure lints in Clarinet.toml:".bold());
     let sample = r#"
-  # Only lint files matching these patterns
+  # Only analyze files matching these patterns
   [repl.analysis]
-  lint_include = ["contracts/*.clar"]
-  lint_exclude = []
+  include = ["contracts/*.clar"]
+  exclude = []
 
   [repl.analysis.lint_groups]
   style = "warning"
@@ -3188,7 +3186,6 @@ mod tests {
             &mut analysis_db,
             &annotations,
             &settings.repl_settings.analysis,
-            false,
         ) {
             Ok(lint_diags) => lint_diags,
             Err(lint_diags) => {

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1254,11 +1254,13 @@ pub fn main() {
                 contract.clarity_version,
             );
             let mut analysis_db = AnalysisDatabase::new(&mut session.interpreter.clarity_datastore);
+            let skip_lints = !settings.repl_settings.analysis.should_lint(&file);
             let lint_diagnostics = match analysis::run_analysis(
                 &mut contract_analysis,
                 &mut analysis_db,
                 &annotations,
                 &settings.repl_settings.analysis,
+                skip_lints,
             ) {
                 Ok(lint_diags) => lint_diags,
                 Err(lint_diags) => {
@@ -1604,6 +1606,12 @@ fn print_available_lints(settings: &analysis::Settings) {
   [repl.analysis.lints]
   unused_const = "error"
   at_block = false
+
+  # Only lint files matching these patterns
+  lint_include = ["contracts/*.clar"]
+
+  # Exclude files matching these patterns from linting
+  lint_exclude = []
 "#;
     println!("{}", sample.dimmed());
     println!(
@@ -3181,6 +3189,7 @@ mod tests {
             &mut analysis_db,
             &annotations,
             &settings.repl_settings.analysis,
+            false,
         ) {
             Ok(lint_diags) => lint_diags,
             Err(lint_diags) => {

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1075,10 +1075,8 @@ pub fn main() {
 
                 let mut answer = String::new();
                 println!(
-                    "{} This command will delete the files {}.test.ts, {}.clar, and remove the contract from the manifest. Do you confirm? [y/N]",
-                    yellow!("warning:"),
-                    contract_name,
-                    contract_name
+                    "{} This command will delete the files {contract_name}.test.ts, {contract_name}.clar, and remove the contract from the manifest. Do you confirm? [y/N]",
+                    yellow!("warning:")
                 );
                 std::io::stdin().read_line(&mut answer).unwrap();
                 if !answer.trim().eq_ignore_ascii_case("y") {

--- a/components/clarinet-cli/src/frontend/cli.rs
+++ b/components/clarinet-cli/src/frontend/cli.rs
@@ -1600,18 +1600,17 @@ fn print_available_lints(settings: &analysis::Settings) {
     println!();
     println!("{}", "Configure lints in Clarinet.toml:".bold());
     let sample = r#"
+  # Only lint files matching these patterns
+  [repl.analysis]
+  lint_include = ["contracts/*.clar"]
+  lint_exclude = []
+
   [repl.analysis.lint_groups]
   style = "warning"
 
   [repl.analysis.lints]
   unused_const = "error"
   at_block = false
-
-  # Only lint files matching these patterns
-  lint_include = ["contracts/*.clar"]
-
-  # Exclude files matching these patterns from linting
-  lint_exclude = []
 "#;
     println!("{}", sample.dimmed());
     println!(

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -1492,8 +1492,10 @@ mod tests {
         session.update_epoch(epoch);
 
         // Enable default lints on the session so analysis actually runs
-        session.interpreter.repl_settings.analysis =
-            clarity_repl::analysis::Settings::from(clarity_repl::analysis::SettingsFile::default());
+        session.interpreter.repl_settings.analysis = clarity_repl::analysis::Settings::try_from(
+            clarity_repl::analysis::SettingsFile::default(),
+        )
+        .unwrap();
 
         let spec = EmulatedContractPublishSpecification {
             contract_name: ContractName::from_literal("lint-test"),
@@ -1526,8 +1528,10 @@ mod tests {
         session.update_epoch(epoch);
 
         // Enable default lints — but skip_analysis on the contract overrides
-        session.interpreter.repl_settings.analysis =
-            clarity_repl::analysis::Settings::from(clarity_repl::analysis::SettingsFile::default());
+        session.interpreter.repl_settings.analysis = clarity_repl::analysis::Settings::try_from(
+            clarity_repl::analysis::SettingsFile::default(),
+        )
+        .unwrap();
 
         let spec = EmulatedContractPublishSpecification {
             contract_name: ContractName::from_literal("lint-test"),
@@ -1565,8 +1569,10 @@ mod tests {
 
         // Enable default lints, then disable them globally
         // (this is what setup_session_with_deployment does when enable_analysis=false)
-        session.interpreter.repl_settings.analysis =
-            clarity_repl::analysis::Settings::from(clarity_repl::analysis::SettingsFile::default());
+        session.interpreter.repl_settings.analysis = clarity_repl::analysis::Settings::try_from(
+            clarity_repl::analysis::SettingsFile::default(),
+        )
+        .unwrap();
         session.interpreter.repl_settings.analysis.disable_all();
 
         let spec = EmulatedContractPublishSpecification {
@@ -1600,8 +1606,10 @@ mod tests {
         let epoch = StacksEpochId::Epoch25;
         session.update_epoch(epoch);
 
-        session.interpreter.repl_settings.analysis =
-            clarity_repl::analysis::Settings::from(clarity_repl::analysis::SettingsFile::default());
+        session.interpreter.repl_settings.analysis = clarity_repl::analysis::Settings::try_from(
+            clarity_repl::analysis::SettingsFile::default(),
+        )
+        .unwrap();
         if disable_analysis {
             session.interpreter.repl_settings.analysis.disable_all();
         }

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -48,17 +48,23 @@ pub fn setup_session_with_deployment(
     contracts_asts: Option<&BTreeMap<QualifiedContractIdentifier, ContractAST>>,
     enable_analysis: bool,
 ) -> DeploymentGenerationArtifacts {
-    // Mark contracts not in the project manifest as requirements
-    // so that REPL analysis (linting) is skipped for them.
-    // This is needed when the deployment plan is loaded from YAML,
-    // where `skip_analysis` is not serialized. We match by location
-    // (absolute path) rather than contract name because requirements
-    // can share a name with a project contract.
+    // Mark contracts that should skip analysis:
+    // - All contracts when analysis is globally disabled
+    // - Contracts not in the project manifest (requirements)
+    // - Contracts excluded by include/exclude filters in analysis settings
     for batch in deployment.plan.batches.iter_mut() {
         for tx in batch.transactions.iter_mut() {
             if let TransactionSpecification::EmulatedContractPublish(ref mut spec) = tx {
                 if !enable_analysis || !manifest.contracts_settings.contains_key(&spec.location) {
                     spec.skip_analysis = true;
+                } else if let Ok(relative) = spec.location.strip_prefix(&manifest.root_dir) {
+                    if !manifest
+                        .repl_settings
+                        .analysis
+                        .should_analyze(&relative.to_string_lossy())
+                    {
+                        spec.skip_analysis = true;
+                    }
                 }
             }
         }

--- a/components/clarinet-files/src/project_manifest.rs
+++ b/components/clarinet-files/src/project_manifest.rs
@@ -362,7 +362,7 @@ impl ProjectManifest {
         allow_remote_data_fetching: bool,
     ) -> Result<ProjectManifest, String> {
         let mut repl_settings = if let Some(repl_settings) = project_manifest_file.repl {
-            repl::Settings::from(repl_settings)
+            repl::Settings::try_from(repl_settings)?
         } else {
             repl::Settings {
                 analysis: clarity_repl::analysis::Settings::with_default_lints(),

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -25,6 +25,7 @@ categories = [
 clarinet-defaults = { workspace = true }
 chrono = { workspace = true }
 colored = { workspace = true }
+glob = "0.3"
 indexmap = { workspace = true, features = ["serde"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/components/clarity-repl/src/analysis/mod.rs
+++ b/components/clarity-repl/src/analysis/mod.rs
@@ -148,9 +148,11 @@ pub struct Settings {
     check_checker: check_checker::Settings,
     /// Compiled glob patterns for files to include in linting.
     #[serde(skip)]
+    #[cfg_attr(feature = "json_schema", schemars(skip))]
     lint_include: Vec<Pattern>,
     /// Compiled glob patterns for files to exclude from linting.
     #[serde(skip)]
+    #[cfg_attr(feature = "json_schema", schemars(skip))]
     lint_exclude: Vec<Pattern>,
 }
 

--- a/components/clarity-repl/src/analysis/mod.rs
+++ b/components/clarity-repl/src/analysis/mod.rs
@@ -146,14 +146,14 @@ pub struct Settings {
     passes: HashSet<Pass>,
     lints: HashMap<LintName, ClarityDiagnosticLevel>,
     check_checker: check_checker::Settings,
-    /// Compiled glob patterns for files to include in linting.
+    /// Compiled glob patterns for files to include in analysis.
     #[serde(skip)]
     #[cfg_attr(feature = "json_schema", schemars(skip))]
-    lint_include: Vec<Pattern>,
-    /// Compiled glob patterns for files to exclude from linting.
+    include: Vec<Pattern>,
+    /// Compiled glob patterns for files to exclude from analysis.
     #[serde(skip)]
     #[cfg_attr(feature = "json_schema", schemars(skip))]
-    lint_exclude: Vec<Pattern>,
+    exclude: Vec<Pattern>,
 }
 
 impl Settings {
@@ -167,8 +167,8 @@ impl Settings {
             passes,
             lints,
             check_checker: check_checker::Settings::default(),
-            lint_include: Vec::new(),
-            lint_exclude: Vec::new(),
+            include: Vec::new(),
+            exclude: Vec::new(),
         }
     }
 
@@ -221,22 +221,22 @@ impl Settings {
         &self.lints
     }
 
-    /// Check if lints should run for the given file path.
+    /// Check if analysis should run for the given file path.
     ///
-    /// - If `lint_include` is set, the file must match at least one pattern.
-    /// - If `lint_exclude` is set, the file must not match any pattern.
-    /// - If neither is set, all files are linted.
-    pub fn should_lint(&self, path: &str) -> bool {
+    /// - If `include` is set, the file must match at least one pattern.
+    /// - If `exclude` is set, the file must not match any pattern.
+    /// - If neither is set, all files are analyzed.
+    pub fn should_analyze(&self, path: &str) -> bool {
         // Normalize path to forward slashes for consistent matching
         let path = path.replace('\\', "/");
 
         // If include patterns are set, file must match at least one
-        if !self.lint_include.is_empty() && !self.lint_include.iter().any(|p| p.matches(&path)) {
+        if !self.include.is_empty() && !self.include.iter().any(|p| p.matches(&path)) {
             return false;
         }
 
         // If exclude patterns are set, file must not match any
-        if self.lint_exclude.iter().any(|p| p.matches(&path)) {
+        if self.exclude.iter().any(|p| p.matches(&path)) {
             return false;
         }
 
@@ -279,12 +279,12 @@ pub struct SettingsFile {
     lint_groups: Option<IndexMap<LintGroup, BoolOr<LintLevel>>>,
     lints: Option<IndexMap<LintName, BoolOr<LintLevel>>>,
     check_checker: Option<check_checker::SettingsFile>,
-    /// Glob patterns for files to include in linting.
+    /// Glob patterns for files to include in analysis.
     #[serde(default)]
-    lint_include: Option<OneOrList<String>>,
-    /// Glob patterns for files to exclude from linting.
+    include: Option<OneOrList<String>>,
+    /// Glob patterns for files to exclude from analysis.
     #[serde(default)]
-    lint_exclude: Option<OneOrList<String>>,
+    exclude: Option<OneOrList<String>>,
 }
 
 impl From<SettingsFile> for Settings {
@@ -327,22 +327,22 @@ impl From<SettingsFile> for Settings {
             settings.check_checker = check_checker::Settings::from(check_checker);
         }
 
-        // Process lint_include patterns
-        if let Some(include) = from_file.lint_include {
+        // Process include patterns
+        if let Some(include) = from_file.include {
             let raw = match include {
                 OneOrList::One(s) => vec![s],
                 OneOrList::List(v) => v,
             };
-            settings.lint_include = compile_patterns(raw, "lint_include");
+            settings.include = compile_patterns(raw, "include");
         }
 
-        // Process lint_exclude patterns
-        if let Some(exclude) = from_file.lint_exclude {
+        // Process exclude patterns
+        if let Some(exclude) = from_file.exclude {
             let raw = match exclude {
                 OneOrList::One(s) => vec![s],
                 OneOrList::List(v) => v,
             };
-            settings.lint_exclude = compile_patterns(raw, "lint_exclude");
+            settings.exclude = compile_patterns(raw, "exclude");
         }
 
         settings
@@ -366,23 +366,20 @@ pub fn run_analysis(
     analysis_db: &mut AnalysisDatabase,
     annotations: &[Annotation],
     settings: &Settings,
-    skip_lints: bool,
 ) -> Result<Vec<LintDiagnostic>, Vec<LintDiagnostic>> {
     let mut errors: Vec<LintDiagnostic> = vec![];
 
-    // Collect non-lint analysis passes (no lint name) - always run
+    // Collect non-lint analysis passes (no lint name)
     let mut passes: Vec<(AnalysisPassFn, ClarityDiagnosticLevel, Option<LintName>)> = vec![];
     for pass in &settings.passes {
         let f = AnalysisPassFn::try_from(pass).unwrap();
         passes.push((f, pass.default_level(), None));
     }
 
-    // Collect lint passes (with lint name) - only if not skipped by include/exclude filters
-    if !skip_lints {
-        for (name, level) in &settings.lints {
-            let lint = AnalysisPassFn::from(name);
-            passes.push((lint, level.clone(), Some(*name)));
-        }
+    // Collect lint passes (with lint name)
+    for (name, level) in &settings.lints {
+        let lint = AnalysisPassFn::from(name);
+        passes.push((lint, level.clone(), Some(*name)));
     }
 
     // Create shared cache for all passes/lints
@@ -463,8 +460,8 @@ mod tests {
             lint_groups: None,
             lints: None,
             check_checker: None,
-            lint_include: None,
-            lint_exclude: None,
+            include: None,
+            exclude: None,
         };
         let settings = Settings::from(file);
         assert!(!settings.lints.is_empty());
@@ -494,58 +491,58 @@ mod tests {
     }
 
     #[test]
-    fn should_lint_with_no_filters() {
+    fn should_analyze_with_no_filters() {
         let settings = Settings::with_default_lints();
-        assert!(settings.should_lint("contracts/foo.clar"));
-        assert!(settings.should_lint("tests/bar.clar"));
+        assert!(settings.should_analyze("contracts/foo.clar"));
+        assert!(settings.should_analyze("tests/bar.clar"));
     }
 
     #[test]
-    fn should_lint_with_include_filter() {
+    fn should_analyze_with_include_filter() {
         let file = SettingsFile {
-            lint_include: Some(OneOrList::One("contracts/*.clar".to_string())),
+            include: Some(OneOrList::One("contracts/*.clar".to_string())),
             ..Default::default()
         };
         let settings = Settings::from(file);
 
-        assert!(settings.should_lint("contracts/foo.clar"));
-        assert!(!settings.should_lint("tests/foo.clar"));
+        assert!(settings.should_analyze("contracts/foo.clar"));
+        assert!(!settings.should_analyze("tests/foo.clar"));
     }
 
     #[test]
-    fn should_lint_with_exclude_filter() {
+    fn should_analyze_with_exclude_filter() {
         let file = SettingsFile {
-            lint_exclude: Some(OneOrList::One("tests/*.clar".to_string())),
+            exclude: Some(OneOrList::One("tests/*.clar".to_string())),
             ..Default::default()
         };
         let settings = Settings::from(file);
 
-        assert!(settings.should_lint("contracts/foo.clar"));
-        assert!(!settings.should_lint("tests/foo.clar"));
+        assert!(settings.should_analyze("contracts/foo.clar"));
+        assert!(!settings.should_analyze("tests/foo.clar"));
     }
 
     #[test]
-    fn should_lint_with_include_and_exclude() {
+    fn should_analyze_with_include_and_exclude() {
         let file = SettingsFile {
-            lint_include: Some(OneOrList::List(vec![
+            include: Some(OneOrList::List(vec![
                 "contracts/*.clar".to_string(),
                 "lib/*.clar".to_string(),
             ])),
-            lint_exclude: Some(OneOrList::One("contracts/legacy*.clar".to_string())),
+            exclude: Some(OneOrList::One("contracts/legacy*.clar".to_string())),
             ..Default::default()
         };
         let settings = Settings::from(file);
 
-        assert!(settings.should_lint("contracts/foo.clar"));
-        assert!(!settings.should_lint("contracts/legacy.clar"));
-        assert!(settings.should_lint("lib/utils.clar"));
-        assert!(!settings.should_lint("tests/foo.clar"));
+        assert!(settings.should_analyze("contracts/foo.clar"));
+        assert!(!settings.should_analyze("contracts/legacy.clar"));
+        assert!(settings.should_analyze("lib/utils.clar"));
+        assert!(!settings.should_analyze("tests/foo.clar"));
     }
 
     #[test]
-    fn should_lint_with_list_include() {
+    fn should_analyze_with_list_include() {
         let file = SettingsFile {
-            lint_include: Some(OneOrList::List(vec![
+            include: Some(OneOrList::List(vec![
                 "contracts/*.clar".to_string(),
                 "src/*.clar".to_string(),
             ])),
@@ -553,8 +550,8 @@ mod tests {
         };
         let settings = Settings::from(file);
 
-        assert!(settings.should_lint("contracts/foo.clar"));
-        assert!(settings.should_lint("src/bar.clar"));
-        assert!(!settings.should_lint("tests/foo.clar"));
+        assert!(settings.should_analyze("contracts/foo.clar"));
+        assert!(settings.should_analyze("src/bar.clar"));
+        assert!(!settings.should_analyze("tests/foo.clar"));
     }
 }

--- a/components/clarity-repl/src/analysis/mod.rs
+++ b/components/clarity-repl/src/analysis/mod.rs
@@ -287,8 +287,10 @@ pub struct SettingsFile {
     exclude: Option<OneOrList<String>>,
 }
 
-impl From<SettingsFile> for Settings {
-    fn from(from_file: SettingsFile) -> Self {
+impl TryFrom<SettingsFile> for Settings {
+    type Error = String;
+
+    fn try_from(from_file: SettingsFile) -> Result<Self, Self::Error> {
         let mut settings = Self::with_default_lints();
 
         // Process lint groups first
@@ -333,7 +335,7 @@ impl From<SettingsFile> for Settings {
                 OneOrList::One(s) => vec![s],
                 OneOrList::List(v) => v,
             };
-            settings.include = compile_patterns(raw, "include");
+            settings.include = compile_patterns(raw, "include")?;
         }
 
         // Process exclude patterns
@@ -342,21 +344,18 @@ impl From<SettingsFile> for Settings {
                 OneOrList::One(s) => vec![s],
                 OneOrList::List(v) => v,
             };
-            settings.exclude = compile_patterns(raw, "exclude");
+            settings.exclude = compile_patterns(raw, "exclude")?;
         }
 
-        settings
+        Ok(settings)
     }
 }
 
-fn compile_patterns(raw: Vec<String>, field_name: &str) -> Vec<Pattern> {
+fn compile_patterns(raw: Vec<String>, field_name: &str) -> Result<Vec<Pattern>, String> {
     raw.into_iter()
-        .filter_map(|p| match Pattern::new(&p) {
-            Ok(pattern) => Some(pattern),
-            Err(e) => {
-                eprintln!("warning: invalid glob pattern in {field_name}: \"{p}\": {e}");
-                None
-            }
+        .map(|p| {
+            Pattern::new(&p)
+                .map_err(|e| format!("invalid glob pattern in {field_name}: \"{p}\": {e}"))
         })
         .collect()
 }
@@ -446,7 +445,7 @@ mod tests {
     /// `SettingsFile::default()`, which should produce the same defaults.
     #[test]
     fn settings_from_empty_settings_file_enables_default_lints() {
-        let settings = Settings::from(SettingsFile::default());
+        let settings = Settings::try_from(SettingsFile::default()).unwrap();
         assert!(!settings.lints.is_empty());
         assert_eq!(settings.passes, HashSet::from(DEFAULT_PASSES));
     }
@@ -463,14 +462,14 @@ mod tests {
             include: None,
             exclude: None,
         };
-        let settings = Settings::from(file);
+        let settings = Settings::try_from(file).unwrap();
         assert!(!settings.lints.is_empty());
         assert_eq!(settings.passes, HashSet::from(DEFAULT_PASSES));
     }
 
     #[test]
     fn disable_all_clears_lints_and_passes() {
-        let mut settings = Settings::from(SettingsFile::default());
+        let mut settings = Settings::try_from(SettingsFile::default()).unwrap();
         assert!(!settings.lints.is_empty());
         assert!(!settings.passes.is_empty());
 
@@ -481,7 +480,7 @@ mod tests {
 
     #[test]
     fn disable_all_passes_preserves_lints() {
-        let mut settings = Settings::from(SettingsFile::default());
+        let mut settings = Settings::try_from(SettingsFile::default()).unwrap();
         assert!(!settings.lints.is_empty());
         assert!(!settings.passes.is_empty());
 
@@ -503,7 +502,7 @@ mod tests {
             include: Some(OneOrList::One("contracts/*.clar".to_string())),
             ..Default::default()
         };
-        let settings = Settings::from(file);
+        let settings = Settings::try_from(file).unwrap();
 
         assert!(settings.should_analyze("contracts/foo.clar"));
         assert!(!settings.should_analyze("tests/foo.clar"));
@@ -515,7 +514,7 @@ mod tests {
             exclude: Some(OneOrList::One("tests/*.clar".to_string())),
             ..Default::default()
         };
-        let settings = Settings::from(file);
+        let settings = Settings::try_from(file).unwrap();
 
         assert!(settings.should_analyze("contracts/foo.clar"));
         assert!(!settings.should_analyze("tests/foo.clar"));
@@ -531,7 +530,7 @@ mod tests {
             exclude: Some(OneOrList::One("contracts/legacy*.clar".to_string())),
             ..Default::default()
         };
-        let settings = Settings::from(file);
+        let settings = Settings::try_from(file).unwrap();
 
         assert!(settings.should_analyze("contracts/foo.clar"));
         assert!(!settings.should_analyze("contracts/legacy.clar"));
@@ -548,7 +547,7 @@ mod tests {
             ])),
             ..Default::default()
         };
-        let settings = Settings::from(file);
+        let settings = Settings::try_from(file).unwrap();
 
         assert!(settings.should_analyze("contracts/foo.clar"));
         assert!(settings.should_analyze("src/bar.clar"));

--- a/components/clarity-repl/src/analysis/mod.rs
+++ b/components/clarity-repl/src/analysis/mod.rs
@@ -354,6 +354,11 @@ impl TryFrom<SettingsFile> for Settings {
 fn compile_patterns(raw: Vec<String>, field_name: &str) -> Result<Vec<Pattern>, String> {
     raw.into_iter()
         .map(|p| {
+            if std::path::Path::new(&p).is_absolute() {
+                return Err(format!(
+                    "invalid glob pattern in {field_name}: \"{p}\": absolute paths are not supported, use paths relative to the project root"
+                ));
+            }
             Pattern::new(&p)
                 .map_err(|e| format!("invalid glob pattern in {field_name}: \"{p}\": {e}"))
         })
@@ -536,6 +541,32 @@ mod tests {
         assert!(!settings.should_analyze("contracts/legacy.clar"));
         assert!(settings.should_analyze("lib/utils.clar"));
         assert!(!settings.should_analyze("tests/foo.clar"));
+    }
+
+    #[test]
+    fn absolute_path_in_include_returns_error() {
+        let file = SettingsFile {
+            include: Some(OneOrList::One("/absolute/path/*.clar".to_string())),
+            ..Default::default()
+        };
+        let result = Settings::try_from(file);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("absolute paths are not supported"));
+    }
+
+    #[test]
+    fn absolute_path_in_exclude_returns_error() {
+        let file = SettingsFile {
+            exclude: Some(OneOrList::One("/absolute/path/*.clar".to_string())),
+            ..Default::default()
+        };
+        let result = Settings::try_from(file);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("absolute paths are not supported"));
     }
 
     #[test]

--- a/components/clarity-repl/src/analysis/mod.rs
+++ b/components/clarity-repl/src/analysis/mod.rs
@@ -354,7 +354,7 @@ impl TryFrom<SettingsFile> for Settings {
 fn compile_patterns(raw: Vec<String>, field_name: &str) -> Result<Vec<Pattern>, String> {
     raw.into_iter()
         .map(|p| {
-            if std::path::Path::new(&p).is_absolute() {
+            if p.starts_with('/') || std::path::Path::new(&p).is_absolute() {
                 return Err(format!(
                     "invalid glob pattern in {field_name}: \"{p}\": absolute paths are not supported, use paths relative to the project root"
                 ));
@@ -560,6 +560,20 @@ mod tests {
     fn absolute_path_in_exclude_returns_error() {
         let file = SettingsFile {
             exclude: Some(OneOrList::One("/absolute/path/*.clar".to_string())),
+            ..Default::default()
+        };
+        let result = Settings::try_from(file);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("absolute paths are not supported"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_absolute_path_in_include_returns_error() {
+        let file = SettingsFile {
+            include: Some(OneOrList::One("C:\\absolute\\path\\*.clar".to_string())),
             ..Default::default()
         };
         let result = Settings::try_from(file);

--- a/components/clarity-repl/src/analysis/mod.rs
+++ b/components/clarity-repl/src/analysis/mod.rs
@@ -18,6 +18,7 @@ use check_checker::CheckChecker;
 use clarity::vm::analysis::analysis_db::AnalysisDatabase;
 use clarity::vm::analysis::types::ContractAnalysis;
 use clarity::vm::diagnostic::{Diagnostic, Level as ClarityDiagnosticLevel};
+use glob::Pattern;
 use indexmap::IndexMap;
 use linter::{LintLevel, LintMapBuilder, LintName};
 #[cfg(feature = "json_schema")]
@@ -145,6 +146,12 @@ pub struct Settings {
     passes: HashSet<Pass>,
     lints: HashMap<LintName, ClarityDiagnosticLevel>,
     check_checker: check_checker::Settings,
+    /// Compiled glob patterns for files to include in linting.
+    #[serde(skip)]
+    lint_include: Vec<Pattern>,
+    /// Compiled glob patterns for files to exclude from linting.
+    #[serde(skip)]
+    lint_exclude: Vec<Pattern>,
 }
 
 impl Settings {
@@ -158,6 +165,8 @@ impl Settings {
             passes,
             lints,
             check_checker: check_checker::Settings::default(),
+            lint_include: Vec::new(),
+            lint_exclude: Vec::new(),
         }
     }
 
@@ -209,6 +218,28 @@ impl Settings {
     pub fn lints(&self) -> &HashMap<LintName, ClarityDiagnosticLevel> {
         &self.lints
     }
+
+    /// Check if lints should run for the given file path.
+    ///
+    /// - If `lint_include` is set, the file must match at least one pattern.
+    /// - If `lint_exclude` is set, the file must not match any pattern.
+    /// - If neither is set, all files are linted.
+    pub fn should_lint(&self, path: &str) -> bool {
+        // Normalize path to forward slashes for consistent matching
+        let path = path.replace('\\', "/");
+
+        // If include patterns are set, file must match at least one
+        if !self.lint_include.is_empty() && !self.lint_include.iter().any(|p| p.matches(&path)) {
+            return false;
+        }
+
+        // If exclude patterns are set, file must not match any
+        if self.lint_exclude.iter().any(|p| p.matches(&path)) {
+            return false;
+        }
+
+        true
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -246,6 +277,12 @@ pub struct SettingsFile {
     lint_groups: Option<IndexMap<LintGroup, BoolOr<LintLevel>>>,
     lints: Option<IndexMap<LintName, BoolOr<LintLevel>>>,
     check_checker: Option<check_checker::SettingsFile>,
+    /// Glob patterns for files to include in linting.
+    #[serde(default)]
+    lint_include: Option<OneOrList<String>>,
+    /// Glob patterns for files to exclude from linting.
+    #[serde(default)]
+    lint_exclude: Option<OneOrList<String>>,
 }
 
 impl From<SettingsFile> for Settings {
@@ -288,8 +325,38 @@ impl From<SettingsFile> for Settings {
             settings.check_checker = check_checker::Settings::from(check_checker);
         }
 
+        // Process lint_include patterns
+        if let Some(include) = from_file.lint_include {
+            let raw = match include {
+                OneOrList::One(s) => vec![s],
+                OneOrList::List(v) => v,
+            };
+            settings.lint_include = compile_patterns(raw, "lint_include");
+        }
+
+        // Process lint_exclude patterns
+        if let Some(exclude) = from_file.lint_exclude {
+            let raw = match exclude {
+                OneOrList::One(s) => vec![s],
+                OneOrList::List(v) => v,
+            };
+            settings.lint_exclude = compile_patterns(raw, "lint_exclude");
+        }
+
         settings
     }
+}
+
+fn compile_patterns(raw: Vec<String>, field_name: &str) -> Vec<Pattern> {
+    raw.into_iter()
+        .filter_map(|p| match Pattern::new(&p) {
+            Ok(pattern) => Some(pattern),
+            Err(e) => {
+                eprintln!("warning: invalid glob pattern in {field_name}: \"{p}\": {e}");
+                None
+            }
+        })
+        .collect()
 }
 
 pub fn run_analysis(
@@ -297,20 +364,23 @@ pub fn run_analysis(
     analysis_db: &mut AnalysisDatabase,
     annotations: &[Annotation],
     settings: &Settings,
+    skip_lints: bool,
 ) -> Result<Vec<LintDiagnostic>, Vec<LintDiagnostic>> {
     let mut errors: Vec<LintDiagnostic> = vec![];
 
-    // Collect non-lint analysis passes (no lint name)
+    // Collect non-lint analysis passes (no lint name) - always run
     let mut passes: Vec<(AnalysisPassFn, ClarityDiagnosticLevel, Option<LintName>)> = vec![];
     for pass in &settings.passes {
         let f = AnalysisPassFn::try_from(pass).unwrap();
         passes.push((f, pass.default_level(), None));
     }
 
-    // Collect lint passes (with lint name)
-    for (name, level) in &settings.lints {
-        let lint = AnalysisPassFn::from(name);
-        passes.push((lint, level.clone(), Some(*name)));
+    // Collect lint passes (with lint name) - only if not skipped by include/exclude filters
+    if !skip_lints {
+        for (name, level) in &settings.lints {
+            let lint = AnalysisPassFn::from(name);
+            passes.push((lint, level.clone(), Some(*name)));
+        }
     }
 
     // Create shared cache for all passes/lints
@@ -391,6 +461,8 @@ mod tests {
             lint_groups: None,
             lints: None,
             check_checker: None,
+            lint_include: None,
+            lint_exclude: None,
         };
         let settings = Settings::from(file);
         assert!(!settings.lints.is_empty());
@@ -417,5 +489,70 @@ mod tests {
         settings.disable_all_passes();
         assert!(!settings.lints.is_empty(), "lints should be preserved");
         assert!(settings.passes.is_empty());
+    }
+
+    #[test]
+    fn should_lint_with_no_filters() {
+        let settings = Settings::with_default_lints();
+        assert!(settings.should_lint("contracts/foo.clar"));
+        assert!(settings.should_lint("tests/bar.clar"));
+    }
+
+    #[test]
+    fn should_lint_with_include_filter() {
+        let file = SettingsFile {
+            lint_include: Some(OneOrList::One("contracts/*.clar".to_string())),
+            ..Default::default()
+        };
+        let settings = Settings::from(file);
+
+        assert!(settings.should_lint("contracts/foo.clar"));
+        assert!(!settings.should_lint("tests/foo.clar"));
+    }
+
+    #[test]
+    fn should_lint_with_exclude_filter() {
+        let file = SettingsFile {
+            lint_exclude: Some(OneOrList::One("tests/*.clar".to_string())),
+            ..Default::default()
+        };
+        let settings = Settings::from(file);
+
+        assert!(settings.should_lint("contracts/foo.clar"));
+        assert!(!settings.should_lint("tests/foo.clar"));
+    }
+
+    #[test]
+    fn should_lint_with_include_and_exclude() {
+        let file = SettingsFile {
+            lint_include: Some(OneOrList::List(vec![
+                "contracts/*.clar".to_string(),
+                "lib/*.clar".to_string(),
+            ])),
+            lint_exclude: Some(OneOrList::One("contracts/legacy*.clar".to_string())),
+            ..Default::default()
+        };
+        let settings = Settings::from(file);
+
+        assert!(settings.should_lint("contracts/foo.clar"));
+        assert!(!settings.should_lint("contracts/legacy.clar"));
+        assert!(settings.should_lint("lib/utils.clar"));
+        assert!(!settings.should_lint("tests/foo.clar"));
+    }
+
+    #[test]
+    fn should_lint_with_list_include() {
+        let file = SettingsFile {
+            lint_include: Some(OneOrList::List(vec![
+                "contracts/*.clar".to_string(),
+                "src/*.clar".to_string(),
+            ])),
+            ..Default::default()
+        };
+        let settings = Settings::from(file);
+
+        assert!(settings.should_lint("contracts/foo.clar"));
+        assert!(settings.should_lint("src/bar.clar"));
+        assert!(!settings.should_lint("tests/foo.clar"));
     }
 }

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -30,7 +30,7 @@ use clarity_types::Value;
 use super::datastore::StacksConstants;
 use super::remote_data::HttpClient;
 use super::settings::{ApiUrl, RemoteNetworkInfo};
-use super::ClarityContract;
+use super::{ClarityCodeSource, ClarityContract};
 use crate::analysis::annotation::{Annotation, AnnotationKind};
 use crate::analysis::ast_dependency_detector::{ASTDependencyDetector, Dependency};
 use crate::analysis::{self, LintDiagnostic};
@@ -295,11 +295,19 @@ impl ClarityInterpreter {
 
         // Run REPL-only analyses (linter, check_checker, etc.)
         let lint_diagnostics = if !contract.skip_analysis {
+            let skip_lints = match &contract.code_source {
+                ClarityCodeSource::ContractOnDisk(path) => !self
+                    .repl_settings
+                    .analysis
+                    .should_lint(&path.to_string_lossy()),
+                _ => false,
+            };
             analysis::run_analysis(
                 &mut contract_analysis,
                 &mut analysis_db,
                 annotations,
                 &self.repl_settings.analysis,
+                skip_lints,
             )
             .map_err(|lds| {
                 // Extract the last diagnostic as the representative error.

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -30,7 +30,7 @@ use clarity_types::Value;
 use super::datastore::StacksConstants;
 use super::remote_data::HttpClient;
 use super::settings::{ApiUrl, RemoteNetworkInfo};
-use super::{ClarityCodeSource, ClarityContract};
+use super::ClarityContract;
 use crate::analysis::annotation::{Annotation, AnnotationKind};
 use crate::analysis::ast_dependency_detector::{ASTDependencyDetector, Dependency};
 use crate::analysis::{self, LintDiagnostic};
@@ -295,19 +295,11 @@ impl ClarityInterpreter {
 
         // Run REPL-only analyses (linter, check_checker, etc.)
         let lint_diagnostics = if !contract.skip_analysis {
-            let skip_lints = match &contract.code_source {
-                ClarityCodeSource::ContractOnDisk(path) => !self
-                    .repl_settings
-                    .analysis
-                    .should_lint(&path.to_string_lossy()),
-                _ => false,
-            };
             analysis::run_analysis(
                 &mut contract_analysis,
                 &mut analysis_db,
                 annotations,
                 &self.repl_settings.analysis,
-                skip_lints,
             )
             .map_err(|lds| {
                 // Extract the last diagnostic as the representative error.

--- a/components/clarity-repl/src/repl/settings.rs
+++ b/components/clarity-repl/src/repl/settings.rs
@@ -121,11 +121,14 @@ pub struct SettingsFile {
     log_print_events: Option<LogPrintEvents>,
 }
 
-impl From<SettingsFile> for Settings {
-    fn from(file: SettingsFile) -> Self {
+impl TryFrom<SettingsFile> for Settings {
+    type Error = String;
+
+    fn try_from(file: SettingsFile) -> Result<Self, Self::Error> {
         let analysis = file
             .analysis
-            .map(analysis::Settings::from)
+            .map(analysis::Settings::try_from)
+            .transpose()?
             .unwrap_or_else(analysis::Settings::with_default_lints);
 
         let remote_data = file
@@ -133,12 +136,12 @@ impl From<SettingsFile> for Settings {
             .map(RemoteDataSettings::from)
             .unwrap_or_default();
 
-        Self {
+        Ok(Self {
             analysis,
             remote_data,
             log_print_events: file.log_print_events.unwrap_or_default(),
             show_timings: false,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
- closes #2444 

Example:
```
[repl.analysis]
passes = ["check_checker"]
exclude = ["contracts/skip-*.clar"]
```
