### PR TITLE
chore: release 3.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-# [3.21.1](https://github.com/stx-labs/clarinet/compare/v3.21.1...v3.22.0) (2026-07-22)
+
+# [3.23.0](https://github.com/stx-labs/clarinet/compare/v3.22.0...v3.23.0) (2026-07-30)
+
+##### New Features
+
+*  Add `renamed_builtin` lint for `with-stacking` deprecation (#2475) (2bfde32a)
+
+##### Chores
+
+*  Add new snapshot starting at epoch 4.0 (block 163) (#2474) (d0956bf)
+*  Use epoch 4.0 and Clarity 6 defaults (#2473) (be9a9d89)
+*  Update Stacks mainnet 4.0 start height (#2480) (21088828)
+
+# [3.22.0](https://github.com/stx-labs/clarinet/compare/v3.21.1...v3.22.0) (2026-07-22)
 
 ##### New Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "chrono",
  "clap",
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "clarinet-defaults"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "clarity",
 ]
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "bitcoin",
  "clarinet-defaults",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-static-cost"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "clarity",
  "clarity-types",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "observer"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "axum",
  "base58",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.22.0"
+version = "3.23.0"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["components/clarinet-cli"]
 opt-level = 3
 
 [workspace.package]
-version = "3.22.0"
+version = "3.23.0"
 
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",


### PR DESCRIPTION
### New Features

*  Add `renamed_builtin` lint for `with-stacking` deprecation (#2475) (2bfde32a)

### Chores

*  Add new snapshot starting at epoch 4.0 (block 163) (#2474) (d0956bf)
*  Use epoch 4.0 and Clarity 6 defaults (#2473) (be9a9d89)
*  Update Stacks mainnet 4.0 start height (#2480) (21088828)
