### PR TITLE
chore: Remove unnecessary `.as_str()`s

### DIFF
--- a/components/clarinet-format/src/formatter/mod.rs
+++ b/components/clarinet-format/src/formatter/mod.rs
@@ -1572,7 +1572,7 @@ impl<'a> Aggregator<'a> {
             return result;
         }
         let result = match pse.pre_expr {
-            PreSymbolicExpressionType::Atom(ref value) => t(value.as_str()).to_string(),
+            PreSymbolicExpressionType::Atom(ref value) => t(value).to_string(),
             PreSymbolicExpressionType::AtomValue(ref value) => match value {
                 clarity::vm::types::Value::Principal(c) => {
                     format!("'{c}")

--- a/components/clarity-lsp/src/common/requests/document_symbols.rs
+++ b/components/clarity-lsp/src/common/requests/document_symbols.rs
@@ -129,7 +129,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
         for (name, expr) in values.iter() {
             if let Some(name) = name {
                 symbols.push(build_symbol(
-                    name.as_str(),
+                    name,
                     None,
                     ClaritySymbolKind::VALUE,
                     &expr.span,
@@ -346,7 +346,7 @@ impl<'a> ASTVisitor<'a> for ASTSymbols {
         let mut bindings_children: Vec<DocumentSymbol> = Vec::new();
         for (name, binding) in bindings.iter() {
             bindings_children.push(build_symbol(
-                name.as_str(),
+                name,
                 None,
                 ClaritySymbolKind::LET_BINDING,
                 &binding.value.span,

--- a/components/clarity-repl/src/analysis/lints/case_const.rs
+++ b/components/clarity-repl/src/analysis/lints/case_const.rs
@@ -90,7 +90,7 @@ impl<'a, 'b> CaseConst<'a, 'b> {
             if Self::allow(const_data, annotations) {
                 continue;
             }
-            let Err(error) = match_screaming_snake_case(const_name.as_str()) else {
+            let Err(error) = match_screaming_snake_case(const_name) else {
                 continue;
             };
             let message = Self::make_diagnostic_message(const_name, &error);

--- a/components/clarity-repl/src/analysis/lints/case_fn.rs
+++ b/components/clarity-repl/src/analysis/lints/case_fn.rs
@@ -55,7 +55,7 @@ impl<'a, 'b> CaseFn<'a, 'b> {
         if Self::allow(annotation, annotations) {
             return;
         }
-        let Err(error) = match_kebab_case(strip_unused_suffix(name.as_str())) else {
+        let Err(error) = match_kebab_case(strip_unused_suffix(name)) else {
             return;
         };
         let message = Self::make_diagnostic_message(name, &error);

--- a/components/clarity-repl/src/analysis/lints/case_trait.rs
+++ b/components/clarity-repl/src/analysis/lints/case_trait.rs
@@ -55,7 +55,7 @@ impl<'a, 'b> CaseTrait<'a, 'b> {
         if Self::allow(annotation, annotations) {
             return;
         }
-        let Err(error) = match_kebab_case(strip_unused_suffix(name.as_str())) else {
+        let Err(error) = match_kebab_case(strip_unused_suffix(name)) else {
             return;
         };
         let message = Self::make_diagnostic_message(name, &error);

--- a/components/clarity-repl/src/analysis/lints/error_const.rs
+++ b/components/clarity-repl/src/analysis/lints/error_const.rs
@@ -110,7 +110,7 @@ impl<'a, 'b> ErrorConst<'a, 'b> {
         let candidate_consts = constants
             .iter()
             // Ignore constants that don't start with `ERR_PREFIX`
-            .filter(|(name, _)| name.as_str().starts_with(ERR_PREFIX))
+            .filter(|(name, _)| name.starts_with(ERR_PREFIX))
             // Ignore constants we explicitly allow
             .filter(|(_, const_data)| !Self::allow(const_data, annotations));
 

--- a/components/clarity-repl/src/repl/debug/dap/mod.rs
+++ b/components/clarity-repl/src/repl/debug/dap/mod.rs
@@ -896,7 +896,7 @@ impl DAPDebugger {
                 .database
                 .lookup_variable(
                     &contract_context.contract_identifier,
-                    name.as_str(),
+                    name,
                     data_types,
                     &DEFAULT_EPOCH,
                 )

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -577,7 +577,7 @@ impl ClarityInterpreter {
                     .get_arguments()
                     .iter()
                     .zip(defined_func.get_arg_types().iter())
-                    .map(|(n, t)| format!("({} {})", n.as_str(), t))
+                    .map(|(n, t)| format!("({n} {t})"))
                     .collect();
 
                 functions.insert(name.to_string(), args);

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -666,7 +666,7 @@ fn extract_function_name(expr: &SymbolicExpression) -> Option<String> {
     expr.match_list().and_then(|list| {
         list.first()
             .and_then(|first| first.match_atom())
-            .filter(|atom| is_function_definition(atom.as_str()))
+            .filter(|atom| is_function_definition(atom))
             .and_then(|_| list.get(1))
             .and_then(|sig| sig.match_list())
             .and_then(|signature| signature.first())
@@ -874,7 +874,7 @@ pub fn build_cost_analysis_tree(
     match &expr.expr {
         SymbolicExpressionType::List(list) => {
             if let Some(function_name) = list.first().and_then(|first| first.match_atom()) {
-                if is_function_definition(function_name.as_str()) {
+                if is_function_definition(function_name) {
                     let (returned_function_name, cost_analysis_tree) =
                         build_function_definition_cost_analysis_tree(
                             list, user_args, ctx, None, None, env,
@@ -1157,7 +1157,7 @@ pub(crate) fn infer_type_from_expression(
         }
         SymbolicExpressionType::Atom(name) => {
             // Try to parse as a type name (e.g., "uint", "int", "bool")
-            TypeSignature::parse_atom_type(name.as_str())
+            TypeSignature::parse_atom_type(name)
                 .map_err(|e| StaticCostError::TypeParse(format!("{e:?}")))
         }
         SymbolicExpressionType::List(_) => {
@@ -1641,7 +1641,7 @@ fn build_listlike_cost_analysis_tree(
             // special functions
             //   - let, etc use bindings lengths not argument lengths
             if let Some(native_function) =
-                NativeFunctions::lookup_by_name_at_version(name.as_str(), ctx.clarity_version)
+                NativeFunctions::lookup_by_name_at_version(name, ctx.clarity_version)
             {
                 // Special handling for Let: increment depth before processing body
                 if native_function == NativeFunctions::Let {
@@ -1822,7 +1822,7 @@ fn build_listlike_cost_analysis_tree(
                 });
                 if ctx.cost_map.contains_key(name.as_str()) {
                     let expr_node = CostExprNode::UserFunction(name.clone());
-                    let default_cost = calculate_function_cost(name.as_str(), ctx.cost_map)?;
+                    let default_cost = calculate_function_cost(name, ctx.cost_map)?;
                     let mut cost =
                         try_narrow_user_function_cost(name, &exprs[1..], user_args, ctx, env)
                             .unwrap_or(default_cost);
@@ -1916,7 +1916,7 @@ fn collect_fn_calls(
     calls: &mut HashSet<String>,
 ) {
     if let CostExprNode::UserFunction(fn_name) = &node.expr {
-        if !is_function_definition(fn_name.as_str())
+        if !is_function_definition(fn_name)
             && !trait_names.contains_key(fn_name)
             && visited_functions.contains(fn_name.as_str())
         {

--- a/components/clarity-static-cost/src/static_cost/special_costs.rs
+++ b/components/clarity-static-cost/src/static_cost/special_costs.rs
@@ -89,7 +89,7 @@ fn infer_field_type_from_binding(
 
         // Check if it's a reserved variable
         if let Some(native_var) =
-            NativeVariables::lookup_by_name_at_version(value_atom.as_str(), &clarity_version)
+            NativeVariables::lookup_by_name_at_version(value_atom, &clarity_version)
         {
             match native_var {
                 NativeVariables::TxSender
@@ -284,7 +284,7 @@ fn get_argument_sizes(
         // Try reserved variables
         let clarity_version = ClarityVersion::default_for_epoch(epoch);
         if let Some(native_var) =
-            NativeVariables::lookup_by_name_at_version(var_name.as_str(), &clarity_version)
+            NativeVariables::lookup_by_name_at_version(var_name, &clarity_version)
         {
             if let Some((min, max)) = get_reserved_variable_size(native_var) {
                 return (Some(min), Some(max));

--- a/components/clarity-static-cost/src/static_cost/trait_counter.rs
+++ b/components/clarity-static-cost/src/static_cost/trait_counter.rs
@@ -510,7 +510,7 @@ impl TraitCountVisitor for TraitCountCollector {
         }
 
         // Determine the containing function name for children
-        let fn_name = if is_function_definition(user_function.as_str()) {
+        let fn_name = if is_function_definition(user_function) {
             context.containing_fn_name.clone()
         } else {
             user_function.to_string()
@@ -573,7 +573,7 @@ impl<'a> TraitCountPropagator<'a> {
         // 1. It's not a function definition keyword
         // 2. It's not a trait call (trait names are in trait_names)
         // 3. It's not a known function from the contract (not in visited_functions or trait_counts)
-        !is_function_definition(user_function.as_str())
+        !is_function_definition(user_function)
             && !self.trait_names.contains_key(user_function)
             && !self.trait_counts.contains_key(fn_name_str)
             && !self.visited_functions.contains(fn_name_str)
@@ -707,9 +707,7 @@ impl<'a> TraitCountVisitor for TraitCountPropagator<'a> {
         user_function: &ClarityName,
         context: &TraitCountContext,
     ) {
-        if !is_function_definition(user_function.as_str())
-            && !self.trait_names.contains_key(user_function)
-        {
+        if !is_function_definition(user_function) && !self.trait_names.contains_key(user_function) {
             // This is a regular function call, not a trait call or function definition
             // Propagate trait counts from the callee to the caller
             let callee_name = user_function.to_string();
@@ -758,7 +756,7 @@ impl<'a> TraitCountVisitor for TraitCountPropagator<'a> {
         // If this is a function call, use the function name as context (for its body)
         // If this is a let-bound variable, keep the current context
         let fn_name_str = user_function.to_string();
-        let fn_name = if is_function_definition(user_function.as_str()) {
+        let fn_name = if is_function_definition(user_function) {
             context.containing_fn_name.clone()
         } else if self.is_let_bound_variable(user_function, &fn_name_str) {
             // This is a let-bound variable - keep the current context


### PR DESCRIPTION
### Description

Remove unnecessary `.as_str()` calls on `ClarityName` and `ContractName`

Not a performance gain, doesn't change behavior, we just rely on `Deref<Target = str>` instead of an explicit function call to clean up the code a bit