### PR TITLE
refactor: Replace `stackslib` with `stacks-codec` where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,9 +715,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "stacks-codec",
  "stacks-common",
  "stacks-rpc-client",
- "stackslib",
  "strum",
  "tempfile",
  "tokio",
@@ -4332,8 +4332,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "stacks-codec",
  "stacks-common",
- "stackslib",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b1
 clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "clarity-types" }
 libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "libsigner", default-features = false }
 pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "pox-locking", default-features = false }
+stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "stacks-codec" }
 stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "stacks-common", default-features = false }
 stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "stackslib", default-features = false }
 

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -32,7 +32,7 @@ bitcoincore-rpc = { workspace= true }
 bitcoincore-rpc-json = { workspace= true }
 base58 = { workspace = true }
 libsecp256k1 = { workspace = true }
-stackslib = { workspace = true }
+stacks-codec = { workspace = true }
 clarinet-utils = { path = "../clarinet-utils" }
 stacks-rpc-client = { path = "../stacks-rpc-client" }
 

--- a/components/clarinet-deployments/src/onchain/mod.rs
+++ b/components/clarinet-deployments/src/onchain/mod.rs
@@ -17,17 +17,17 @@ use clarity_repl::repl::boot::{
 use clarity_repl::repl::{Session, SessionSettings};
 use libsecp256k1::PublicKey;
 use reqwest::Url;
+use stacks_codec::strings::StacksString;
+use stacks_codec::transaction::{
+    SinglesigHashMode, SinglesigSpendingCondition, StacksTransaction, TokenTransferMemo,
+    TransactionAnchorMode, TransactionAuth, TransactionContractCall, TransactionPayload,
+    TransactionPostConditionMode, TransactionPublicKeyEncoding, TransactionSmartContract,
+    TransactionSpendingCondition, TransactionVersion,
+};
 use stacks_common::address::{
     AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
 use stacks_rpc_client::StacksRpc;
-use stackslib::chainstate::stacks::{
-    SinglesigHashMode, SinglesigSpendingCondition, StacksTransaction, StacksTransactionSigner,
-    TokenTransferMemo, TransactionAnchorMode, TransactionAuth, TransactionContractCall,
-    TransactionPayload, TransactionPostConditionMode, TransactionPublicKeyEncoding,
-    TransactionSmartContract, TransactionSpendingCondition, TransactionVersion,
-};
-use stackslib::util_lib::strings::StacksString;
 
 mod bitcoin_deployment;
 
@@ -105,9 +105,9 @@ fn sign_transaction_payload(
         .consensus_serialize(&mut unsigned_tx_bytes)
         .expect("FATAL: invalid transaction");
 
-    let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
-    tx_signer.sign_origin(&secret_key).unwrap();
-    let signed_tx = tx_signer.get_tx().unwrap();
+    let mut signed_tx = unsigned_tx;
+    let sighash = signed_tx.sign_begin();
+    signed_tx.sign_next_origin(&sighash, &secret_key).unwrap();
     Ok(signed_tx)
 }
 

--- a/components/stacks-rpc-client/Cargo.toml
+++ b/components/stacks-rpc-client/Cargo.toml
@@ -12,8 +12,8 @@ reqwest = { workspace = true, features = ["blocking"] }
 libsecp256k1 = { workspace = true }
 
 clarity = { workspace = true, default-features = false }
+stacks-codec = { workspace = true }
 stacks-common = { workspace = true, default-features = false }
-stackslib = { workspace = true }
 clarinet-utils = { path = "../clarinet-utils" }
 
 # enable mock stacks rpc for tests

--- a/components/stacks-rpc-client/src/crypto.rs
+++ b/components/stacks-rpc-client/src/crypto.rs
@@ -5,16 +5,16 @@ use clarity::util::secp256k1::{MessageSignature, Secp256k1PrivateKey, Secp256k1P
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use clarity::vm::{ClarityName, ClarityVersion, ContractName, Value as ClarityValue};
 use libsecp256k1::PublicKey;
+use stacks_codec::strings::StacksString;
+use stacks_codec::transaction::{
+    SinglesigHashMode, SinglesigSpendingCondition, StacksTransaction, TokenTransferMemo,
+    TransactionAnchorMode, TransactionAuth, TransactionContractCall, TransactionPayload,
+    TransactionPostConditionMode, TransactionPublicKeyEncoding, TransactionSmartContract,
+    TransactionSpendingCondition, TransactionVersion,
+};
 use stacks_common::address::{
     AddressHashMode, C32_ADDRESS_VERSION_MAINNET_SINGLESIG, C32_ADDRESS_VERSION_TESTNET_SINGLESIG,
 };
-use stackslib::chainstate::stacks::{
-    SinglesigHashMode, SinglesigSpendingCondition, StacksTransaction, StacksTransactionSigner,
-    TokenTransferMemo, TransactionAnchorMode, TransactionAuth, TransactionContractCall,
-    TransactionPayload, TransactionPostConditionMode, TransactionPublicKeyEncoding,
-    TransactionSmartContract, TransactionSpendingCondition, TransactionVersion,
-};
-use stackslib::util_lib::strings::StacksString;
 
 #[derive(Clone, Debug)]
 pub struct Wallet {
@@ -102,9 +102,11 @@ pub fn sign_transaction_payload(
         .consensus_serialize(&mut unsigned_tx_bytes)
         .expect("FATAL: invalid transaction");
 
-    let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
-    tx_signer.sign_origin(&keypair.secret_key).unwrap();
-    let signed_tx = tx_signer.get_tx().unwrap();
+    let mut signed_tx = unsigned_tx;
+    let sighash = signed_tx.sign_begin();
+    signed_tx
+        .sign_next_origin(&sighash, &keypair.secret_key)
+        .unwrap();
     Ok(signed_tx)
 }
 
@@ -219,10 +221,11 @@ pub fn build_contract_call_transaction(
         .consensus_serialize(&mut unsigned_tx_bytes)
         .expect("FATAL: invalid transaction");
 
-    let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
-    tx_signer.sign_origin(&secret_key).unwrap();
+    let mut signed_tx = unsigned_tx;
+    let sighash = signed_tx.sign_begin();
+    signed_tx.sign_next_origin(&sighash, &secret_key).unwrap();
 
-    tx_signer.get_tx().unwrap()
+    signed_tx
 }
 
 pub fn build_contract_publish_transaction(
@@ -272,8 +275,9 @@ pub fn build_contract_publish_transaction(
         .consensus_serialize(&mut unsigned_tx_bytes)
         .expect("FATAL: invalid transaction");
 
-    let mut tx_signer = StacksTransactionSigner::new(&unsigned_tx);
-    tx_signer.sign_origin(&secret_key).unwrap();
+    let mut signed_tx = unsigned_tx;
+    let sighash = signed_tx.sign_begin();
+    signed_tx.sign_next_origin(&sighash, &secret_key).unwrap();
 
-    tx_signer.get_tx().unwrap()
+    signed_tx
 }

--- a/components/stacks-rpc-client/src/rpc_client.rs
+++ b/components/stacks-rpc-client/src/rpc_client.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 #[cfg(any(test, feature = "mock"))]
 use serde::Serialize;
 use serde_json::json;
-use stackslib::chainstate::stacks::{StacksTransaction, TransactionPayload};
+use stacks_codec::transaction::{StacksTransaction, TransactionPayload};
 
 #[derive(Clone, Debug)]
 pub enum RpcError {


### PR DESCRIPTION
### Description

Since we've moved a lot of structs and ser/deser logic from `stackslib` into `stacks-codec`, we can remove the dependency on `stackslib` for a couple crates in this repo

This doesn't reduce compile time when building the full `clarinet` binary, since it still requires `stackslib`, but it could if we're building some subset that doesn't require it
