### PR TITLE
fix(static-cost): price epoch 4.0 with costs-5

### DIFF
--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -2424,27 +2424,27 @@ mod tests {
         assert_eq!(result, None);
     }
 
-    /// Verify that hash function costs vary with input buffer size.
-    /// The runtime charges based on the serialized size of the input value,
-    /// so (sha256 0x00) should cost less than (sha256 0x0011223344...).
-    /// If these fail, it means static analysis is passing arg_count (always 1)
-    /// instead of the input byte length.
-    #[test]
-    fn test_hash_function_costs_vary_with_buffer_size() {
+    fn buff_literal(bytes: usize) -> String {
+        format!("0x{}", "ab".repeat(bytes))
+    }
+
+    /// Hashing more input must cost more, which catches static analysis passing
+    /// `arg_count` instead of the input size.
+    ///
+    /// The sizes straddle 512 bytes because epoch 4.0 prices hashing per
+    /// 512-byte block, so smaller inputs all cost the same.
+    #[track_caller]
+    fn assert_hash_cost_grows_with_input(hash_fn: &str) {
         let v = &ClarityVersion::Clarity3;
 
-        // Small buffer (1 byte)
-        let small = static_cost_native_test("(sha256 0x00)", v).unwrap();
-        // Large buffer (32 bytes)
-        let large = static_cost_native_test(
-            "(sha256 0x0102030405060708091011121314151617181920212223242526272829303132)",
-            v,
-        )
-        .unwrap();
+        let small =
+            static_cost_native_test(&format!("({hash_fn} {})", buff_literal(1)), v).unwrap();
+        let large =
+            static_cost_native_test(&format!("({hash_fn} {})", buff_literal(2048)), v).unwrap();
 
         assert!(
             large.min.runtime > small.min.runtime,
-            "sha256: 32-byte input should cost more than 1-byte input, \
+            "{hash_fn}: 2048-byte input should cost more than 1-byte input, \
              but got small={}, large={}; \
              static analysis likely passes arg_count instead of input size",
             small.min.runtime,
@@ -2453,24 +2453,13 @@ mod tests {
     }
 
     #[test]
+    fn test_hash_function_costs_vary_with_buffer_size() {
+        assert_hash_cost_grows_with_input("sha256");
+    }
+
+    #[test]
     fn test_hash160_cost_varies_with_buffer_size() {
-        let v = &ClarityVersion::Clarity3;
-
-        let small = static_cost_native_test("(hash160 0x00)", v).unwrap();
-        let large = static_cost_native_test(
-            "(hash160 0x0102030405060708091011121314151617181920212223242526272829303132)",
-            v,
-        )
-        .unwrap();
-
-        assert!(
-            large.min.runtime > small.min.runtime,
-            "hash160: 32-byte input should cost more than 1-byte input, \
-             but got small={}, large={}; \
-             static analysis likely passes arg_count instead of input size",
-            small.min.runtime,
-            large.min.runtime,
-        );
+        assert_hash_cost_grows_with_input("hash160");
     }
 
     #[test]
@@ -2533,23 +2522,7 @@ mod tests {
 
     #[test]
     fn test_keccak256_cost_varies_with_buffer_size() {
-        let v = &ClarityVersion::Clarity3;
-
-        let small = static_cost_native_test("(keccak256 0x00)", v).unwrap();
-        let large = static_cost_native_test(
-            "(keccak256 0x0102030405060708091011121314151617181920212223242526272829303132)",
-            v,
-        )
-        .unwrap();
-
-        assert!(
-            large.min.runtime > small.min.runtime,
-            "keccak256: 32-byte input should cost more than 1-byte input, \
-             but got small={}, large={}; \
-             static analysis likely passes arg_count instead of input size",
-            small.min.runtime,
-            large.min.runtime,
-        );
+        assert_hash_cost_grows_with_input("keccak256");
     }
     #[test]
     fn test_infer_type_from_listcons_uses_least_supertype_over_all_elements() {

--- a/components/clarity-static-cost/src/static_cost/cost_analysis.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_analysis.rs
@@ -2431,8 +2431,9 @@ mod tests {
     /// Hashing more input must cost more, which catches static analysis passing
     /// `arg_count` instead of the input size.
     ///
-    /// The sizes straddle 512 bytes because epoch 4.0 prices hashing per
-    /// 512-byte block, so smaller inputs all cost the same.
+    /// From epoch 4.0 the cost is `(serialized_size >> 9) + 38`
+    /// (`Costs5::cost_hash160`), so inputs under ~512 bytes all cost the same.
+    /// The sizes below straddle that step.
     #[track_caller]
     fn assert_hash_cost_grows_with_input(hash_fn: &str) {
         let v = &ClarityVersion::Clarity3;

--- a/components/clarity-static-cost/src/static_cost/cost_functions.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_functions.rs
@@ -3,10 +3,72 @@ use clarity::vm::costs::costs_1::Costs1;
 use clarity::vm::costs::costs_2::Costs2;
 use clarity::vm::costs::costs_3::Costs3;
 use clarity::vm::costs::costs_4::Costs4;
+use clarity::vm::costs::costs_5::Costs5;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::errors::VmExecutionError;
 use clarity::vm::functions::NativeFunctions;
 use stacks_common::types::StacksEpochId;
+
+/// The cost-function table the VM prices an epoch with.
+///
+/// Selection is separate from evaluation so a test can check it against
+/// `LimitedCostTracker::default_cost_contract_for_epoch`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CostModel {
+    Costs1,
+    Costs2,
+    Costs3,
+    Costs4,
+    Costs5,
+}
+
+impl CostModel {
+    /// Mirrors `LimitedCostTracker::default_cost_contract_for_epoch`; keep the
+    /// arms grouped the way it groups them.
+    fn for_epoch(epoch: StacksEpochId) -> Self {
+        match epoch {
+            StacksEpochId::Epoch10 => unreachable!("epoch 1.0 is not supported"),
+            StacksEpochId::Epoch20 => CostModel::Costs1,
+            StacksEpochId::Epoch2_05 => CostModel::Costs2,
+            StacksEpochId::Epoch21
+            | StacksEpochId::Epoch22
+            | StacksEpochId::Epoch23
+            | StacksEpochId::Epoch24
+            | StacksEpochId::Epoch25
+            | StacksEpochId::Epoch30
+            | StacksEpochId::Epoch31
+            | StacksEpochId::Epoch32 => CostModel::Costs3,
+            StacksEpochId::Epoch33 | StacksEpochId::Epoch34 => CostModel::Costs4,
+            StacksEpochId::Epoch40 => CostModel::Costs5,
+        }
+    }
+
+    fn eval(self, f: &ClarityCostFunction, n: u64) -> Result<ExecutionCost, VmExecutionError> {
+        match self {
+            CostModel::Costs1 => f.eval::<Costs1>(n),
+            CostModel::Costs2 => f.eval::<Costs2>(n),
+            CostModel::Costs3 => f.eval::<Costs3>(n),
+            CostModel::Costs4 => f.eval::<Costs4>(n),
+            CostModel::Costs5 => f.eval::<Costs5>(n),
+        }
+    }
+
+    /// The boot contract the VM loads for this table.
+    #[cfg(test)]
+    fn boot_contract_name(self) -> &'static str {
+        use clarity::vm::costs::{
+            COSTS_1_NAME, COSTS_2_NAME, COSTS_3_NAME, COSTS_4_NAME, COSTS_5_NAME,
+        };
+
+        match self {
+            CostModel::Costs1 => COSTS_1_NAME,
+            CostModel::Costs2 => COSTS_2_NAME,
+            CostModel::Costs3 => COSTS_3_NAME,
+            CostModel::Costs4 => COSTS_4_NAME,
+            CostModel::Costs5 => COSTS_5_NAME,
+        }
+    }
+}
 
 /// Extension trait for ClarityCostFunction to evaluate costs for a specific epoch
 pub trait ClarityCostFunctionExt {
@@ -23,21 +85,7 @@ impl ClarityCostFunctionExt for ClarityCostFunction {
         n: u64,
         epoch: StacksEpochId,
     ) -> Result<ExecutionCost, VmExecutionError> {
-        match epoch {
-            StacksEpochId::Epoch10 => unreachable!("epoch 1.0 is not supported"),
-            StacksEpochId::Epoch20 => self.eval::<Costs1>(n),
-            StacksEpochId::Epoch2_05 => self.eval::<Costs2>(n),
-            StacksEpochId::Epoch21
-            | StacksEpochId::Epoch22
-            | StacksEpochId::Epoch23
-            | StacksEpochId::Epoch24
-            | StacksEpochId::Epoch25
-            | StacksEpochId::Epoch30
-            | StacksEpochId::Epoch31
-            | StacksEpochId::Epoch32 => self.eval::<Costs3>(n),
-            StacksEpochId::Epoch33 => self.eval::<Costs4>(n),
-            StacksEpochId::Epoch34 | StacksEpochId::Epoch40 => self.eval::<Costs4>(n),
-        }
+        CostModel::for_epoch(epoch).eval(self, n)
     }
 }
 
@@ -169,5 +217,61 @@ pub fn from_native_function(native_function: NativeFunctions) -> ClarityCostFunc
         NativeFunctions::GetBitcoinTxOutput => ClarityCostFunction::GetBitcoinTxOutput,
         NativeFunctions::Ed25519Verify => ClarityCostFunction::Ed25519verify,
         NativeFunctions::Secp256k1Decompress => ClarityCostFunction::Secp256k1decompress,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clarity::vm::costs::LimitedCostTracker;
+
+    use super::*;
+
+    /// Our mapping must match the VM's, and nothing else holds them together.
+    ///
+    /// Compares cost contracts, so it does not cover the mainnet/testnet split
+    /// of `costs-2`, which this crate does not model.
+    #[test]
+    fn cost_model_matches_the_table_the_vm_prices_with() {
+        for &epoch in StacksEpochId::ALL {
+            // Epoch 1.0 predates Clarity and has no cost contract.
+            if epoch == StacksEpochId::Epoch10 {
+                continue;
+            }
+
+            let expected = LimitedCostTracker::default_cost_contract_for_epoch(epoch)
+                .expect("every Clarity-bearing epoch has a default cost contract");
+
+            assert_eq!(
+                CostModel::for_epoch(epoch).boot_contract_name(),
+                expected,
+                "static cost analysis prices {epoch} with a different table than the VM"
+            );
+        }
+    }
+
+    #[test]
+    fn epoch_4_prices_with_costs_5() {
+        assert_eq!(
+            CostModel::for_epoch(StacksEpochId::Epoch33),
+            CostModel::Costs4
+        );
+        assert_eq!(
+            CostModel::for_epoch(StacksEpochId::Epoch34),
+            CostModel::Costs4
+        );
+        assert_eq!(
+            CostModel::for_epoch(StacksEpochId::Epoch40),
+            CostModel::Costs5
+        );
+    }
+
+    /// The two tables differ, so switching epoch 4.0 is not a no-op.
+    #[test]
+    fn costs_4_and_costs_5_disagree() {
+        let f = ClarityCostFunction::Add;
+        assert_ne!(
+            f.eval_for_epoch(10, StacksEpochId::Epoch34).unwrap(),
+            f.eval_for_epoch(10, StacksEpochId::Epoch40).unwrap(),
+        );
     }
 }


### PR DESCRIPTION
### Description

Static cost analysis prices epoch 4.0 with the `Costs4` table, but the VM prices it with `Costs5`. Since `DEFAULT_EPOCH` is `Epoch40`, reported costs are wrong for most users.

This PR:

- maps epoch 4.0 to `Costs5`
- adds a test comparing our epoch → cost table mapping against `LimitedCostTracker::default_cost_contract_for_epoch`, which is what the VM consults, so the two can't silently diverge again

Three hash-cost tests compared a 1-byte input against a 32-byte one. `Costs5` prices hashing per 512-byte block, so those now cost the same and the assertion no longer proved anything; they compare 1 byte against 2048 bytes instead.

#### Breaking change?

No API change, but reported costs for epoch 4.0 change — that's the fix.

---

### Checklist

- [x] Tests added in this PR (if applicable)
