### PR TITLE
feat: Track account nonces in simnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "clarity-types",
  "integer-sqrt",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2490,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "libsigner"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "clarity",
  "hashbrown 0.15.5",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "clarity",
  "serde",
@@ -3063,7 +3063,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "clarity",
  "slog",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "clarity-types",
  "serde",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
 dependencies = [
  "clarity",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "clarity-types",
  "integer-sqrt",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2490,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "libsigner"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "clarity",
  "hashbrown 0.15.5",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "clarity",
  "serde",
@@ -3063,7 +3063,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "clarity",
  "slog",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "clarity-types",
  "serde",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=b17d3a12e1a2d4540473fcca62aac8b9731334f3#b17d3a12e1a2d4540473fcca62aac8b9731334f3"
+source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
 dependencies = [
  "clarity",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "clarity-types",
  "integer-sqrt",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2490,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "libsigner"
 version = "0.0.1"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "clarity",
  "hashbrown 0.15.5",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "clarity",
  "serde",
@@ -3063,7 +3063,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "clarity",
  "slog",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "0.1.0"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "clarity-types",
  "serde",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/jbencin-stacks/stacks-core.git?rev=87f959466930be798592355534ac601d121339f2#87f959466930be798592355534ac601d121339f2"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=425a14582f301f9fa045524c597f4f3b95dfde8e#425a14582f301f9fa045524c597f4f3b95dfde8e"
 dependencies = [
  "clarity",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ version = "3.23.2"
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]
 # stacks-core git dependencies
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "clarity", default-features = false }
-clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "clarity-types" }
-libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "libsigner", default-features = false }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "pox-locking", default-features = false }
-stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "stacks-codec" }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "stacks-common", default-features = false }
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "b17d3a12e1a2d4540473fcca62aac8b9731334f3", package = "stackslib", default-features = false }
+clarity = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "clarity", default-features = false }
+clarity-types = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "clarity-types" }
+libsigner = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "libsigner", default-features = false }
+pox-locking = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "pox-locking", default-features = false }
+stacks-codec = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "stacks-codec" }
+stacks-common = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "stacks-common", default-features = false }
+stackslib = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "stackslib", default-features = false }
 
 # Internal crates
 clarinet-defaults = { path = "components/clarinet-defaults" }
@@ -95,7 +95,7 @@ wasm-bindgen-futures = { version = "0.4.58" }
 web-sys = { version = "0.3.85" }
 yaml_serde = "0.10.3"
 
-# [patch.'https://github.com/stacks-network/stacks-core.git']
+# [patch.'https://github.com/jbencin-stacks/stacks-core.git']
 # clarity = { path = "../stacks-core/clarity" }
 # clarity-types = { path = "../stacks-core/clarity-types" }
 # libsigner = { path = "../stacks-core/libsigner" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ version = "3.23.2"
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]
 # stacks-core git dependencies
-clarity = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "clarity", default-features = false }
-clarity-types = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "clarity-types" }
-libsigner = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "libsigner", default-features = false }
-pox-locking = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "pox-locking", default-features = false }
-stacks-codec = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "stacks-codec" }
-stacks-common = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "stacks-common", default-features = false }
-stackslib = { git = "https://github.com/jbencin-stacks/stacks-core.git", rev = "87f959466930be798592355534ac601d121339f2", package = "stackslib", default-features = false }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "clarity", default-features = false }
+clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "clarity-types" }
+libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "libsigner", default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "pox-locking", default-features = false }
+stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "stacks-codec" }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "stacks-common", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "stackslib", default-features = false }
 
 # Internal crates
 clarinet-defaults = { path = "components/clarinet-defaults" }
@@ -95,7 +95,7 @@ wasm-bindgen-futures = { version = "0.4.58" }
 web-sys = { version = "0.3.85" }
 yaml_serde = "0.10.3"
 
-# [patch.'https://github.com/jbencin-stacks/stacks-core.git']
+# [patch.'https://github.com/stacks-network/stacks-core.git']
 # clarity = { path = "../stacks-core/clarity" }
 # clarity-types = { path = "../stacks-core/clarity-types" }
 # libsigner = { path = "../stacks-core/libsigner" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ version = "3.23.2"
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]
 # stacks-core git dependencies
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "clarity", default-features = false }
-clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "clarity-types" }
-libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "libsigner", default-features = false }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "pox-locking", default-features = false }
-stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "stacks-codec" }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "stacks-common", default-features = false }
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "425a14582f301f9fa045524c597f4f3b95dfde8e", package = "stackslib", default-features = false }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "clarity", default-features = false }
+clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "clarity-types" }
+libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "libsigner", default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "pox-locking", default-features = false }
+stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "stacks-codec" }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "stacks-common", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "stackslib", default-features = false }
 
 # Internal crates
 clarinet-defaults = { path = "components/clarinet-defaults" }

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -313,9 +313,7 @@ fn handle_emulated_contract_call(
         .iter()
         .map(|p| session.eval_clarity_string(p))
         .collect();
-    // An emulated contract call in a deployment plan is a transaction, so it
-    // consumes the emulated sender's nonce — same reasoning as the plan's
-    // contract publishes, and including failures mainnet would still mine.
+    // Deployment-plan calls are transactions from the emulated sender.
     let result = session.call_contract_fn(
         &tx.contract_id.to_string(),
         &tx.method.to_string(),
@@ -1437,9 +1435,7 @@ mod tests {
 
     #[test]
     fn test_emulated_plan_transactions_consume_the_senders_nonce() {
-        // Every entry in a deployment plan is a transaction the emulated sender
-        // sent, so each consumes a nonce — the publishes as well as the calls.
-        // This is why a project's deployer starts above zero.
+        // Publishes and emulated calls are transactions from the plan's sender.
         let mut session = Session::new(SessionSettings::default());
         let epoch = StacksEpochId::Epoch25;
         session.update_epoch(epoch);
@@ -1473,9 +1469,7 @@ mod tests {
             parameters: vec![],
         };
 
-        // A call that fails at runtime is still mined on mainnet, so it still
-        // consumes a nonce. Assert the state change too, so a regression that
-        // turns the successful call into a no-op cannot pass vacuously.
+        // Assert the state change so the successful call cannot pass as a no-op.
         let mut spec = call("add");
         spec.parameters = vec!["1".to_string()];
         handle_emulated_contract_call(&mut session, &spec).unwrap();
@@ -1495,12 +1489,7 @@ mod tests {
             "a failed-but-included plan call still consumes a nonce"
         );
 
-        // Calling a function that does not exist raises `UndefinedFunction`, a
-        // `RuntimeCheck` error. It is not in `RuntimeCheckErrorKind::rejectable`,
-        // so from epoch 2.1 onward mainnet mines the transaction and it fails —
-        // it is only rejected in earlier epochs. Worth stating because it is
-        // easy to assume "the function doesn't exist" means "never a valid
-        // transaction"; the epoch is what decides.
+        // `UndefinedFunction` is an included failure from epoch 2.1 onward.
         assert!(handle_emulated_contract_call(&mut session, &call("nope")).is_err());
         assert_eq!(
             session.get_nonce(&deployer).unwrap(),

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -25,6 +25,7 @@ use clarity_repl::repl::boot::{
     SBTC_DEPOSIT_MAINNET_ADDRESS, SBTC_MAINNET_ADDRESS, SBTC_TESTNET_ADDRESS_PRINCIPAL,
     SBTC_TOKEN_MAINNET_ADDRESS,
 };
+use clarity_repl::repl::interpreter::BlockInclusion;
 use clarity_repl::repl::session::{AnnotatedExecutionResult, ExecutionResultMap};
 use clarity_repl::repl::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Session,
@@ -325,14 +326,15 @@ fn handle_emulated_contract_call(
     // An emulated contract call in a deployment plan is a transaction, so it
     // consumes the emulated sender's nonce — same reasoning as the plan's
     // contract publishes, and including failures mainnet would still mine.
-    let included = result
-        .as_ref()
-        .map_or_else(|e| e.inclusion.is_included(), |_| true);
-    if included {
-        session.bump_nonce(tx.emulated_sender.clone().into());
-    }
+    let bump = BlockInclusion::of_result(&result)
+        .is_included()
+        .then(|| session.bump_nonce(tx.emulated_sender.clone().into()))
+        .transpose();
 
+    // Restore the sender before reporting, so a failed bump does not also
+    // leave the session pointed at the emulated sender.
     session.set_tx_sender(&default_tx_sender);
+    bump.map_err(Session::nonce_failure)?;
     result.map_err(Vec::from)
 }
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -319,11 +319,21 @@ fn handle_emulated_contract_call(
         false,
     );
     if let Err(errors) = &result {
-        println!("error: {:?}", errors.first().unwrap().message);
+        println!("error: {:?}", errors.diagnostics.first().unwrap().message);
+    }
+
+    // An emulated contract call in a deployment plan is a transaction, so it
+    // consumes the emulated sender's nonce — same reasoning as the plan's
+    // contract publishes, and including failures mainnet would still mine.
+    let included = result
+        .as_ref()
+        .map_or_else(|e| e.inclusion.is_included(), |_| true);
+    if included {
+        session.bump_nonce(tx.emulated_sender.clone().into());
     }
 
     session.set_tx_sender(&default_tx_sender);
-    result
+    result.map_err(Vec::from)
 }
 
 /// Hash contract source for cache validation. SHA-256 is hardware-accelerated

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -25,8 +25,7 @@ use clarity_repl::repl::boot::{
     SBTC_DEPOSIT_MAINNET_ADDRESS, SBTC_MAINNET_ADDRESS, SBTC_TESTNET_ADDRESS_PRINCIPAL,
     SBTC_TOKEN_MAINNET_ADDRESS,
 };
-use clarity_repl::repl::interpreter::BlockInclusion;
-use clarity_repl::repl::session::{AnnotatedExecutionResult, ExecutionResultMap};
+use clarity_repl::repl::session::{AnnotatedExecutionResult, CallKind, ExecutionResultMap};
 use clarity_repl::repl::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Session,
     SessionSettings,
@@ -191,6 +190,8 @@ fn fund_genesis_account_with_sbtc(session: &mut Session, deployment: &Deployment
                 height.clone(),
                 sweep_tx_id,
             ];
+            // Session setup, not something the sbtc address sent: like the
+            // boot contracts, it stays at nonce 0.
             let _ = session.call_contract_fn(
                 &SBTC_DEPOSIT_MAINNET_ADDRESS.to_string(),
                 "complete-deposit-wrapper",
@@ -198,6 +199,7 @@ fn fund_genesis_account_with_sbtc(session: &mut Session, deployment: &Deployment
                 SBTC_MAINNET_ADDRESS,
                 false,
                 false,
+                CallKind::Free,
             );
         }
     }
@@ -311,6 +313,9 @@ fn handle_emulated_contract_call(
         .iter()
         .map(|p| session.eval_clarity_string(p))
         .collect();
+    // An emulated contract call in a deployment plan is a transaction, so it
+    // consumes the emulated sender's nonce — same reasoning as the plan's
+    // contract publishes, and including failures mainnet would still mine.
     let result = session.call_contract_fn(
         &tx.contract_id.to_string(),
         &tx.method.to_string(),
@@ -318,23 +323,13 @@ fn handle_emulated_contract_call(
         &tx.emulated_sender.to_string(),
         true,
         false,
+        CallKind::Transaction,
     );
     if let Err(errors) = &result {
         println!("error: {:?}", errors.diagnostics.first().unwrap().message);
     }
 
-    // An emulated contract call in a deployment plan is a transaction, so it
-    // consumes the emulated sender's nonce — same reasoning as the plan's
-    // contract publishes, and including failures mainnet would still mine.
-    let bump = BlockInclusion::of_result(&result)
-        .is_included()
-        .then(|| session.bump_nonce(tx.emulated_sender.clone().into()))
-        .transpose();
-
-    // Restore the sender before reporting, so a failed bump does not also
-    // leave the session pointed at the emulated sender.
     session.set_tx_sender(&default_tx_sender);
-    bump.map_err(Session::nonce_failure)?;
     result.map_err(Vec::from)
 }
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -1439,6 +1439,80 @@ mod tests {
     }
 
     #[test]
+    fn test_emulated_plan_transactions_consume_the_senders_nonce() {
+        // Every entry in a deployment plan is a transaction the emulated sender
+        // sent, so each consumes a nonce — the publishes as well as the calls.
+        // This is why a project's deployer starts above zero.
+        let mut session = Session::new(SessionSettings::default());
+        let epoch = StacksEpochId::Epoch25;
+        session.update_epoch(epoch);
+
+        let deployer: PrincipalData = PrincipalData::parse_standard_principal(DEPLOYER)
+            .unwrap()
+            .into();
+        assert_eq!(session.get_nonce(&deployer).unwrap(), 0);
+
+        let snippet = [
+            "(define-data-var x int 0)",
+            "(define-public (add (n int)) (ok (var-set x (+ (var-get x) n))))",
+            "(define-public (boom) (ok (/ (var-get x) 0)))",
+        ]
+        .join("\n");
+        deploy_contract(&mut session, "contract_1", &snippet, epoch).unwrap();
+        assert_eq!(
+            session.get_nonce(&deployer).unwrap(),
+            1,
+            "an emulated publish is a transaction"
+        );
+
+        let contract_id = QualifiedContractIdentifier::new(
+            PrincipalData::parse_standard_principal(DEPLOYER).unwrap(),
+            ContractName::from_literal("contract_1"),
+        );
+        let call = |method: &'static str| EmulatedContractCallSpecification {
+            contract_id: contract_id.clone(),
+            emulated_sender: PrincipalData::parse_standard_principal(DEPLOYER).unwrap(),
+            method: ClarityName::from_literal(method),
+            parameters: vec![],
+        };
+
+        // A call that fails at runtime is still mined on mainnet, so it still
+        // consumes a nonce. Assert the state change too, so a regression that
+        // turns the successful call into a no-op cannot pass vacuously.
+        let mut spec = call("add");
+        spec.parameters = vec!["1".to_string()];
+        handle_emulated_contract_call(&mut session, &spec).unwrap();
+        assert_eq!(
+            session.interpreter.get_data_var(&contract_id, "x"),
+            Some(to_raw_value(&Value::Int(1)))
+        );
+        assert_eq!(session.get_nonce(&deployer).unwrap(), 2);
+
+        assert!(
+            handle_emulated_contract_call(&mut session, &call("boom")).is_err(),
+            "dividing by zero must surface as an error"
+        );
+        assert_eq!(
+            session.get_nonce(&deployer).unwrap(),
+            3,
+            "a failed-but-included plan call still consumes a nonce"
+        );
+
+        // Calling a function that does not exist raises `UndefinedFunction`, a
+        // `RuntimeCheck` error. It is not in `RuntimeCheckErrorKind::rejectable`,
+        // so from epoch 2.1 onward mainnet mines the transaction and it fails —
+        // it is only rejected in earlier epochs. Worth stating because it is
+        // easy to assume "the function doesn't exist" means "never a valid
+        // transaction"; the epoch is what decides.
+        assert!(handle_emulated_contract_call(&mut session, &call("nope")).is_err());
+        assert_eq!(
+            session.get_nonce(&deployer).unwrap(),
+            4,
+            "an undefined function is an included runtime failure from epoch 2.1"
+        );
+    }
+
+    #[test]
     fn test_handle_emulated_contract_call_with_tuple() {
         let mut session = Session::new(SessionSettings::default());
         let epoch = StacksEpochId::Epoch25;

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -199,7 +199,7 @@ fn fund_genesis_account_with_sbtc(session: &mut Session, deployment: &Deployment
                 SBTC_MAINNET_ADDRESS,
                 false,
                 false,
-                CallKind::Free,
+                CallKind::NonceFree,
             );
         }
     }

--- a/components/clarinet-deployments/src/types.rs
+++ b/components/clarinet-deployments/src/types.rs
@@ -65,6 +65,9 @@ impl From<StacksEpochId> for EpochSpec {
             StacksEpochId::Epoch34 => EpochSpec::Epoch3_4,
             StacksEpochId::Epoch40 => EpochSpec::Epoch4_0,
             StacksEpochId::Epoch10 => unreachable!("epoch 1.0 is not supported"),
+            // Clarinet has no `EpochSpec` for 4.1 yet, so a manifest cannot name
+            // it and `DEFAULT_EPOCH` is still 4.0 — nothing can reach this arm.
+            StacksEpochId::Epoch41 => unreachable!("epoch 4.1 is not supported"),
         }
     }
 }

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -900,7 +900,7 @@ impl SDK {
             }
         }
         // A read-only call sends nothing, so it is never a transaction.
-        self.call_contract_fn(args, false, CallKind::Free)
+        self.call_contract_fn(args, false, CallKind::NonceFree)
     }
 
     /// Charge an included preflight failure. No VM state exists to commit.

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -21,6 +21,7 @@ use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPri
 use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExpression};
 use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::hooks::perf::CostField;
+use clarity_repl::repl::interpreter::BlockInclusion;
 use clarity_repl::repl::session::CostsReport;
 use clarity_repl::repl::settings::RemoteDataSettings;
 use clarity_repl::repl::{
@@ -72,6 +73,35 @@ struct DeploymentArtifacts {
     artifacts: DeploymentGenerationArtifacts,
     deployment: DeploymentSpecification,
     manifest: ProjectManifest,
+}
+
+/// A failed simnet operation, plus whether mainnet would still have included
+/// the transaction that produced it.
+///
+/// Only the callers that decide nonce consumption need the verdict; the wasm
+/// boundary reports a plain message, so it is dropped on the way out via
+/// `String::from`.
+struct OperationFailure {
+    message: String,
+    inclusion: BlockInclusion,
+}
+
+impl OperationFailure {
+    /// A failure simnet detects before running anything — an invalid sender,
+    /// an unknown contract id. Mainnet would not have included such a
+    /// transaction either, so it consumes no nonce.
+    fn rejected(message: String) -> Self {
+        Self {
+            message,
+            inclusion: BlockInclusion::Rejected,
+        }
+    }
+}
+
+impl From<OperationFailure> for String {
+    fn from(failure: OperationFailure) -> Self {
+        failure.message
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -816,13 +846,15 @@ impl SDK {
             sender,
         }: &CallFnArgs,
         allow_private: bool,
-    ) -> Result<TransactionRes, String> {
+    ) -> Result<TransactionRes, OperationFailure> {
         let test_name = self.current_test_name.clone();
         let track_costs = self.options.track_costs;
         let track_performance = self.options.track_performance;
 
         if PrincipalData::parse_standard_principal(sender).is_err() {
-            return Err(format!("Invalid sender address '{sender}'."));
+            return Err(OperationFailure::rejected(format!(
+                "Invalid sender address '{sender}'."
+            )));
         }
 
         let parsed_args = args
@@ -840,7 +872,7 @@ impl SDK {
                 allow_private,
                 track_costs,
             )
-            .map_err(|diagnostics| {
+            .map_err(|failure| {
                 let mut message = format!(
                     "Call contract function error: {contract}::{method}({})",
                     args.iter()
@@ -848,10 +880,13 @@ impl SDK {
                         .collect::<Vec<String>>()
                         .join(", ")
                 );
-                if let Some(diag) = diagnostics.last() {
+                if let Some(diag) = failure.diagnostics.last() {
                     message = format!("{message} -> {}", diag.message);
                 }
-                message
+                OperationFailure {
+                    message,
+                    inclusion: failure.inclusion,
+                }
             })?;
 
         // Collect performance data before accessing self.costs_reports
@@ -866,8 +901,12 @@ impl SDK {
 
         if track_costs {
             if let Some(ref cost) = execution.cost {
-                let contract_id =
-                    Session::desugar_contract_id(&self.deployer, contract)?.to_string();
+                // Unreachable in practice: the same id was desugared to run
+                // the call above. Classify conservatively rather than claim a
+                // transaction happened on a path that cannot be reached.
+                let contract_id = Session::desugar_contract_id(&self.deployer, contract)
+                    .map_err(OperationFailure::rejected)?
+                    .to_string();
                 self.costs_reports.push(CostsReport {
                     test_name,
                     contract_id,
@@ -894,7 +933,36 @@ impl SDK {
                 return Err(format!("{} is not a read-only function", args.method));
             }
         }
-        self.call_contract_fn(args, false)
+        self.call_contract_fn(args, false).map_err(String::from)
+    }
+
+    /// Bump `sender`'s nonce if the call made it into a block.
+    ///
+    /// Only the callers that know an operation is a transaction do this.
+    /// `callReadOnlyFn` shares the same underlying session primitive as the
+    /// public and private call paths, but a read-only call sends nothing, so it
+    /// deliberately does not bump.
+    fn bump_sender_nonce_if_included(
+        &mut self,
+        sender: &str,
+        result: &Result<TransactionRes, OperationFailure>,
+    ) {
+        let included = match result {
+            Ok(_) => true,
+            Err(failure) => failure.inclusion.is_included(),
+        };
+        if !included {
+            return;
+        }
+        match PrincipalData::parse_standard_principal(sender) {
+            Ok(principal) => self.get_session_mut().bump_nonce(principal.into()),
+            Err(e) => {
+                // `call_contract_fn` rejects an unparseable sender before
+                // running anything, so reaching an included result here implies
+                // a valid address.
+                log!("Failed to bump nonce for '{sender}': {e:?}");
+            }
+        }
     }
 
     fn inner_call_public_fn(
@@ -912,7 +980,9 @@ impl SDK {
             let session = self.get_session_mut();
             session.advance_chain_tip(1);
         }
-        self.call_contract_fn(args, false)
+        let result = self.call_contract_fn(args, false);
+        self.bump_sender_nonce_if_included(&args.sender, &result);
+        result.map_err(String::from)
     }
 
     fn inner_call_private_fn(
@@ -929,7 +999,9 @@ impl SDK {
             let session = self.get_session_mut();
             session.advance_chain_tip(1);
         }
-        self.call_contract_fn(args, true)
+        let result = self.call_contract_fn(args, true);
+        self.bump_sender_nonce_if_included(&args.sender, &result);
+        result.map_err(String::from)
     }
 
     fn inner_transfer_stx(

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -21,6 +21,7 @@ use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPri
 use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExpression};
 use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::hooks::perf::CostField;
+use clarity_repl::repl::interpreter::BlockInclusion;
 use clarity_repl::repl::session::{CallKind, CostsReport};
 use clarity_repl::repl::settings::RemoteDataSettings;
 use clarity_repl::repl::{
@@ -903,8 +904,17 @@ impl SDK {
         self.call_contract_fn(args, false, CallKind::NonceFree)
     }
 
-    /// Charge an included preflight failure. No VM state exists to commit.
-    fn charge_preflight_rejection(&mut self, sender: &str) -> Result<(), String> {
+    /// Charge the nonce for a preflight failure if the equivalent VM error
+    /// would be included in this epoch.
+    fn charge_preflight_rejection(&mut self, args: &CallFnArgs) -> Result<(), String> {
+        let epoch = self.get_session().interpreter.datastore.get_current_epoch();
+        if !BlockInclusion::from_uncallable_function(&args.contract, &args.method, epoch)
+            .is_included()
+        {
+            return Ok(());
+        }
+
+        let sender = &args.sender;
         let principal = PrincipalData::parse_standard_principal(sender)
             .map_err(|e| format!("Failed to charge a nonce for '{sender}': {e:?}"))?;
         self.get_session_mut()
@@ -933,7 +943,7 @@ impl SDK {
         }
 
         if let Some(message) = wrong_access {
-            self.charge_preflight_rejection(&args.sender)?;
+            self.charge_preflight_rejection(args)?;
             return Err(message);
         }
 

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -903,13 +903,7 @@ impl SDK {
         self.call_contract_fn(args, false, CallKind::Free)
     }
 
-    /// Charge `sender` for a transaction rejected before it reached the VM.
-    ///
-    /// Safe as a standalone write only because nothing has executed: the
-    /// preflight below runs before `call_contract_fn`, so there is no committed
-    /// state for a failed charge to come apart from. Every path that *does*
-    /// execute names a `CallKind` instead, and is charged inside the
-    /// execution's own transaction.
+    /// Charge an included preflight failure. No VM state exists to commit.
     fn charge_preflight_rejection(&mut self, sender: &str) -> Result<(), String> {
         let principal = PrincipalData::parse_standard_principal(sender)
             .map_err(|e| format!("Failed to charge a nonce for '{sender}': {e:?}"))?;
@@ -918,15 +912,8 @@ impl SDK {
         Ok(())
     }
 
-    /// Run a contract call submitted as a transaction, and charge its nonce.
-    ///
-    /// The access check is done here, ahead of the VM, only so the error names
-    /// the mistake. The VM reaches the same verdict on its own — a function
-    /// that is not public raises `NoSuchPublicFunction`, a non-rejectable
-    /// `RuntimeCheck` that mainnet mines and charges a nonce for. So this
-    /// shortcut has to report the same disposition and take the same block, or
-    /// one call would consume a nonce and an identical one would not, decided
-    /// by nothing more than whether an interface happened to be cached.
+    /// Run a contract-call transaction. The cached-interface preflight must
+    /// preserve the VM path's nonce and block-advance behavior.
     fn call_fn_as_transaction(
         &mut self,
         args: &CallFnArgs,

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -21,7 +21,7 @@ use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPri
 use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExpression};
 use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::hooks::perf::CostField;
-use clarity_repl::repl::interpreter::BlockInclusion;
+use clarity_repl::repl::interpreter::{BlockInclusion, FailureInclusion};
 use clarity_repl::repl::session::CostsReport;
 use clarity_repl::repl::settings::RemoteDataSettings;
 use clarity_repl::repl::{
@@ -95,6 +95,21 @@ impl OperationFailure {
             message,
             inclusion: BlockInclusion::Rejected,
         }
+    }
+
+    /// A failure simnet detects before running anything, for a transaction
+    /// mainnet *would* have mined and charged a nonce for.
+    fn included(message: String) -> Self {
+        Self {
+            message,
+            inclusion: BlockInclusion::Included,
+        }
+    }
+}
+
+impl FailureInclusion for OperationFailure {
+    fn inclusion(&self) -> BlockInclusion {
+        self.inclusion
     }
 }
 
@@ -946,23 +961,54 @@ impl SDK {
         &mut self,
         sender: &str,
         result: &Result<TransactionRes, OperationFailure>,
-    ) {
-        let included = match result {
-            Ok(_) => true,
-            Err(failure) => failure.inclusion.is_included(),
-        };
-        if !included {
-            return;
+    ) -> Result<(), String> {
+        if !BlockInclusion::of_result(result).is_included() {
+            return Ok(());
         }
-        match PrincipalData::parse_standard_principal(sender) {
-            Ok(principal) => self.get_session_mut().bump_nonce(principal.into()),
-            Err(e) => {
-                // `call_contract_fn` rejects an unparseable sender before
-                // running anything, so reaching an included result here implies
-                // a valid address.
-                log!("Failed to bump nonce for '{sender}': {e:?}");
+        // `call_contract_fn` rejects an unparseable sender before running
+        // anything, so reaching an included result here implies a valid address.
+        let principal = PrincipalData::parse_standard_principal(sender)
+            .map_err(|e| format!("Failed to bump nonce for '{sender}': {e:?}"))?;
+        self.get_session_mut().bump_nonce(principal.into())?;
+        Ok(())
+    }
+
+    /// Run a contract call submitted as a transaction, and charge its nonce.
+    ///
+    /// The access check is done here, ahead of the VM, only so the error names
+    /// the mistake. The VM reaches the same verdict on its own — a function
+    /// that is not public raises `NoSuchPublicFunction`, a non-rejectable
+    /// `RuntimeCheck` that mainnet mines and charges a nonce for. So this
+    /// shortcut has to report the same disposition and take the same block, or
+    /// one call would consume a nonce and an identical one would not, decided
+    /// by nothing more than whether an interface happened to be cached.
+    fn call_fn_as_transaction(
+        &mut self,
+        args: &CallFnArgs,
+        advance_chain_tip: bool,
+        required_access: ContractInterfaceFunctionAccess,
+    ) -> Result<TransactionRes, String> {
+        let wrong_access = match self.get_function_interface(&args.contract, &args.method) {
+            Ok(interface) if interface.access != required_access => {
+                Some(OperationFailure::included(format!(
+                    "{} is not a {required_access:?} function",
+                    args.method
+                )))
             }
+            _ => None,
+        };
+
+        if advance_chain_tip {
+            self.get_session_mut().advance_chain_tip(1);
         }
+
+        let allow_private = required_access == ContractInterfaceFunctionAccess::private;
+        let result = match wrong_access {
+            Some(failure) => Err(failure),
+            None => self.call_contract_fn(args, allow_private),
+        };
+        self.bump_sender_nonce_if_included(&args.sender, &result)?;
+        result.map_err(String::from)
     }
 
     fn inner_call_public_fn(
@@ -970,19 +1016,11 @@ impl SDK {
         args: &CallFnArgs,
         advance_chain_tip: bool,
     ) -> Result<TransactionRes, String> {
-        if let Ok(interface) = self.get_function_interface(&args.contract, &args.method) {
-            if interface.access != ContractInterfaceFunctionAccess::public {
-                return Err(format!("{} is not a public function", args.method));
-            }
-        }
-
-        if advance_chain_tip {
-            let session = self.get_session_mut();
-            session.advance_chain_tip(1);
-        }
-        let result = self.call_contract_fn(args, false);
-        self.bump_sender_nonce_if_included(&args.sender, &result);
-        result.map_err(String::from)
+        self.call_fn_as_transaction(
+            args,
+            advance_chain_tip,
+            ContractInterfaceFunctionAccess::public,
+        )
     }
 
     fn inner_call_private_fn(
@@ -990,18 +1028,11 @@ impl SDK {
         args: &CallFnArgs,
         advance_chain_tip: bool,
     ) -> Result<TransactionRes, String> {
-        if let Ok(interface) = self.get_function_interface(&args.contract, &args.method) {
-            if interface.access != ContractInterfaceFunctionAccess::private {
-                return Err(format!("{} is not a private function", args.method));
-            }
-        }
-        if advance_chain_tip {
-            let session = self.get_session_mut();
-            session.advance_chain_tip(1);
-        }
-        let result = self.call_contract_fn(args, true);
-        self.bump_sender_nonce_if_included(&args.sender, &result);
-        result.map_err(String::from)
+        self.call_fn_as_transaction(
+            args,
+            advance_chain_tip,
+            ContractInterfaceFunctionAccess::private,
+        )
     }
 
     fn inner_transfer_stx(

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -21,8 +21,7 @@ use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPri
 use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExpression};
 use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::hooks::perf::CostField;
-use clarity_repl::repl::interpreter::{BlockInclusion, FailureInclusion};
-use clarity_repl::repl::session::CostsReport;
+use clarity_repl::repl::session::{CallKind, CostsReport};
 use clarity_repl::repl::settings::RemoteDataSettings;
 use clarity_repl::repl::{
     clarity_values, epoch_from_str, ClarityCodeSource, ClarityContract, ContractDeployer, Epoch,
@@ -73,50 +72,6 @@ struct DeploymentArtifacts {
     artifacts: DeploymentGenerationArtifacts,
     deployment: DeploymentSpecification,
     manifest: ProjectManifest,
-}
-
-/// A failed simnet operation, plus whether mainnet would still have included
-/// the transaction that produced it.
-///
-/// Only the callers that decide nonce consumption need the verdict; the wasm
-/// boundary reports a plain message, so it is dropped on the way out via
-/// `String::from`.
-struct OperationFailure {
-    message: String,
-    inclusion: BlockInclusion,
-}
-
-impl OperationFailure {
-    /// A failure simnet detects before running anything — an invalid sender,
-    /// an unknown contract id. Mainnet would not have included such a
-    /// transaction either, so it consumes no nonce.
-    fn rejected(message: String) -> Self {
-        Self {
-            message,
-            inclusion: BlockInclusion::Rejected,
-        }
-    }
-
-    /// A failure simnet detects before running anything, for a transaction
-    /// mainnet *would* have mined and charged a nonce for.
-    fn included(message: String) -> Self {
-        Self {
-            message,
-            inclusion: BlockInclusion::Included,
-        }
-    }
-}
-
-impl FailureInclusion for OperationFailure {
-    fn inclusion(&self) -> BlockInclusion {
-        self.inclusion
-    }
-}
-
-impl From<OperationFailure> for String {
-    fn from(failure: OperationFailure) -> Self {
-        failure.message
-    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -861,15 +816,14 @@ impl SDK {
             sender,
         }: &CallFnArgs,
         allow_private: bool,
-    ) -> Result<TransactionRes, OperationFailure> {
+        kind: CallKind,
+    ) -> Result<TransactionRes, String> {
         let test_name = self.current_test_name.clone();
         let track_costs = self.options.track_costs;
         let track_performance = self.options.track_performance;
 
         if PrincipalData::parse_standard_principal(sender).is_err() {
-            return Err(OperationFailure::rejected(format!(
-                "Invalid sender address '{sender}'."
-            )));
+            return Err(format!("Invalid sender address '{sender}'."));
         }
 
         let parsed_args = args
@@ -886,6 +840,7 @@ impl SDK {
                 sender,
                 allow_private,
                 track_costs,
+                kind,
             )
             .map_err(|failure| {
                 let mut message = format!(
@@ -898,10 +853,7 @@ impl SDK {
                 if let Some(diag) = failure.diagnostics.last() {
                     message = format!("{message} -> {}", diag.message);
                 }
-                OperationFailure {
-                    message,
-                    inclusion: failure.inclusion,
-                }
+                message
             })?;
 
         // Collect performance data before accessing self.costs_reports
@@ -919,9 +871,8 @@ impl SDK {
                 // Unreachable in practice: the same id was desugared to run
                 // the call above. Classify conservatively rather than claim a
                 // transaction happened on a path that cannot be reached.
-                let contract_id = Session::desugar_contract_id(&self.deployer, contract)
-                    .map_err(OperationFailure::rejected)?
-                    .to_string();
+                let contract_id =
+                    Session::desugar_contract_id(&self.deployer, contract)?.to_string();
                 self.costs_reports.push(CostsReport {
                     test_name,
                     contract_id,
@@ -948,28 +899,22 @@ impl SDK {
                 return Err(format!("{} is not a read-only function", args.method));
             }
         }
-        self.call_contract_fn(args, false).map_err(String::from)
+        // A read-only call sends nothing, so it is never a transaction.
+        self.call_contract_fn(args, false, CallKind::Free)
     }
 
-    /// Bump `sender`'s nonce if the call made it into a block.
+    /// Charge `sender` for a transaction rejected before it reached the VM.
     ///
-    /// Only the callers that know an operation is a transaction do this.
-    /// `callReadOnlyFn` shares the same underlying session primitive as the
-    /// public and private call paths, but a read-only call sends nothing, so it
-    /// deliberately does not bump.
-    fn bump_sender_nonce_if_included(
-        &mut self,
-        sender: &str,
-        result: &Result<TransactionRes, OperationFailure>,
-    ) -> Result<(), String> {
-        if !BlockInclusion::of_result(result).is_included() {
-            return Ok(());
-        }
-        // `call_contract_fn` rejects an unparseable sender before running
-        // anything, so reaching an included result here implies a valid address.
+    /// Safe as a standalone write only because nothing has executed: the
+    /// preflight below runs before `call_contract_fn`, so there is no committed
+    /// state for a failed charge to come apart from. Every path that *does*
+    /// execute names a `CallKind` instead, and is charged inside the
+    /// execution's own transaction.
+    fn charge_preflight_rejection(&mut self, sender: &str) -> Result<(), String> {
         let principal = PrincipalData::parse_standard_principal(sender)
-            .map_err(|e| format!("Failed to bump nonce for '{sender}': {e:?}"))?;
-        self.get_session_mut().bump_nonce(principal.into())?;
+            .map_err(|e| format!("Failed to charge a nonce for '{sender}': {e:?}"))?;
+        self.get_session_mut()
+            .charge_nonce_without_execution(principal.into())?;
         Ok(())
     }
 
@@ -989,12 +934,10 @@ impl SDK {
         required_access: ContractInterfaceFunctionAccess,
     ) -> Result<TransactionRes, String> {
         let wrong_access = match self.get_function_interface(&args.contract, &args.method) {
-            Ok(interface) if interface.access != required_access => {
-                Some(OperationFailure::included(format!(
-                    "{} is not a {required_access:?} function",
-                    args.method
-                )))
-            }
+            Ok(interface) if interface.access != required_access => Some(format!(
+                "{} is not a {required_access:?} function",
+                args.method
+            )),
             _ => None,
         };
 
@@ -1002,13 +945,13 @@ impl SDK {
             self.get_session_mut().advance_chain_tip(1);
         }
 
+        if let Some(message) = wrong_access {
+            self.charge_preflight_rejection(&args.sender)?;
+            return Err(message);
+        }
+
         let allow_private = required_access == ContractInterfaceFunctionAccess::private;
-        let result = match wrong_access {
-            Some(failure) => Err(failure),
-            None => self.call_contract_fn(args, allow_private),
-        };
-        self.bump_sender_nonce_if_included(&args.sender, &result)?;
-        result.map_err(String::from)
+        self.call_contract_fn(args, allow_private, CallKind::Transaction)
     }
 
     fn inner_call_public_fn(

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -750,6 +750,16 @@ impl SDK {
         Ok(encode_to_js(&self.accounts)?.unchecked_into::<Accounts>())
     }
 
+    /// The number of transactions `address` has sent, as mainnet counts them.
+    /// The deployer starts above zero because the deployment plan's contract
+    /// publishes are themselves transactions.
+    #[wasm_bindgen(js_name=getAccountNonce)]
+    pub fn get_account_nonce(&mut self, address: &str) -> Result<u64, String> {
+        let principal = PrincipalData::parse_standard_principal(address)
+            .map_err(|e| format!("Invalid address '{address}': {e}"))?;
+        self.get_session_mut().get_nonce(&principal.into())
+    }
+
     #[wasm_bindgen(js_name=getDataVar)]
     pub fn get_data_var(&mut self, contract: &str, var_name: &str) -> Result<String, String> {
         let contract_id = Session::desugar_contract_id(&self.deployer, contract)?;

--- a/components/clarinet-sdk-wasm/src/test_wasm.rs
+++ b/components/clarinet-sdk-wasm/src/test_wasm.rs
@@ -223,6 +223,70 @@ async fn it_charges_a_nonce_for_a_call_the_access_preflight_rejects() {
 }
 
 #[wasm_bindgen_test]
+async fn it_gates_the_preflight_nonce_on_the_epoch_like_the_vm_does() {
+    // Calling a read-only or private function as a public function produces
+    // `RuntimeCheckErrorKind::NoSuchPublicFunction`. Such transactions are
+    // only included from epoch 2.1 onward. Verify that the cached-interface
+    // preflight applies the same epoch rule as the VM.
+    const SENDER: &str = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+
+    for (epoch, is_included) in [
+        ("2.0", false),
+        ("2.05", false),
+        ("2.1", true),
+        ("2.4", true),
+    ] {
+        let js_noop = JsFunction::new_no_args("return");
+        let mut sdk = SDK::new(js_noop, None);
+        let _ = sdk.init_empty_session(JsValue::undefined()).await;
+        sdk.set_epoch(EpochString::new(epoch));
+        // Ensure `set_epoch` did not fall back to the default epoch.
+        assert_eq!(sdk.current_epoch(), epoch, "epoch {epoch} was not selected");
+
+        sdk.deploy_contract(&DeployContractArgs::new(
+            "access-contract".into(),
+            "(define-read-only (peek) u1)
+             (define-public (poke) (ok u1))"
+                .into(),
+            ContractOptions::new(None),
+            SENDER.into(),
+        ))
+        .unwrap();
+
+        let call = |method: &str| {
+            CallFnArgs::new(
+                format!("{SENDER}.access-contract"),
+                method.into(),
+                vec![],
+                SENDER.into(),
+            )
+        };
+
+        // The cached interface rejects `peek` before it reaches the VM.
+        let before = sdk.get_account_nonce(SENDER).unwrap();
+        let err = sdk.call_public_fn(&call("peek")).unwrap_err();
+        assert_eq!(err, "peek is not a public function");
+        let preflight_delta = sdk.get_account_nonce(SENDER).unwrap() - before;
+
+        // An unknown function reaches the VM and produces the equivalent error.
+        let before = sdk.get_account_nonce(SENDER).unwrap();
+        sdk.call_public_fn(&call("no-such-fn"))
+            .expect_err("a call to an undefined function must fail");
+        let vm_delta = sdk.get_account_nonce(SENDER).unwrap() - before;
+
+        let expected = u64::from(is_included);
+        assert_eq!(
+            preflight_delta, expected,
+            "{epoch}: the preflight route disagrees with the mainnet gate"
+        );
+        assert_eq!(
+            vm_delta, expected,
+            "{epoch}: the VM route disagrees with the mainnet gate"
+        );
+    }
+}
+
+#[wasm_bindgen_test]
 async fn it_rejects_a_nonce_lookup_for_an_invalid_address() {
     let mut sdk = init_sdk().await;
 

--- a/components/clarinet-sdk-wasm/src/test_wasm.rs
+++ b/components/clarinet-sdk-wasm/src/test_wasm.rs
@@ -80,10 +80,6 @@ async fn it_can_call_a_private_function() {
     assert_eq!(tx.result, expected);
 }
 
-/// Which contract calls consume a nonce is decided here in `core.rs`, not in
-/// `Session::call_contract_fn` — that primitive also backs `callReadOnlyFn`,
-/// which sends nothing. So this rule can only be tested at this layer; a
-/// `cargo tst` run will not tell you whether a call consumes a nonce.
 #[wasm_bindgen_test]
 async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
     const SENDER: &str = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
@@ -116,9 +112,7 @@ async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
     // boot contracts deployed by `init_sdk` consumed nothing.
     assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 1);
 
-    // Each call asserts its return value as well as the nonce, so that a
-    // regression turning one of these into a no-op cannot satisfy the nonce
-    // check vacuously.
+    // Assert results as well as nonces so calls cannot pass as no-ops.
     assert_tx_result(
         &sdk.call_read_only_fn(&call("peek")).unwrap(),
         ClarityValue::UInt(1),
@@ -143,9 +137,7 @@ async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
     );
     assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 3);
 
-    // A call that fails at runtime is still mined on mainnet, so it still
-    // consumes a nonce. This is the divergence the old `is_ok()` rule had, and
-    // the contract-call half of it can only be observed from here.
+    // Included runtime failures still consume a nonce.
     let err = sdk
         .call_public_fn(&call("boom"))
         .expect_err("dividing by zero must surface as an error");
@@ -157,15 +149,9 @@ async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
     );
 }
 
-/// The access preflight short-circuits a call the VM would otherwise run, so
-/// it has to reach the VM's answer about the nonce as well as about the error.
-///
-/// Mainnet mines a `contract-call?` naming a non-public function:
-/// `NoSuchPublicFunction` is a non-rejectable `RuntimeCheck`. The pairs below
-/// are that same failure arriving by the two different routes — one with a
-/// cached interface, one without — and they must not disagree.
 #[wasm_bindgen_test]
 async fn it_charges_a_nonce_for_a_call_the_access_preflight_rejects() {
+    // Cached-interface and VM paths must agree on nonce consumption.
     const SENDER: &str = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
     let mut sdk = init_sdk().await;
 

--- a/components/clarinet-sdk-wasm/src/test_wasm.rs
+++ b/components/clarinet-sdk-wasm/src/test_wasm.rs
@@ -157,6 +157,85 @@ async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
     );
 }
 
+/// The access preflight short-circuits a call the VM would otherwise run, so
+/// it has to reach the VM's answer about the nonce as well as about the error.
+///
+/// Mainnet mines a `contract-call?` naming a non-public function:
+/// `NoSuchPublicFunction` is a non-rejectable `RuntimeCheck`. The pairs below
+/// are that same failure arriving by the two different routes — one with a
+/// cached interface, one without — and they must not disagree.
+#[wasm_bindgen_test]
+async fn it_charges_a_nonce_for_a_call_the_access_preflight_rejects() {
+    const SENDER: &str = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+    let mut sdk = init_sdk().await;
+
+    let call = |method: &str| {
+        CallFnArgs::new(
+            format!("{SENDER}.access-contract"),
+            method.into(),
+            vec![],
+            SENDER.into(),
+        )
+    };
+
+    sdk.deploy_contract(&DeployContractArgs::new(
+        "access-contract".into(),
+        "(define-read-only (peek) u1)
+         (define-public (poke) (ok u1))
+         (define-private (hidden) u1)"
+            .into(),
+        ContractOptions::new(None),
+        SENDER.into(),
+    ))
+    .unwrap();
+    assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 1);
+
+    // Rejected by the preflight, because the interface says the access is wrong.
+    for (method, expected) in [
+        ("peek", "peek is not a public function"),
+        ("hidden", "hidden is not a public function"),
+    ] {
+        let before = sdk.get_account_nonce(SENDER).unwrap();
+        let err = sdk.call_public_fn(&call(method)).unwrap_err();
+        assert_eq!(err, expected);
+        assert_eq!(
+            sdk.get_account_nonce(SENDER).unwrap(),
+            before + 1,
+            "mainnet mines a call to a non-public function, so `{method}` owes a nonce"
+        );
+    }
+
+    // The same failure reached through the VM: no interface entry exists for a
+    // name the contract does not define, so the preflight has nothing to say.
+    let before = sdk.get_account_nonce(SENDER).unwrap();
+    sdk.call_public_fn(&call("no-such-fn"))
+        .expect_err("a call to an undefined function must fail");
+    assert_eq!(
+        sdk.get_account_nonce(SENDER).unwrap(),
+        before + 1,
+        "the VM route must charge the same nonce the preflight route does"
+    );
+
+    // simnet models a private call as a transaction, so its preflight follows
+    // the same rule.
+    let before = sdk.get_account_nonce(SENDER).unwrap();
+    let err = sdk.call_private_fn(&call("poke")).unwrap_err();
+    assert_eq!(err, "poke is not a private function");
+    assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), before + 1);
+
+    // A read-only call sends nothing, so neither route charges anything.
+    let before = sdk.get_account_nonce(SENDER).unwrap();
+    let err = sdk.call_read_only_fn(&call("poke")).unwrap_err();
+    assert_eq!(err, "poke is not a read-only function");
+    sdk.call_read_only_fn(&call("no-such-fn"))
+        .expect_err("a read-only call to an undefined function must fail");
+    assert_eq!(
+        sdk.get_account_nonce(SENDER).unwrap(),
+        before,
+        "a read-only call is not a transaction by either route"
+    );
+}
+
 #[wasm_bindgen_test]
 async fn it_rejects_a_nonce_lookup_for_an_invalid_address() {
     let mut sdk = init_sdk().await;

--- a/components/clarinet-sdk-wasm/src/test_wasm.rs
+++ b/components/clarinet-sdk-wasm/src/test_wasm.rs
@@ -1,4 +1,4 @@
-use clarity::types::StacksEpochId;
+use clarinet_defaults::DEFAULT_EPOCH;
 use clarity::vm::Value as ClarityValue;
 use clarity_repl::repl::settings::{ApiUrl, RemoteDataSettings};
 use gloo_utils::format::JsValueSerdeExt;
@@ -13,8 +13,20 @@ async fn init_sdk() -> SDK {
     let js_noop = JsFunction::new_no_args("return");
     let mut sdk = SDK::new(js_noop, None);
     let _ = sdk.init_empty_session(JsValue::undefined()).await;
-    sdk.set_epoch(EpochString::new(&StacksEpochId::latest().to_string()));
+    // `DEFAULT_EPOCH`, not `StacksEpochId::latest()`: clarinet trails upstream
+    // until an epoch is adopted here, and `set_epoch` falls back to the default
+    // for one it does not know — which would make these tests assert against an
+    // epoch they did not actually select.
+    sdk.set_epoch(EpochString::new(&DEFAULT_EPOCH.to_string()));
     sdk
+}
+
+#[track_caller]
+fn assert_tx_result(tx: &TransactionRes, expected: ClarityValue) {
+    assert_eq!(
+        tx.result,
+        format!("0x{}", expected.serialize_to_hex().unwrap())
+    );
 }
 
 #[track_caller]
@@ -41,7 +53,7 @@ async fn it_can_set_epoch() {
     let mut sdk = init_sdk().await;
     // set_epoch("4.0") transitions from Epoch2_05, which advances the burn chain tip by 1.
     assert_eq!(sdk.block_height(), 1);
-    assert_eq!(sdk.current_epoch(), StacksEpochId::latest().to_string());
+    assert_eq!(sdk.current_epoch(), DEFAULT_EPOCH.to_string());
 }
 
 #[wasm_bindgen_test]
@@ -66,6 +78,91 @@ async fn it_can_call_a_private_function() {
         .unwrap();
     let expected = format!("0x{}", ClarityValue::UInt(2).serialize_to_hex().unwrap());
     assert_eq!(tx.result, expected);
+}
+
+/// Which contract calls consume a nonce is decided here in `core.rs`, not in
+/// `Session::call_contract_fn` — that primitive also backs `callReadOnlyFn`,
+/// which sends nothing. So this rule can only be tested at this layer; a
+/// `cargo tst` run will not tell you whether a call consumes a nonce.
+#[wasm_bindgen_test]
+async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
+    const SENDER: &str = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+    let mut sdk = init_sdk().await;
+
+    let call = |method: &str| {
+        CallFnArgs::new(
+            format!("{SENDER}.nonce-contract"),
+            method.into(),
+            vec![],
+            SENDER.into(),
+        )
+    };
+
+    assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 0);
+
+    sdk.deploy_contract(&DeployContractArgs::new(
+        "nonce-contract".into(),
+        "(define-read-only (peek) u1)
+         (define-public (poke) (ok u1))
+         (define-private (hidden) u1)
+         (define-public (boom) (ok (/ u1 u0)))"
+            .into(),
+        ContractOptions::new(None),
+        SENDER.into(),
+    ))
+    .unwrap();
+
+    // The deploy is itself a transaction. Landing on exactly 1 also proves the
+    // boot contracts deployed by `init_sdk` consumed nothing.
+    assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 1);
+
+    // Each call asserts its return value as well as the nonce, so that a
+    // regression turning one of these into a no-op cannot satisfy the nonce
+    // check vacuously.
+    assert_tx_result(
+        &sdk.call_read_only_fn(&call("peek")).unwrap(),
+        ClarityValue::UInt(1),
+    );
+    assert_eq!(
+        sdk.get_account_nonce(SENDER).unwrap(),
+        1,
+        "a read-only call sends nothing and must not consume a nonce"
+    );
+
+    assert_tx_result(
+        &sdk.call_public_fn(&call("poke")).unwrap(),
+        ClarityValue::okay(ClarityValue::UInt(1)).unwrap(),
+    );
+    assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 2);
+
+    // simnet models a private call as a transaction, even though mainnet has no
+    // way to reach a private function from one.
+    assert_tx_result(
+        &sdk.call_private_fn(&call("hidden")).unwrap(),
+        ClarityValue::UInt(1),
+    );
+    assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 3);
+
+    // A call that fails at runtime is still mined on mainnet, so it still
+    // consumes a nonce. This is the divergence the old `is_ok()` rule had, and
+    // the contract-call half of it can only be observed from here.
+    let err = sdk
+        .call_public_fn(&call("boom"))
+        .expect_err("dividing by zero must surface as an error");
+    assert!(err.contains("DivisionByZero"), "got: {err}");
+    assert_eq!(
+        sdk.get_account_nonce(SENDER).unwrap(),
+        4,
+        "a failed-but-included contract call still consumes a nonce"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn it_rejects_a_nonce_lookup_for_an_invalid_address() {
+    let mut sdk = init_sdk().await;
+
+    let err = sdk.get_account_nonce("not-an-address").unwrap_err();
+    assert!(err.contains("Invalid address"), "got: {err}");
 }
 
 #[wasm_bindgen_test]

--- a/components/clarinet-sdk/node/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/node/tests/simnet-usage.test.ts
@@ -85,6 +85,60 @@ describe("basic simnet interactions", () => {
     expect(assets.get("STX")?.get(address1)).toBe(100000000000000n);
   });
 
+  it("expose account nonces", () => {
+    // Contract publishes in the deployment plan are transactions, so the
+    // deployer has already consumed nonces before the first test runs.
+    expect(simnet.getAccountNonce(deployerAddr)).toBeGreaterThan(0n);
+    expect(simnet.getAccountNonce(address1)).toBe(0n);
+  });
+
+  it("bumps the sender nonce for transactions but not read-only calls", () => {
+    const before = simnet.getAccountNonce(address1);
+
+    simnet.callReadOnlyFn("counter", "get-count", [], address1);
+    expect(simnet.getAccountNonce(address1)).toBe(before);
+
+    simnet.callPublicFn("counter", "increment", [], address1);
+    expect(simnet.getAccountNonce(address1)).toBe(before + 1n);
+
+    simnet.transferSTX(1000, address2, address1);
+    expect(simnet.getAccountNonce(address1)).toBe(before + 2n);
+
+    // address2 received STX but sent nothing, so it owes no nonce.
+    expect(simnet.getAccountNonce(address2)).toBe(0n);
+  });
+
+  it("bumps the nonce of a call that reverts", () => {
+    // `(err ...)` is a successful transaction returning a failure response:
+    // mainnet mines it and charges the nonce, and so does simnet. `withdraw`
+    // asserts the caller is the contract owner, which address1 is not.
+    const before = simnet.getAccountNonce(address1);
+
+    const { result } = simnet.callPublicFn("counter", "withdraw", [Cl.uint(1)], address1);
+    expect(result).toStrictEqual(Cl.error(Cl.uint(1)));
+
+    expect(simnet.getAccountNonce(address1)).toBe(before + 1n);
+  });
+
+  it("bumps the nonce once per transaction in a mined block", () => {
+    const before = simnet.getAccountNonce(address1);
+    const deployerBefore = simnet.getAccountNonce(deployerAddr);
+
+    simnet.mineBlock([
+      tx.callPublicFn("counter", "increment", [], address1),
+      tx.callPublicFn("counter", "increment", [], address1),
+      tx.transferSTX(1000, address2, address1),
+      tx.deployContract("mined-contract", "(define-read-only (n) u1)", null, deployerAddr),
+      tx.callPrivateFn("counter", "inner-increment", [], address1),
+    ]);
+
+    // Batching into one block does not merge the transactions: each still
+    // consumes its own nonce, as it would on mainnet.
+    expect(simnet.getAccountNonce(address1)).toBe(before + 4n);
+    // The deploy is charged to its own sender, not the block's first sender.
+    expect(simnet.getAccountNonce(deployerAddr)).toBe(deployerBefore + 1n);
+  });
+
   it("can get and set epoch", () => {
     // should be 3.1 at the beginning because
     // the latest contract in the manifest is deployed in 3.1

--- a/components/clarinet-sdk/node/tests/simnet-usage.test.ts
+++ b/components/clarinet-sdk/node/tests/simnet-usage.test.ts
@@ -328,15 +328,44 @@ describe("simnet can call contracts function", () => {
   });
 
   it("can not call a public function with callPrivateFn", () => {
+    const before = simnet.getAccountNonce(address1);
+
     expect(() => {
       simnet.callPrivateFn("counter", "increment", [], address1);
     }).toThrow(/^increment is not a private function$/);
+
+    expect(simnet.getAccountNonce(address1)).toBe(before + 1n);
   });
 
   it("can not call a private function with callPublicFn", () => {
+    // Mainnet mines a contract-call naming a non-public function and charges
+    // its nonce, so rejecting it here early must charge one too — otherwise
+    // this call and a call to a name the contract does not define, which fail
+    // identically on mainnet, would disagree.
+    const before = simnet.getAccountNonce(address1);
+
     expect(() => {
       simnet.callPublicFn("counter", "inner-increment", [], address1);
     }).toThrow(/^inner-increment is not a public function$/);
+
+    expect(simnet.getAccountNonce(address1)).toBe(before + 1n);
+
+    expect(() => {
+      simnet.callPublicFn("counter", "no-such-function", [], address1);
+    }).toThrow();
+
+    expect(simnet.getAccountNonce(address1)).toBe(before + 2n);
+  });
+
+  it("can not call a public function with callReadOnlyFn, and is charged nothing", () => {
+    const before = simnet.getAccountNonce(address1);
+
+    expect(() => {
+      simnet.callReadOnlyFn("counter", "increment", [], address1);
+    }).toThrow(/^increment is not a read-only function$/);
+
+    // A read-only call sends nothing, so no route through it is a transaction.
+    expect(simnet.getAccountNonce(address1)).toBe(before);
   });
 
   it("can get updated assets map", () => {

--- a/components/clarity-repl/benches/simnet.rs
+++ b/components/clarity-repl/benches/simnet.rs
@@ -2,6 +2,7 @@ use std::hint::black_box;
 
 use clarinet_defaults::{DEFAULT_CLARITY_VERSION, DEFAULT_EPOCH};
 use clarity::vm::{EvaluationResult, ExecutionResult, SymbolicExpression, Value as ClarityValue};
+use clarity_repl::repl::session::CallKind;
 use clarity_repl::repl::{
     ClarityCodeSource, ClarityContract, ContractDeployer, Epoch, Session, SessionSettings,
 };
@@ -86,6 +87,7 @@ fn call_fn(
             "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
             false,
             false,
+            CallKind::Transaction,
         )
         .unwrap();
 

--- a/components/clarity-repl/src/analysis/coverage.rs
+++ b/components/clarity-repl/src/analysis/coverage.rs
@@ -4,7 +4,8 @@ use clarity::vm::ast::ContractAST;
 use clarity::vm::errors::VmExecutionError;
 use clarity::vm::functions::define::DefineFunctionsParsed;
 use clarity::vm::functions::NativeFunctions;
-use clarity::vm::{EvalHook, SymbolicExpression};
+use clarity::vm::hooks::EvalHook;
+use clarity::vm::SymbolicExpression;
 use clarity_types::types::QualifiedContractIdentifier;
 use serde::{Deserialize, Serialize};
 

--- a/components/clarity-repl/src/repl/datastore.rs
+++ b/components/clarity-repl/src/repl/datastore.rs
@@ -61,6 +61,7 @@ fn epoch_to_peer_version(epoch: StacksEpochId) -> u8 {
         StacksEpochId::Epoch33 => PEER_VERSION_EPOCH_3_3,
         StacksEpochId::Epoch34 => PEER_VERSION_EPOCH_3_4,
         StacksEpochId::Epoch40 => PEER_VERSION_EPOCH_4_0,
+        StacksEpochId::Epoch41 => PEER_VERSION_EPOCH_4_1,
     }
 }
 
@@ -1287,7 +1288,7 @@ impl BurnStateDB for Datastore {
                     .map(|block| block.burn_block_height)
             }
             // Note: at-block removed at 3.4+
-            Epoch30 | Epoch31 | Epoch32 | Epoch33 | Epoch34 | Epoch40 => {
+            Epoch30 | Epoch31 | Epoch32 | Epoch33 | Epoch34 | Epoch40 | Epoch41 => {
                 Some(self.burn_chain_height)
             }
         }

--- a/components/clarity-repl/src/repl/debug/cli.rs
+++ b/components/clarity-repl/src/repl/debug/cli.rs
@@ -1,7 +1,8 @@
 use clarity::vm::contexts::{ExecutionState, InvocationContext, LocalContext};
 use clarity::vm::errors::VmExecutionError;
+use clarity::vm::hooks::EvalHook;
 use clarity::vm::representations::Span;
-use clarity::vm::{ContractName, EvalHook, SymbolicExpression, ValueRef};
+use clarity::vm::{ContractName, SymbolicExpression, ValueRef};
 use clarity_types::types::QualifiedContractIdentifier;
 use indoc::printdoc;
 use rustyline::error::ReadlineError;

--- a/components/clarity-repl/src/repl/debug/dap/mod.rs
+++ b/components/clarity-repl/src/repl/debug/dap/mod.rs
@@ -7,8 +7,9 @@ use clarity::vm::contexts::{
     ContractContext, ExecutionState, GlobalContext, InvocationContext, LocalContext,
 };
 use clarity::vm::errors::VmExecutionError;
+use clarity::vm::hooks::EvalHook;
 use clarity::vm::representations::Span;
-use clarity::vm::{EvalHook, EvaluationResult, ExecutionResult, SymbolicExpression, ValueRef};
+use clarity::vm::{EvaluationResult, ExecutionResult, SymbolicExpression, ValueRef};
 use clarity_types::types::{
     PrincipalData, QualifiedContractIdentifier, SequenceData, StandardPrincipalData,
 };

--- a/components/clarity-repl/src/repl/hooks/logger.rs
+++ b/components/clarity-repl/src/repl/hooks/logger.rs
@@ -1,9 +1,8 @@
 use clarity::vm::contexts::{ExecutionState, InvocationContext, LocalContext};
 use clarity::vm::errors::VmExecutionError;
 use clarity::vm::functions::NativeFunctions;
-use clarity::vm::{
-    EvalHook, ExecutionResult, SymbolicExpression, SymbolicExpressionType, ValueRef,
-};
+use clarity::vm::hooks::EvalHook;
+use clarity::vm::{ExecutionResult, SymbolicExpression, SymbolicExpressionType, ValueRef};
 
 use crate::repl::boot::{
     BOOT_MAINNET_PRINCIPAL, BOOT_TESTNET_PRINCIPAL, SBTC_MAINNET_ADDRESS_PRINCIPAL,

--- a/components/clarity-repl/src/repl/hooks/perf.rs
+++ b/components/clarity-repl/src/repl/hooks/perf.rs
@@ -4,7 +4,8 @@ use std::io::Write;
 use clarity::vm::contexts::{ExecutionState, InvocationContext, LocalContext};
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::errors::VmExecutionError;
-use clarity::vm::{EvalHook, SymbolicExpression, SymbolicExpressionType, ValueRef};
+use clarity::vm::hooks::EvalHook;
+use clarity::vm::{SymbolicExpression, SymbolicExpressionType, ValueRef};
 use clarity_types::types::QualifiedContractIdentifier;
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/components/clarity-repl/src/repl/hooks/tracer.rs
+++ b/components/clarity-repl/src/repl/hooks/tracer.rs
@@ -3,9 +3,9 @@ use clarity::vm::errors::VmExecutionError;
 use clarity::vm::events::StacksTransactionEvent;
 use clarity::vm::functions::define::DefineFunctions;
 use clarity::vm::functions::NativeFunctions;
+use clarity::vm::hooks::EvalHook;
 use clarity::vm::{
-    eval, ClarityVersion, EvalHook, EvaluationResult, SymbolicExpression, SymbolicExpressionType,
-    ValueRef,
+    eval, ClarityVersion, EvaluationResult, SymbolicExpression, SymbolicExpressionType, ValueRef,
 };
 use clarity_types::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
 

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use clarinet_defaults::DEFAULT_EPOCH;
 use clarity::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET};
 use clarity::types::StacksEpochId;
+use clarity::vm::analysis::errors::RuntimeCheckErrorKind;
 use clarity::vm::analysis::{AnalysisDatabase, ContractAnalysis};
 use clarity::vm::ast::{build_ast, build_ast_with_diagnostics, ContractAST};
 use clarity::vm::clarity::{
@@ -18,6 +19,7 @@ use clarity::vm::costs::{ExecutionCost, LimitedCostTracker};
 use clarity::vm::database::clarity_db::ContractDataVarName;
 use clarity::vm::database::{ClarityBackingStore, ClarityDatabase, StoreType};
 use clarity::vm::diagnostic::{Diagnostic, Level};
+use clarity::vm::errors::{VmExecutionError, VmInternalError};
 use clarity::vm::events::*;
 use clarity::vm::hooks::EvalHook;
 use clarity::vm::representations::SymbolicExpressionType::{Atom, List};
@@ -152,14 +154,45 @@ pub enum ContractCallError {
     Uncategorized(String),
 }
 
-impl From<String> for ContractCallError {
-    fn from(s: String) -> Self {
-        if s.contains("UndefinedFunction") || s.contains("NoSuchPublicFunction") {
-            ContractCallError::NoSuchFunction(s)
-        } else if s.contains("Failed to read non-consensus contract metadata") {
-            ContractCallError::NoSuchContract(s)
-        } else {
-            ContractCallError::Uncategorized(s)
+impl ContractCallError {
+    /// Classify a VM failure by the error the VM actually raised.
+    ///
+    /// This used to grep the *formatted* message for `"UndefinedFunction"`,
+    /// which matched whenever that text appeared anywhere in a nested error's
+    /// `Debug` output — including inside an unrelated failure that merely
+    /// mentioned one. Matching the typed error instead makes the classification
+    /// mean what it says.
+    ///
+    /// `message` is still carried verbatim, and the variants are unchanged, so
+    /// the diagnostics `Session::call_contract_fn` builds from these are
+    /// identical for every input that was already classified correctly.
+    fn from_vm_error(error: &VmExecutionError, message: String) -> Self {
+        match error {
+            // Either the function is absent, or it exists but is not callable
+            // from outside the contract.
+            VmExecutionError::RuntimeCheck(
+                RuntimeCheckErrorKind::UndefinedFunction(_)
+                | RuntimeCheckErrorKind::NoSuchPublicFunction(..),
+            ) => ContractCallError::NoSuchFunction(message),
+
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::NoSuchContract(_)) => {
+                ContractCallError::NoSuchContract(message)
+            }
+
+            // Simnet reaches a missing contract by a different route than a
+            // `contract-call?` does. `call_contract_fn` enters with a contract
+            // id already in hand, so the metadata read fails before any name
+            // resolution, and `clarity` reports that as a failed internal
+            // expectation rather than `NoSuchContract`. Scoped to the one
+            // variant that can carry it, rather than searched for in the whole
+            // formatted message.
+            VmExecutionError::Internal(VmInternalError::Expect(e))
+                if e.starts_with("Failed to read non-consensus contract metadata") =>
+            {
+                ContractCallError::NoSuchContract(message)
+            }
+
+            _ => ContractCallError::Uncategorized(message),
         }
     }
 }
@@ -264,6 +297,11 @@ impl ClarityInterpreter {
                 });
             }
         };
+        // Note the ordering, which predates the inclusion work: analysis runs
+        // before the parse result is consulted, so a source that fails both
+        // reports the *analysis* verdict. Mainnet parses first and would report
+        // the parse one. Both go through `handle_clarity_analysis_error`, so
+        // the two agree unless exactly one of them is `rejectable_in_epoch`.
         if !success {
             return Err(ExecutionError {
                 inclusion: self.classify_parse_failure(contract),
@@ -849,7 +887,8 @@ impl ClarityInterpreter {
         let mut global_context =
             self.get_global_context(epoch, track_costs)
                 .map_err(|e| ContractCallFailure {
-                    error: ContractCallError::from(e),
+                    // Not a VM error, so there is nothing to classify.
+                    error: ContractCallError::Uncategorized(e),
                     inclusion: BlockInclusion::Rejected,
                 })?;
 
@@ -898,7 +937,7 @@ impl ClarityInterpreter {
                 global_context.eval_hooks = Some(eval_hooks);
             }
             ContractCallFailure {
-                error: ContractCallError::from(err),
+                error: ContractCallError::from_vm_error(&e, err),
                 inclusion: BlockInclusion::from_runtime_error(ClarityError::Interpreter(e), epoch),
             }
         });
@@ -1520,6 +1559,41 @@ mod tests {
         PrincipalData::parse_standard_principal(addr)
             .expect("valid principal")
             .into()
+    }
+
+    #[test]
+    fn contract_call_errors_are_classified_by_type_not_message() {
+        use clarity::vm::errors::RuntimeError;
+
+        // The old classifier searched the *formatted* message, so any failure
+        // whose text merely mentioned `UndefinedFunction` was reported to the
+        // user as a missing function. Nested `Debug` output is exactly how that
+        // text gets somewhere it does not belong.
+        let misleading =
+            VmExecutionError::Runtime(RuntimeError::Arithmetic("UndefinedFunction".into()), None);
+        assert!(matches!(
+            ContractCallError::from_vm_error(&misleading, "UndefinedFunction".into()),
+            ContractCallError::Uncategorized(_)
+        ));
+
+        // A genuinely undefined function is still classified as one.
+        let undefined =
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::UndefinedFunction("no".into()));
+        assert!(matches!(
+            ContractCallError::from_vm_error(&undefined, "message".into()),
+            ContractCallError::NoSuchFunction(_)
+        ));
+
+        // As is the internal-expectation route simnet takes to a contract that
+        // does not exist.
+        let missing_contract = VmExecutionError::Internal(VmInternalError::Expect(
+            "Failed to read non-consensus contract metadata, even though contract exists in MARF."
+                .into(),
+        ));
+        assert!(matches!(
+            ContractCallError::from_vm_error(&missing_contract, "message".into()),
+            ContractCallError::NoSuchContract(_)
+        ));
     }
 
     /// Pin both directions of the delegation to `clarity`.

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -1090,6 +1090,50 @@ impl ClarityInterpreter {
             _ => 0,
         }
     }
+
+    /// Read the transaction nonce of `principal`.
+    ///
+    /// Nonces are kept where mainnet keeps them — behind the
+    /// `ClarityBackingStore`, under `make_key_for_account_nonce` — rather than
+    /// beside the `tokens` map, which is a reporting mirror with no rollback.
+    /// Storing them in the backing store means a nonce bump is discarded along
+    /// with the rest of a rolled-back transaction, which is what post-condition
+    /// enforcement will rely on.
+    pub fn get_nonce(&mut self, principal: &PrincipalData) -> Result<u64, String> {
+        let mut conn = ClarityDatabase::new(
+            &mut self.clarity_datastore,
+            &self.datastore,
+            &self.datastore,
+        );
+        // Reads through the rollback wrapper require a nested context.
+        conn.begin();
+        let nonce = conn
+            .get_account_nonce(principal)
+            .map_err(|e| format!("failed to read nonce for {principal}: {e}"));
+        // Discard rather than commit: a read must not leave anything behind.
+        conn.roll_back()
+            .map_err(|e| format!("failed to roll back nonce read for {principal}: {e}"))?;
+        nonce
+    }
+
+    /// Bump the transaction nonce of `principal`, returning the new value.
+    pub fn increment_nonce(&mut self, principal: &PrincipalData) -> Result<u64, String> {
+        let mut conn = ClarityDatabase::new(
+            &mut self.clarity_datastore,
+            &self.datastore,
+            &self.datastore,
+        );
+        conn.begin();
+        let next = conn
+            .get_account_nonce(principal)
+            .map_err(|e| format!("failed to read nonce for {principal}: {e}"))?
+            .saturating_add(1);
+        conn.set_account_nonce(principal, next)
+            .map_err(|e| format!("failed to set nonce for {principal}: {e}"))?;
+        conn.commit()
+            .map_err(|e| format!("failed to commit nonce for {principal}: {e}"))?;
+        Ok(next)
+    }
 }
 
 #[cfg(test)]
@@ -1308,6 +1352,57 @@ mod tests {
 
         let balance = interpreter.get_balance_for_account(addr, "STX");
         assert_eq!(balance, amount);
+    }
+
+    #[track_caller]
+    fn principal(addr: &str) -> PrincipalData {
+        PrincipalData::parse_standard_principal(addr)
+            .expect("valid principal")
+            .into()
+    }
+
+    #[test]
+    fn test_nonce_starts_at_zero() {
+        let mut interpreter = get_interpreter(None);
+        let addr = principal("ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5");
+
+        assert_eq!(interpreter.get_nonce(&addr).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_increment_nonce() {
+        let mut interpreter = get_interpreter(None);
+        let addr = principal("ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5");
+
+        assert_eq!(interpreter.increment_nonce(&addr).unwrap(), 1);
+        assert_eq!(interpreter.get_nonce(&addr).unwrap(), 1);
+
+        assert_eq!(interpreter.increment_nonce(&addr).unwrap(), 2);
+        assert_eq!(interpreter.get_nonce(&addr).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_nonces_are_tracked_per_principal() {
+        let mut interpreter = get_interpreter(None);
+        let addr_1 = principal("ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5");
+        let addr_2 = principal("ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG");
+
+        interpreter.increment_nonce(&addr_1).unwrap();
+        interpreter.increment_nonce(&addr_1).unwrap();
+
+        assert_eq!(interpreter.get_nonce(&addr_1).unwrap(), 2);
+        assert_eq!(interpreter.get_nonce(&addr_2).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_reading_a_nonce_does_not_bump_it() {
+        let mut interpreter = get_interpreter(None);
+        let addr = principal("ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5");
+
+        interpreter.increment_nonce(&addr).unwrap();
+        for _ in 0..3 {
+            assert_eq!(interpreter.get_nonce(&addr).unwrap(), 1);
+        }
     }
 
     #[test]

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -385,6 +385,14 @@ impl ClarityInterpreter {
         let (annotations, mut annotation_diagnostics) = self.collect_annotations(code_source);
         diagnostics.append(&mut annotation_diagnostics);
 
+        // Mainnet checks parsing before analysis. Their inclusion verdicts can
+        // differ, so analysing a partial AST first could incorrectly charge a
+        // nonce for a transaction rejected during parsing.
+        if !success {
+            let inclusion = self.classify_parse_failure(contract);
+            return Err(self.fail_before_execution(diagnostics, inclusion, charge));
+        }
+
         let (analysis, lint_diagnostics) = match self.run_analysis(contract, &ast, &annotations) {
             Ok((analysis, lint_diags)) => (analysis, lint_diags),
             Err(mut analysis_failure) => {
@@ -396,13 +404,6 @@ impl ClarityInterpreter {
                 ));
             }
         };
-        // Analysis currently runs before the parse result is checked. Mainnet
-        // checks parsing first, so a source failing both may get a different
-        // verdict when only one error is rejectable in this epoch.
-        if !success {
-            let inclusion = self.classify_parse_failure(contract);
-            return Err(self.fail_before_execution(diagnostics, inclusion, charge));
-        }
 
         let mut result =
             match self.execute(contract, &ast, analysis, cost_track, eval_hooks, charge) {

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -60,24 +60,7 @@ pub enum BlockInclusion {
     Rejected,
 }
 
-/// A failure that knows whether the transaction producing it was still mined.
-///
-/// Implemented by every error type on a transaction path so that the
-/// success-is-included half of the rule lives in [`BlockInclusion::of_result`]
-/// alone, instead of being re-derived by each caller that bumps a nonce.
-pub trait FailureInclusion {
-    fn inclusion(&self) -> BlockInclusion;
-}
-
 impl BlockInclusion {
-    /// The disposition of a whole operation. A success is always included.
-    pub fn of_result<T, E: FailureInclusion>(result: &Result<T, E>) -> Self {
-        match result {
-            Ok(_) => BlockInclusion::Included,
-            Err(e) => e.inclusion(),
-        }
-    }
-
     /// Classify a failure from the execution phase — a contract call, an STX
     /// transfer, or the body of a contract being deployed.
     pub fn from_runtime_error(error: ClarityError, epoch: StacksEpochId) -> Self {
@@ -106,6 +89,54 @@ impl From<bool> for BlockInclusion {
     }
 }
 
+/// Whose nonce an execution consumes, if it consumes one.
+///
+/// Passed *into* execution rather than applied after it. A bump issued
+/// afterwards is a second database transaction that can fail on its own,
+/// leaving committed state behind a nonce that never moved — and since the next
+/// transaction then reuses the stale value, a caller retrying the reported
+/// error would apply the state changes twice.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum NonceCharge {
+    /// Not a transaction: a read-only call, or bare snippet evaluation.
+    #[default]
+    Free,
+    /// A transaction sent by this principal, consuming one of its nonces.
+    Sender(PrincipalData),
+}
+
+impl NonceCharge {
+    /// Write the charge into `db`'s open transaction, so it lands or is
+    /// discarded with everything else that transaction holds.
+    fn apply(&self, db: &mut ClarityDatabase) -> Result<(), String> {
+        let NonceCharge::Sender(principal) = self else {
+            return Ok(());
+        };
+        let next = db
+            .get_account_nonce(principal)
+            .map_err(|e| format!("failed to read nonce for {principal}: {e}"))?
+            .checked_add(1)
+            .ok_or_else(|| format!("nonce overflow for {principal}"))?;
+        db.set_account_nonce(principal, next)
+            .map_err(|e| format!("failed to set nonce for {principal}: {e}"))
+    }
+
+    /// Commit the charge as the *only* write in `global_context`'s open
+    /// transaction, for a failure mainnet would still have mined.
+    ///
+    /// `GlobalContext::execute` rolls its own context back before returning an
+    /// error, and nothing else writes to the enclosing one, so this commit
+    /// carries the nonce alone. That is what makes charging a failed
+    /// transaction safe here: there is no half-applied state to pair it with.
+    fn commit_alone(&self, global_context: &mut GlobalContext) -> Result<(), String> {
+        self.apply(&mut global_context.database)?;
+        global_context
+            .commit()
+            .map(|_| ())
+            .map_err(|e| format!("failed to commit nonce: {e}"))
+    }
+}
+
 /// A failed `ClarityInterpreter::run`.
 #[derive(Debug, Clone)]
 pub struct ExecutionError {
@@ -113,12 +144,6 @@ pub struct ExecutionError {
     pub diagnostics: Vec<Diagnostic>,
     /// Whether the operation still counts as a transaction on mainnet.
     pub inclusion: BlockInclusion,
-}
-
-impl FailureInclusion for ExecutionError {
-    fn inclusion(&self) -> BlockInclusion {
-        self.inclusion
-    }
 }
 
 impl ExecutionError {
@@ -162,12 +187,6 @@ pub struct ContractCallFailure {
     pub error: ContractCallError,
     /// Whether the call still counts as a transaction on mainnet.
     pub inclusion: BlockInclusion,
-}
-
-impl FailureInclusion for ContractCallFailure {
-    fn inclusion(&self) -> BlockInclusion {
-        self.inclusion
-    }
 }
 
 impl std::fmt::Display for ContractCallFailure {
@@ -321,12 +340,52 @@ impl ClarityInterpreter {
         }
     }
 
+    /// Execute `contract` without consuming anyone's nonce.
+    ///
+    /// For bare snippets and function-argument evaluation. A deploy or an STX
+    /// transfer is a transaction and must use [`Self::run_transaction`].
     pub fn run(
         &mut self,
         contract: &ClarityContract,
         cached_ast: Option<&ContractAST>,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
+    ) -> Result<AnnotatedExecutionResult, ExecutionError> {
+        self.run_with_charge(
+            contract,
+            cached_ast,
+            cost_track,
+            eval_hooks,
+            &NonceCharge::Free,
+        )
+    }
+
+    /// Execute `contract` as a transaction sent by `sender`, consuming one of
+    /// its nonces in the same commit as the execution's own state changes.
+    pub fn run_transaction(
+        &mut self,
+        contract: &ClarityContract,
+        cached_ast: Option<&ContractAST>,
+        cost_track: bool,
+        eval_hooks: Option<Vec<&mut dyn EvalHook>>,
+        sender: PrincipalData,
+    ) -> Result<AnnotatedExecutionResult, ExecutionError> {
+        self.run_with_charge(
+            contract,
+            cached_ast,
+            cost_track,
+            eval_hooks,
+            &NonceCharge::Sender(sender),
+        )
+    }
+
+    pub(crate) fn run_with_charge(
+        &mut self,
+        contract: &ClarityContract,
+        cached_ast: Option<&ContractAST>,
+        cost_track: bool,
+        eval_hooks: Option<Vec<&mut dyn EvalHook>>,
+        charge: &NonceCharge,
     ) -> Result<AnnotatedExecutionResult, ExecutionError> {
         let (ast, mut diagnostics, success) = match cached_ast {
             Some(ast) => (ast.clone(), vec![], true),
@@ -342,10 +401,11 @@ impl ClarityInterpreter {
             Ok((analysis, lint_diags)) => (analysis, lint_diags),
             Err(mut analysis_failure) => {
                 diagnostics.append(&mut analysis_failure.diagnostics);
-                return Err(ExecutionError {
+                return Err(self.fail_before_execution(
                     diagnostics,
-                    inclusion: analysis_failure.inclusion,
-                });
+                    analysis_failure.inclusion,
+                    charge,
+                ));
             }
         };
         // Note the ordering, which predates the inclusion work: analysis runs
@@ -354,28 +414,53 @@ impl ClarityInterpreter {
         // the parse one. Both go through `handle_clarity_analysis_error`, so
         // the two agree unless exactly one of them is `rejectable_in_epoch`.
         if !success {
-            return Err(ExecutionError {
-                inclusion: self.classify_parse_failure(contract),
-                diagnostics,
-            });
+            let inclusion = self.classify_parse_failure(contract);
+            return Err(self.fail_before_execution(diagnostics, inclusion, charge));
         }
 
-        let mut result = match self.execute(contract, &ast, analysis, cost_track, eval_hooks) {
-            Ok(result) => result,
-            Err(mut runtime_failure) => {
-                diagnostics.append(&mut runtime_failure.diagnostics);
-                return Err(ExecutionError {
-                    diagnostics,
-                    inclusion: runtime_failure.inclusion,
-                });
-            }
-        };
+        let mut result =
+            match self.execute(contract, &ast, analysis, cost_track, eval_hooks, charge) {
+                Ok(result) => result,
+                Err(mut runtime_failure) => {
+                    diagnostics.append(&mut runtime_failure.diagnostics);
+                    return Err(ExecutionError {
+                        diagnostics,
+                        inclusion: runtime_failure.inclusion,
+                    });
+                }
+            };
 
         result.diagnostics = diagnostics.to_vec();
         Ok(AnnotatedExecutionResult {
             execution_result: result,
             lint_diagnostics,
         })
+    }
+
+    /// Build the error for a transaction that failed before reaching the VM,
+    /// charging its nonce if mainnet would still have mined it.
+    ///
+    /// Parse and analysis failures never enter `execute`, so there is no
+    /// execution transaction for the charge to ride along in. A standalone
+    /// commit is safe precisely because nothing ran: it cannot leave a nonce
+    /// paired with half-applied state, and if it fails, nothing happened at all
+    /// and the transaction becomes a rejection.
+    fn fail_before_execution(
+        &mut self,
+        mut diagnostics: Vec<Diagnostic>,
+        inclusion: BlockInclusion,
+        charge: &NonceCharge,
+    ) -> ExecutionError {
+        if let (BlockInclusion::Included, NonceCharge::Sender(principal)) = (inclusion, charge) {
+            if let Err(e) = self.increment_nonce(&principal.clone()) {
+                diagnostics.push(runtime_diagnostic(e));
+                return ExecutionError::rejected(diagnostics);
+            }
+        }
+        ExecutionError {
+            diagnostics,
+            inclusion,
+        }
     }
 
     pub fn detect_dependencies(
@@ -693,6 +778,7 @@ impl ClarityInterpreter {
         analysis: ContractAnalysis,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
+        charge: &NonceCharge,
     ) -> Result<ExecutionResult, ExecutionError> {
         let contract_id = contract.expect_resolved_contract_identifier(Some(&self.tx_sender));
         let snippet = contract.expect_in_memory_code_source();
@@ -813,12 +899,23 @@ impl ClarityInterpreter {
                     }
                     global_context.eval_hooks = Some(eval_hooks);
                 }
+                let inclusion =
+                    BlockInclusion::from_runtime_error(ClarityError::Interpreter(e), epoch);
+                let mut diagnostics = vec![runtime_diagnostic(err)];
+
+                // The execution left nothing behind, but mainnet still mines an
+                // included failure and charges it. Nothing else is pending, so
+                // this commit carries the nonce alone; if it fails, nothing at
+                // all happened and the operation is a rejection.
+                if inclusion.is_included() {
+                    if let Err(e) = charge.commit_alone(&mut global_context) {
+                        diagnostics.push(runtime_diagnostic(e));
+                        return Err(ExecutionError::rejected(diagnostics));
+                    }
+                }
                 return Err(ExecutionError {
-                    diagnostics: vec![runtime_diagnostic(err)],
-                    inclusion: BlockInclusion::from_runtime_error(
-                        ClarityError::Interpreter(e),
-                        epoch,
-                    ),
+                    diagnostics,
+                    inclusion,
                 });
             }
         };
@@ -884,6 +981,11 @@ impl ClarityInterpreter {
             EvaluationResult::Snippet(SnippetEvaluationResult { result })
         };
 
+        // The nonce joins the execution's own transaction, so the commit below
+        // either lands both or lands neither.
+        if let Err(e) = charge.apply(&mut global_context.database) {
+            return Err(ExecutionError::rejected(vec![runtime_diagnostic(e)]));
+        }
         global_context.commit().unwrap();
 
         let (events, accounts_to_credit, accounts_to_debit) =
@@ -920,6 +1022,12 @@ impl ClarityInterpreter {
         Ok(execution_result)
     }
 
+    /// Call `method`, charging `charge` in the same commit as the call's own
+    /// state changes.
+    ///
+    /// This primitive backs both transactions and read-only queries, so the
+    /// charge is the caller's to name — see [`NonceCharge`].
+    #[allow(clippy::too_many_arguments)]
     pub fn call_contract_fn(
         &mut self,
         contract_id: &QualifiedContractIdentifier,
@@ -930,6 +1038,7 @@ impl ClarityInterpreter {
         track_costs: bool,
         allow_private: bool,
         eval_hooks: Vec<&mut dyn EvalHook>,
+        charge: &NonceCharge,
     ) -> Result<ExecutionResult, ContractCallFailure> {
         let tx_sender: PrincipalData = self.tx_sender.clone().into();
 
@@ -1001,7 +1110,35 @@ impl ClarityInterpreter {
             .flat_map(|b| b.0.events.clone())
             .collect::<Vec<_>>();
 
-        let eval_result = EvaluationResult::Snippet(SnippetEvaluationResult { result: value? });
+        let value = match value {
+            Ok(value) => value,
+            Err(failure) => {
+                // The call left nothing behind, but mainnet still mines an
+                // included failure and charges it. Nothing else is pending, so
+                // this commit carries the nonce alone; if it fails, nothing at
+                // all happened and the call is a rejection.
+                if failure.inclusion.is_included() {
+                    if let Err(e) = charge.commit_alone(&mut global_context) {
+                        return Err(ContractCallFailure {
+                            error: ContractCallError::Uncategorized(e),
+                            inclusion: BlockInclusion::Rejected,
+                        });
+                    }
+                }
+                return Err(failure);
+            }
+        };
+
+        let eval_result = EvaluationResult::Snippet(SnippetEvaluationResult { result: value });
+
+        // The nonce joins the call's own transaction, so the commit below
+        // either lands both or lands neither.
+        if let Err(e) = charge.apply(&mut global_context.database) {
+            return Err(ContractCallFailure {
+                error: ContractCallError::Uncategorized(e),
+                inclusion: BlockInclusion::Rejected,
+            });
+        }
         global_context.commit().unwrap();
 
         let (events, accounts_to_credit, accounts_to_debit) =
@@ -1446,7 +1583,7 @@ mod tests {
             .run_analysis(contract, &ast, &annotations)
             .unwrap();
 
-        let result = interpreter.execute(contract, &ast, analysis, false, None);
+        let result = interpreter.execute(contract, &ast, analysis, false, None, &NonceCharge::Free);
         assert!(result.is_ok());
         result
     }
@@ -1998,7 +2135,8 @@ mod tests {
             .run_analysis(&contract, &ast, &annotations)
             .unwrap();
 
-        let result = interpreter.execute(&contract, &ast, analysis, false, None);
+        let result =
+            interpreter.execute(&contract, &ast, analysis, false, None, &NonceCharge::Free);
         assert!(result.is_ok());
         let ExecutionResult {
             diagnostics,
@@ -2247,6 +2385,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
         assert_execution_result_value(
             result,
@@ -2270,6 +2409,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
         assert_execution_result_value(
             result,
@@ -2326,6 +2466,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
         assert_execution_result_value(
             result,
@@ -2391,6 +2532,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
         assert_execution_result_value(
             result,
@@ -2417,6 +2559,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
         assert_execution_result_value(
             result,
@@ -2594,6 +2737,7 @@ mod tests {
             false,
             allow_private,
             vec![],
+            &NonceCharge::Free,
         );
 
         assert!(result.is_ok());
@@ -2623,6 +2767,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
 
         assert!(result.is_err());
@@ -2643,6 +2788,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
 
         assert!(result.is_err());
@@ -2672,6 +2818,7 @@ mod tests {
             false,
             allow_private,
             vec![],
+            &NonceCharge::Free,
         );
 
         assert!(result.is_ok());
@@ -2702,6 +2849,7 @@ mod tests {
             false,
             allow_private,
             vec![],
+            &NonceCharge::Free,
         );
 
         assert!(result.is_err());
@@ -2744,6 +2892,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
 
         // this hash changes if the contract id or the block height at which it is deployed changes
@@ -2784,6 +2933,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
 
         let value = get_evaluation_result(get_time).expect_tuple().unwrap();
@@ -2824,6 +2974,7 @@ mod tests {
             false,
             false,
             vec![],
+            &NonceCharge::Free,
         );
 
         assert_execution_result_value(

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -48,11 +48,10 @@ use crate::repl::Settings;
 /// Whether mainnet would still include the transaction that produced a
 /// failure — and therefore charge its fee and advance its nonces.
 ///
-/// Never decide this by matching `ClarityError` variants here. The rule is
-/// consensus-critical and changes as variants are added upstream, so it is
-/// delegated to `clarity`'s `handle_clarity_runtime_error` /
-/// `handle_clarity_analysis_error`, which the node itself calls on the block
-/// assembly path. See stacks-network/stacks-core#7486.
+/// Never decide this by matching `ClarityError` variants here: the rule is
+/// consensus-critical and moves as variants are added upstream. Delegate to
+/// `clarity`'s `handle_clarity_runtime_error` / `handle_clarity_analysis_error`,
+/// which the node itself calls on the block-assembly path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockInclusion {
     /// The transaction is included: it consumes a nonce even though it failed.
@@ -61,7 +60,24 @@ pub enum BlockInclusion {
     Rejected,
 }
 
+/// A failure that knows whether the transaction producing it was still mined.
+///
+/// Implemented by every error type on a transaction path so that the
+/// success-is-included half of the rule lives in [`BlockInclusion::of_result`]
+/// alone, instead of being re-derived by each caller that bumps a nonce.
+pub trait FailureInclusion {
+    fn inclusion(&self) -> BlockInclusion;
+}
+
 impl BlockInclusion {
+    /// The disposition of a whole operation. A success is always included.
+    pub fn of_result<T, E: FailureInclusion>(result: &Result<T, E>) -> Self {
+        match result {
+            Ok(_) => BlockInclusion::Included,
+            Err(e) => e.inclusion(),
+        }
+    }
+
     /// Classify a failure from the execution phase — a contract call, an STX
     /// transfer, or the body of a contract being deployed.
     pub fn from_runtime_error(error: ClarityError, epoch: StacksEpochId) -> Self {
@@ -90,12 +106,19 @@ impl From<bool> for BlockInclusion {
     }
 }
 
-/// A failed `ClarityInterpreter::run`, carrying the diagnostics to report and
-/// whether the operation still counts as a transaction on mainnet.
+/// A failed `ClarityInterpreter::run`.
 #[derive(Debug, Clone)]
 pub struct ExecutionError {
+    /// Everything to report to the user about the failure.
     pub diagnostics: Vec<Diagnostic>,
+    /// Whether the operation still counts as a transaction on mainnet.
     pub inclusion: BlockInclusion,
+}
+
+impl FailureInclusion for ExecutionError {
+    fn inclusion(&self) -> BlockInclusion {
+        self.inclusion
+    }
 }
 
 impl ExecutionError {
@@ -128,15 +151,23 @@ fn runtime_diagnostic(message: impl std::fmt::Display) -> Diagnostic {
     }
 }
 
-/// A failed contract call, carrying the same disposition as [`ExecutionError`].
+/// A failed contract call.
 ///
-/// The verdict is a sibling of the error rather than part of it because
-/// [`ContractCallError`] still classifies itself by matching on formatted
-/// message text; keeping them separate lets that be replaced independently.
+/// The two fields answer different questions and are derived from the VM error
+/// independently: `error` decides which message the user sees, `inclusion`
+/// decides whether a nonce is consumed. Neither may be inferred from the other.
 #[derive(Debug, Clone)]
 pub struct ContractCallFailure {
+    /// What to tell the user went wrong.
     pub error: ContractCallError,
+    /// Whether the call still counts as a transaction on mainnet.
     pub inclusion: BlockInclusion,
+}
+
+impl FailureInclusion for ContractCallFailure {
+    fn inclusion(&self) -> BlockInclusion {
+        self.inclusion
+    }
 }
 
 impl std::fmt::Display for ContractCallFailure {
@@ -155,17 +186,11 @@ pub enum ContractCallError {
 }
 
 impl ContractCallError {
-    /// Classify a VM failure by the error the VM actually raised.
+    /// Classify a VM failure by the typed error, never by `message`.
     ///
-    /// This used to grep the *formatted* message for `"UndefinedFunction"`,
-    /// which matched whenever that text appeared anywhere in a nested error's
-    /// `Debug` output — including inside an unrelated failure that merely
-    /// mentioned one. Matching the typed error instead makes the classification
-    /// mean what it says.
-    ///
-    /// `message` is still carried verbatim, and the variants are unchanged, so
-    /// the diagnostics `Session::call_contract_fn` builds from these are
-    /// identical for every input that was already classified correctly.
+    /// `message` is the `Debug` rendering of the whole error, so it embeds the
+    /// text of any nested error too: searching it for a variant name matches
+    /// unrelated failures that merely mention one.
     fn from_vm_error(error: &VmExecutionError, message: String) -> Self {
         match error {
             // Either the function is absent, or it exists but is not callable
@@ -179,20 +204,46 @@ impl ContractCallError {
                 ContractCallError::NoSuchContract(message)
             }
 
-            // Simnet reaches a missing contract by a different route than a
-            // `contract-call?` does. `call_contract_fn` enters with a contract
-            // id already in hand, so the metadata read fails before any name
-            // resolution, and `clarity` reports that as a failed internal
-            // expectation rather than `NoSuchContract`. Scoped to the one
-            // variant that can carry it, rather than searched for in the whole
-            // formatted message.
-            VmExecutionError::Internal(VmInternalError::Expect(e))
-                if e.starts_with("Failed to read non-consensus contract metadata") =>
-            {
-                ContractCallError::NoSuchContract(message)
-            }
+            _ if is_missing_contract_metadata(error) => ContractCallError::NoSuchContract(message),
 
             _ => ContractCallError::Uncategorized(message),
+        }
+    }
+}
+
+/// Whether this failure is simnet's way of saying the contract is not deployed.
+///
+/// A `contract-call?` resolves the contract name first and raises
+/// `NoSuchContract`. `call_contract_fn` enters with a contract id already in
+/// hand, so the metadata read fails before any name resolution and `clarity`
+/// reports a failed internal expectation instead. Scoped to the one variant
+/// that can carry it, rather than searched for in the whole formatted message.
+fn is_missing_contract_metadata(error: &VmExecutionError) -> bool {
+    matches!(
+        error,
+        VmExecutionError::Internal(VmInternalError::Expect(e))
+            if e.starts_with("Failed to read non-consensus contract metadata")
+    )
+}
+
+impl ContractCallFailure {
+    /// Classify a VM failure from `ClarityInterpreter::call_contract_fn`.
+    ///
+    /// The disposition normally comes straight from `clarity`, but the route
+    /// described on [`is_missing_contract_metadata`] hands it a
+    /// `VmInternalError`, which it rejects. Mainnet raises `NoSuchContract`
+    /// there — a non-rejectable `RuntimeCheck` — and mines the transaction, so
+    /// the nonce is charged. Follow mainnet rather than the route simnet took.
+    fn from_vm_error(error: VmExecutionError, message: String, epoch: StacksEpochId) -> Self {
+        if is_missing_contract_metadata(&error) {
+            return Self {
+                error: ContractCallError::from_vm_error(&error, message),
+                inclusion: BlockInclusion::Included,
+            };
+        }
+        Self {
+            error: ContractCallError::from_vm_error(&error, message),
+            inclusion: BlockInclusion::from_runtime_error(ClarityError::Interpreter(error), epoch),
         }
     }
 }
@@ -936,10 +987,7 @@ impl ClarityInterpreter {
                 }
                 global_context.eval_hooks = Some(eval_hooks);
             }
-            ContractCallFailure {
-                error: ContractCallError::from_vm_error(&e, err),
-                inclusion: BlockInclusion::from_runtime_error(ClarityError::Interpreter(e), epoch),
-            }
+            ContractCallFailure::from_vm_error(e, err, epoch)
         });
 
         let mut cost = None;
@@ -1294,12 +1342,15 @@ impl ClarityInterpreter {
 
     /// Read the transaction nonce of `principal`.
     ///
-    /// Nonces are kept where mainnet keeps them — behind the
-    /// `ClarityBackingStore`, under `make_key_for_account_nonce` — rather than
-    /// beside the `tokens` map, which is a reporting mirror with no rollback.
-    /// Storing them in the backing store means a nonce bump is discarded along
-    /// with the rest of a rolled-back transaction, which is what post-condition
-    /// enforcement will rely on.
+    /// Nonces live where mainnet keeps them — behind the `ClarityBackingStore`,
+    /// under `make_key_for_account_nonce` — rather than beside the `tokens`
+    /// map, which is a reporting mirror the VM cannot see. Keeping them in the
+    /// backing store is what will let a future post-condition abort roll a
+    /// nonce back with the transaction that set it; today the bump is a
+    /// separate commit made after execution, so nothing rolls it back yet.
+    ///
+    /// Takes `&mut self` because every `ClarityBackingStore` read does, and
+    /// because a remote-data session may fetch the value over the network.
     pub fn get_nonce(&mut self, principal: &PrincipalData) -> Result<u64, String> {
         let mut conn = ClarityDatabase::new(
             &mut self.clarity_datastore,
@@ -1318,6 +1369,10 @@ impl ClarityInterpreter {
     }
 
     /// Bump the transaction nonce of `principal`, returning the new value.
+    ///
+    /// Errors if the nonce would overflow. Saturating instead would report
+    /// success while leaving the nonce unchanged, so every later transaction
+    /// would silently reuse it.
     pub fn increment_nonce(&mut self, principal: &PrincipalData) -> Result<u64, String> {
         let mut conn = ClarityDatabase::new(
             &mut self.clarity_datastore,
@@ -1328,12 +1383,30 @@ impl ClarityInterpreter {
         let next = conn
             .get_account_nonce(principal)
             .map_err(|e| format!("failed to read nonce for {principal}: {e}"))?
-            .saturating_add(1);
+            .checked_add(1)
+            .ok_or_else(|| format!("nonce overflow for {principal}"))?;
         conn.set_account_nonce(principal, next)
             .map_err(|e| format!("failed to set nonce for {principal}: {e}"))?;
         conn.commit()
             .map_err(|e| format!("failed to commit nonce for {principal}: {e}"))?;
         Ok(next)
+    }
+
+    /// Drive a principal's nonce straight to `nonce`.
+    ///
+    /// Nothing reachable from the public API can do this — the only writer is
+    /// `increment_nonce`, one step at a time — so the failure paths that depend
+    /// on a nonce's value are otherwise unreachable from a test.
+    #[cfg(test)]
+    pub(crate) fn force_nonce(&mut self, principal: &PrincipalData, nonce: u64) {
+        let mut conn = ClarityDatabase::new(
+            &mut self.clarity_datastore,
+            &self.datastore,
+            &self.datastore,
+        );
+        conn.begin();
+        conn.set_account_nonce(principal, nonce).unwrap();
+        conn.commit().unwrap();
     }
 }
 
@@ -1565,10 +1638,8 @@ mod tests {
     fn contract_call_errors_are_classified_by_type_not_message() {
         use clarity::vm::errors::RuntimeError;
 
-        // The old classifier searched the *formatted* message, so any failure
-        // whose text merely mentioned `UndefinedFunction` was reported to the
-        // user as a missing function. Nested `Debug` output is exactly how that
-        // text gets somewhere it does not belong.
+        // An unrelated failure whose text merely mentions `UndefinedFunction`
+        // must not be reported as a missing function.
         let misleading =
             VmExecutionError::Runtime(RuntimeError::Arithmetic("UndefinedFunction".into()), None);
         assert!(matches!(
@@ -1598,15 +1669,12 @@ mod tests {
 
     /// Pin both directions of the delegation to `clarity`.
     ///
-    /// The end-to-end nonce tests in `session.rs` only reach *included*
-    /// failures, because the rejected ones — cost overruns, resource-budget
-    /// exhaustion, `rejectable_in_epoch` errors — are impractical to provoke
-    /// from ordinary contract source. Without this test, mapping every failure
-    /// to `Included` would pass the whole suite.
-    ///
-    /// This asserts that clarinet asks the right classifier and reads the
-    /// answer the right way round. Which specific variants fall on which side
-    /// is upstream's business, and is tested there.
+    /// Rejected failures — cost overruns, resource-budget exhaustion — are
+    /// impractical to provoke from contract source, so the end-to-end tests
+    /// reach only included ones: without this, mapping *everything* to
+    /// `Included` would pass the whole suite. Which variants fall on which
+    /// side is upstream's business; this only checks that clarinet asks the
+    /// right classifier and reads the answer the right way round.
     #[test]
     fn block_inclusion_delegates_to_clarity() {
         use clarity::vm::analysis::errors::{StaticCheckError, StaticCheckErrorKind};
@@ -1667,6 +1735,24 @@ mod tests {
 
         assert_eq!(interpreter.increment_nonce(&addr).unwrap(), 2);
         assert_eq!(interpreter.get_nonce(&addr).unwrap(), 2);
+    }
+
+    #[test]
+    fn a_nonce_at_the_maximum_fails_instead_of_repeating_itself() {
+        let mut interpreter = get_interpreter(None);
+        let addr = principal("ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5");
+
+        interpreter.force_nonce(&addr, u64::MAX - 1);
+
+        assert_eq!(interpreter.increment_nonce(&addr).unwrap(), u64::MAX);
+
+        // Saturating here would report success and hand the same nonce to
+        // every later transaction.
+        let err = interpreter
+            .increment_nonce(&addr)
+            .expect_err("a nonce past u64::MAX has nowhere to go");
+        assert!(err.contains("overflow"), "got: {err}");
+        assert_eq!(interpreter.get_nonce(&addr).unwrap(), u64::MAX);
     }
 
     #[test]

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -216,18 +216,28 @@ fn is_missing_contract_metadata(error: &VmExecutionError) -> bool {
 }
 
 impl ContractCallFailure {
-    /// Classify a call failure, correcting simnet's missing-contract internal
-    /// error to the included `NoSuchContract` disposition mainnet produces.
-    fn from_vm_error(error: VmExecutionError, message: String, epoch: StacksEpochId) -> Self {
-        if is_missing_contract_metadata(&error) {
-            return Self {
-                error: ContractCallError::from_vm_error(&error, message),
-                inclusion: BlockInclusion::Included,
-            };
-        }
+    /// Classify simnet's missing-contract internal error as the equivalent
+    /// `NoSuchContract`, preserving upstream's epoch-dependent disposition.
+    fn from_vm_error(
+        error: VmExecutionError,
+        message: String,
+        contract_id: &QualifiedContractIdentifier,
+        epoch: StacksEpochId,
+    ) -> Self {
+        let kind = ContractCallError::from_vm_error(&error, message);
+        let as_mainnet_raised_it = if is_missing_contract_metadata(&error) {
+            VmExecutionError::RuntimeCheck(RuntimeCheckErrorKind::NoSuchContract(
+                contract_id.to_string(),
+            ))
+        } else {
+            error
+        };
         Self {
-            error: ContractCallError::from_vm_error(&error, message),
-            inclusion: BlockInclusion::from_runtime_error(ClarityError::Interpreter(error), epoch),
+            error: kind,
+            inclusion: BlockInclusion::from_runtime_error(
+                ClarityError::Interpreter(as_mainnet_raised_it),
+                epoch,
+            ),
         }
     }
 }
@@ -1043,7 +1053,7 @@ impl ClarityInterpreter {
                 }
                 global_context.eval_hooks = Some(eval_hooks);
             }
-            ContractCallFailure::from_vm_error(e, err, epoch)
+            ContractCallFailure::from_vm_error(e, err, contract_id, epoch)
         });
 
         let mut cost = None;
@@ -2694,11 +2704,14 @@ mod tests {
             &NonceCharge::Free,
         );
 
-        assert!(result.is_err());
-        matches!(
-            result.unwrap_err().error,
-            ContractCallError::NoSuchFunction(_)
+        let failure = result.expect_err("calling an undefined function must fail");
+        assert!(
+            matches!(failure.error, ContractCallError::NoSuchFunction(_)),
+            "got: {:?}",
+            failure.error
         );
+        // This non-rejectable runtime check is included from epoch 2.1 onward.
+        assert!(failure.inclusion.is_included());
 
         let result = interpreter.call_contract_fn(
             &QualifiedContractIdentifier {
@@ -2715,11 +2728,55 @@ mod tests {
             &NonceCharge::Free,
         );
 
-        assert!(result.is_err());
-        matches!(
-            result.unwrap_err().error,
-            ContractCallError::NoSuchContract(_)
+        let failure = result.expect_err("calling a missing contract must fail");
+        assert!(
+            matches!(failure.error, ContractCallError::NoSuchContract(_)),
+            "got: {:?}",
+            failure.error
         );
+        assert!(failure.inclusion.is_included());
+    }
+
+    #[test]
+    fn a_missing_contract_is_included_only_from_epoch_2_1() {
+        // Pin both sides of upstream's epoch gate for non-rejectable runtime checks.
+        let missing = QualifiedContractIdentifier {
+            issuer: StandardPrincipalData::transient(),
+            name: ContractName::from_literal("unexisting"),
+        };
+
+        for (epoch, expected_included) in [
+            (StacksEpochId::Epoch20, false),
+            (StacksEpochId::Epoch2_05, false),
+            (StacksEpochId::Epoch21, true),
+            (StacksEpochId::Epoch24, true),
+        ] {
+            let mut interpreter = get_interpreter(None);
+            let failure = interpreter
+                .call_contract_fn(
+                    &missing,
+                    "whatever",
+                    &[],
+                    epoch,
+                    ClarityVersion::Clarity1,
+                    false,
+                    false,
+                    vec![],
+                    &NonceCharge::Free,
+                )
+                .expect_err("calling a missing contract must fail");
+
+            assert!(
+                matches!(failure.error, ContractCallError::NoSuchContract(_)),
+                "{epoch}: got {:?}",
+                failure.error
+            );
+            assert_eq!(
+                failure.inclusion.is_included(),
+                expected_included,
+                "{epoch} disagrees with the mainnet gate"
+            );
+        }
     }
 
     #[test]

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -16,12 +16,13 @@ use clarity::vm::database::clarity_db::ContractDataVarName;
 use clarity::vm::database::{ClarityBackingStore, ClarityDatabase, StoreType};
 use clarity::vm::diagnostic::{Diagnostic, Level};
 use clarity::vm::events::*;
+use clarity::vm::hooks::EvalHook;
 use clarity::vm::representations::SymbolicExpressionType::{Atom, List};
 use clarity::vm::representations::{Span, SymbolicExpression};
-use clarity::vm::time_tracker::TimeTracker;
+use clarity::vm::resource_limiter::ResourceLimiter;
 use clarity::vm::{
-    eval, eval_all, ClarityVersion, ContractEvaluationResult, CostSynthesis, EvalHook,
-    EvaluationResult, ExecutionResult, ParsedContract, SnippetEvaluationResult,
+    eval, eval_all, ClarityVersion, ContractEvaluationResult, CostSynthesis, EvaluationResult,
+    ExecutionResult, ParsedContract, SnippetEvaluationResult,
 };
 use clarity_types::types::{
     AssetIdentifier, PrincipalData, QualifiedContractIdentifier, StandardPrincipalData,
@@ -303,7 +304,7 @@ impl ClarityInterpreter {
             contract.epoch.resolve(),
             contract.clarity_version,
             true,
-            TimeTracker::unlimited(),
+            ResourceLimiter::unlimited(),
         )
         .map_err(|boxed_error| {
             let mut diagnostics = renamed_builtin_level

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -6,7 +6,10 @@ use clarinet_defaults::DEFAULT_EPOCH;
 use clarity::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET};
 use clarity::types::StacksEpochId;
 use clarity::vm::analysis::{AnalysisDatabase, ContractAnalysis};
-use clarity::vm::ast::{build_ast_with_diagnostics, ContractAST};
+use clarity::vm::ast::{build_ast, build_ast_with_diagnostics, ContractAST};
+use clarity::vm::clarity::{
+    handle_clarity_analysis_error, handle_clarity_runtime_error, ClarityError,
+};
 use clarity::vm::contexts::{
     CallStack, ContractContext, ExecutionState, GlobalContext, InvocationContext, LocalContext,
 };
@@ -39,6 +42,108 @@ use crate::analysis::{self, LintDiagnostic};
 use crate::repl::datastore::{ClarityDatastore, Datastore};
 use crate::repl::session::AnnotatedExecutionResult;
 use crate::repl::Settings;
+
+/// Whether mainnet would still include the transaction that produced a
+/// failure — and therefore charge its fee and advance its nonces.
+///
+/// Never decide this by matching `ClarityError` variants here. The rule is
+/// consensus-critical and changes as variants are added upstream, so it is
+/// delegated to `clarity`'s `handle_clarity_runtime_error` /
+/// `handle_clarity_analysis_error`, which the node itself calls on the block
+/// assembly path. See stacks-network/stacks-core#7486.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockInclusion {
+    /// The transaction is included: it consumes a nonce even though it failed.
+    Included,
+    /// The transaction is invalid: nothing happens, and no nonce is consumed.
+    Rejected,
+}
+
+impl BlockInclusion {
+    /// Classify a failure from the execution phase — a contract call, an STX
+    /// transfer, or the body of a contract being deployed.
+    pub fn from_runtime_error(error: ClarityError, epoch: StacksEpochId) -> Self {
+        Self::from(handle_clarity_runtime_error(error, epoch).is_included_in_block())
+    }
+
+    /// Classify a failure from a deployment's analysis phase, which never
+    /// reaches `handle_clarity_runtime_error` on mainnet: the `SmartContract`
+    /// arm matches `ClarityError` directly and decides on `rejectable_in_epoch`.
+    pub fn from_analysis_error(error: ClarityError, epoch: StacksEpochId) -> Self {
+        Self::from(handle_clarity_analysis_error(error, epoch).is_included_in_block())
+    }
+
+    pub fn is_included(self) -> bool {
+        self == BlockInclusion::Included
+    }
+}
+
+impl From<bool> for BlockInclusion {
+    fn from(is_included: bool) -> Self {
+        if is_included {
+            BlockInclusion::Included
+        } else {
+            BlockInclusion::Rejected
+        }
+    }
+}
+
+/// A failed `ClarityInterpreter::run`, carrying the diagnostics to report and
+/// whether the operation still counts as a transaction on mainnet.
+#[derive(Debug, Clone)]
+pub struct ExecutionError {
+    pub diagnostics: Vec<Diagnostic>,
+    pub inclusion: BlockInclusion,
+}
+
+impl ExecutionError {
+    /// A failure that invalidates the transaction outright. This is the right
+    /// default for anything simnet rejects before execution — an unparseable
+    /// epoch, a bad contract id — none of which mainnet would include.
+    pub fn rejected(diagnostics: Vec<Diagnostic>) -> Self {
+        Self {
+            diagnostics,
+            inclusion: BlockInclusion::Rejected,
+        }
+    }
+}
+
+impl From<ExecutionError> for Vec<Diagnostic> {
+    fn from(e: ExecutionError) -> Self {
+        e.diagnostics
+    }
+}
+
+/// Wrap a failure message the way `ClarityInterpreter::run` has always
+/// reported one. Kept in one place because the exact text is asserted by
+/// `simnet-usage.test.ts` and matched by the tracer hook.
+fn runtime_diagnostic(message: impl std::fmt::Display) -> Diagnostic {
+    Diagnostic {
+        level: Level::Error,
+        message: format!("Runtime Error: {message}"),
+        spans: vec![],
+        suggestion: None,
+    }
+}
+
+/// A failed contract call, carrying the same disposition as [`ExecutionError`].
+///
+/// The verdict is a sibling of the error rather than part of it because
+/// [`ContractCallError`] still classifies itself by matching on formatted
+/// message text; keeping them separate lets that be replaced independently.
+#[derive(Debug, Clone)]
+pub struct ContractCallFailure {
+    pub error: ContractCallError,
+    pub inclusion: BlockInclusion,
+}
+
+impl std::fmt::Display for ContractCallFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(f)
+    }
+}
+
+impl std::error::Error for ContractCallFailure {}
 
 #[derive(Debug, Clone)]
 pub enum ContractCallError {
@@ -138,7 +243,7 @@ impl ClarityInterpreter {
         cached_ast: Option<&ContractAST>,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
-    ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
+    ) -> Result<AnnotatedExecutionResult, ExecutionError> {
         let (ast, mut diagnostics, success) = match cached_ast {
             Some(ast) => (ast.clone(), vec![], true),
             None => self.build_ast(contract),
@@ -151,25 +256,29 @@ impl ClarityInterpreter {
 
         let (analysis, lint_diagnostics) = match self.run_analysis(contract, &ast, &annotations) {
             Ok((analysis, lint_diags)) => (analysis, lint_diags),
-            Err(mut analysis_diagnostics) => {
-                diagnostics.append(&mut analysis_diagnostics);
-                return Err(diagnostics.to_vec());
+            Err(mut analysis_failure) => {
+                diagnostics.append(&mut analysis_failure.diagnostics);
+                return Err(ExecutionError {
+                    diagnostics,
+                    inclusion: analysis_failure.inclusion,
+                });
             }
         };
         if !success {
-            return Err(diagnostics.to_vec());
+            return Err(ExecutionError {
+                inclusion: self.classify_parse_failure(contract),
+                diagnostics,
+            });
         }
 
         let mut result = match self.execute(contract, &ast, analysis, cost_track, eval_hooks) {
             Ok(result) => result,
-            Err(e) => {
-                diagnostics.push(Diagnostic {
-                    level: Level::Error,
-                    message: format!("Runtime Error: {e}"),
-                    spans: vec![],
-                    suggestion: None,
+            Err(mut runtime_failure) => {
+                diagnostics.append(&mut runtime_failure.diagnostics);
+                return Err(ExecutionError {
+                    diagnostics,
+                    inclusion: runtime_failure.inclusion,
                 });
-                return Err(diagnostics.to_vec());
             }
         };
 
@@ -225,6 +334,31 @@ impl ClarityInterpreter {
         )
     }
 
+    /// Whether a deploy that failed to parse is still included in a block.
+    ///
+    /// Ordinary syntax errors are included on mainnet — the deploy is mined and
+    /// fails — while `rejectable_in_epoch` errors invalidate the transaction.
+    /// `build_ast_with_diagnostics` reports every diagnostic but discards the
+    /// typed `ParseError` that distinction needs, so re-parse here to recover
+    /// it. This runs only on the failure path, and the diagnostics the caller
+    /// reports still come from the richer pass.
+    fn classify_parse_failure(&self, contract: &ClarityContract) -> BlockInclusion {
+        let epoch = contract.epoch.resolve();
+        let contract_id = contract.expect_resolved_contract_identifier(Some(&self.tx_sender));
+        match build_ast(
+            &contract_id,
+            contract.expect_in_memory_code_source(),
+            &mut (),
+            contract.clarity_version,
+            epoch,
+        ) {
+            Err(e) => BlockInclusion::from_analysis_error(ClarityError::Parse(e), epoch),
+            // The diagnostic pass found a problem the typed pass did not, so
+            // there is no error to classify. Stay conservative.
+            Ok(_) => BlockInclusion::Rejected,
+        }
+    }
+
     pub fn collect_annotations(&self, code_source: &str) -> (Vec<Annotation>, Vec<Diagnostic>) {
         let mut annotations = vec![];
         let mut diagnostics = vec![];
@@ -278,7 +412,7 @@ impl ClarityInterpreter {
         contract: &ClarityContract,
         contract_ast: &ContractAST,
         annotations: &[Annotation],
-    ) -> Result<(ContractAnalysis, Vec<LintDiagnostic>), Vec<Diagnostic>> {
+    ) -> Result<(ContractAnalysis, Vec<LintDiagnostic>), ExecutionError> {
         // Extract the lint level before borrowing self.clarity_datastore via analysis_db.
         // Only bother if skip_analysis is false; boot contracts and similar skip lints entirely.
         let renamed_builtin_level = if !contract.skip_analysis {
@@ -318,11 +452,20 @@ impl ClarityInterpreter {
                     )
                 })
                 .unwrap_or_default();
-            diagnostics.push(boxed_error.0.diagnostic);
-            diagnostics
+            let static_check_error = boxed_error.0;
+            diagnostics.push(static_check_error.diagnostic.clone());
+            ExecutionError {
+                diagnostics,
+                inclusion: BlockInclusion::from_analysis_error(
+                    ClarityError::StaticCheck(static_check_error),
+                    contract.epoch.resolve(),
+                ),
+            }
         })?;
 
-        // Run REPL-only analyses (linter, check_checker, etc.)
+        // Run REPL-only analyses (linter, check_checker, etc.). These are
+        // clarinet's own lints, not consensus rules, so a mainnet node would
+        // never see them — they can only reject an operation here.
         let lint_diagnostics = if !contract.skip_analysis {
             analysis::run_analysis(
                 &mut contract_analysis,
@@ -330,7 +473,9 @@ impl ClarityInterpreter {
                 annotations,
                 &self.repl_settings.analysis,
             )
-            .map_err(|lds| lds.into_iter().map(Diagnostic::from).collect::<Vec<_>>())?
+            .map_err(|lds| {
+                ExecutionError::rejected(lds.into_iter().map(Diagnostic::from).collect())
+            })?
         } else {
             vec![]
         };
@@ -459,7 +604,7 @@ impl ClarityInterpreter {
         analysis: ContractAnalysis,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
-    ) -> Result<ExecutionResult, String> {
+    ) -> Result<ExecutionResult, ExecutionError> {
         let contract_id = contract.expect_resolved_contract_identifier(Some(&self.tx_sender));
         let snippet = contract.expect_in_memory_code_source();
         let mut contract_context =
@@ -470,7 +615,12 @@ impl ClarityInterpreter {
 
         let tx_sender: PrincipalData = self.tx_sender.clone().into();
 
-        let mut global_context = self.get_global_context(contract.epoch.resolve(), cost_track)?;
+        let epoch = contract.epoch.resolve();
+        // Failing to stand up the VM is a simnet problem, not a transaction
+        // outcome — mainnet would never have accepted the transaction at all.
+        let mut global_context = self
+            .get_global_context(epoch, cost_track)
+            .map_err(|e| ExecutionError::rejected(vec![runtime_diagnostic(e)]))?;
 
         if let Some(in_hooks) = eval_hooks {
             let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
@@ -564,16 +714,25 @@ impl ClarityInterpreter {
             eval_all(&contract_ast.expressions, &mut contract_context, g, None)
         });
 
-        let value = result.map_err(|e| {
-            let err = format!("Runtime error while interpreting {contract_id}: {e:?}");
-            if let Some(mut eval_hooks) = global_context.eval_hooks.take() {
-                for hook in eval_hooks.iter_mut() {
-                    hook.did_complete(Err(err.clone()));
+        let value = match result {
+            Ok(value) => value,
+            Err(e) => {
+                let err = format!("Runtime error while interpreting {contract_id}: {e:?}");
+                if let Some(mut eval_hooks) = global_context.eval_hooks.take() {
+                    for hook in eval_hooks.iter_mut() {
+                        hook.did_complete(Err(err.clone()));
+                    }
+                    global_context.eval_hooks = Some(eval_hooks);
                 }
-                global_context.eval_hooks = Some(eval_hooks);
+                return Err(ExecutionError {
+                    diagnostics: vec![runtime_diagnostic(err)],
+                    inclusion: BlockInclusion::from_runtime_error(
+                        ClarityError::Interpreter(e),
+                        epoch,
+                    ),
+                });
             }
-            err
-        })?;
+        };
 
         let mut cost = None;
         if cost_track {
@@ -682,12 +841,17 @@ impl ClarityInterpreter {
         track_costs: bool,
         allow_private: bool,
         eval_hooks: Vec<&mut dyn EvalHook>,
-    ) -> Result<ExecutionResult, ContractCallError> {
+    ) -> Result<ExecutionResult, ContractCallFailure> {
         let tx_sender: PrincipalData = self.tx_sender.clone().into();
 
-        let mut global_context = self
-            .get_global_context(epoch, track_costs)
-            .map_err(ContractCallError::from)?;
+        // Failing to stand up the VM is a simnet problem, not a transaction
+        // outcome — mainnet would never have accepted the transaction at all.
+        let mut global_context =
+            self.get_global_context(epoch, track_costs)
+                .map_err(|e| ContractCallFailure {
+                    error: ContractCallError::from(e),
+                    inclusion: BlockInclusion::Rejected,
+                })?;
 
         let mut hooks: Vec<&mut dyn EvalHook> = Vec::new();
         for hook in eval_hooks {
@@ -733,7 +897,10 @@ impl ClarityInterpreter {
                 }
                 global_context.eval_hooks = Some(eval_hooks);
             }
-            err
+            ContractCallFailure {
+                error: ContractCallError::from(err),
+                inclusion: BlockInclusion::from_runtime_error(ClarityError::Interpreter(e), epoch),
+            }
         });
 
         let mut cost = None;
@@ -747,12 +914,7 @@ impl ClarityInterpreter {
             .flat_map(|b| b.0.events.clone())
             .collect::<Vec<_>>();
 
-        let eval_result = match value {
-            Ok(result) => EvaluationResult::Snippet(SnippetEvaluationResult { result }),
-            Err(e) => {
-                return Err(ContractCallError::from(e));
-            }
-        };
+        let eval_result = EvaluationResult::Snippet(SnippetEvaluationResult { result: value? });
         global_context.commit().unwrap();
 
         let (events, accounts_to_credit, accounts_to_debit) =
@@ -1163,7 +1325,7 @@ mod tests {
     fn deploy_contract(
         interpreter: &mut ClarityInterpreter,
         contract: &ClarityContract,
-    ) -> Result<ExecutionResult, ContractCallError> {
+    ) -> Result<ExecutionResult, ExecutionError> {
         let source = contract.expect_in_memory_code_source();
         let (ast, ..) = interpreter.build_ast(contract);
         let (annotations, _) = interpreter.collect_annotations(source);
@@ -1172,17 +1334,16 @@ mod tests {
             .run_analysis(contract, &ast, &annotations)
             .unwrap();
 
-        let result = interpreter
-            .execute(contract, &ast, analysis, false, None)
-            .map_err(ContractCallError::from);
+        let result = interpreter.execute(contract, &ast, analysis, false, None);
         assert!(result.is_ok());
         result
     }
 
+    // Generic over the error so it serves both `execute` (`ExecutionError`)
+    // and `call_contract_fn` (`ContractCallFailure`).
     #[track_caller]
-    fn get_evaluation_result(result: Result<ExecutionResult, ContractCallError>) -> Value {
-        assert!(result.is_ok());
-        let result = result.unwrap();
+    fn get_evaluation_result<E: std::fmt::Debug>(result: Result<ExecutionResult, E>) -> Value {
+        let result = result.expect("execution should succeed");
         match result.result {
             EvaluationResult::Contract(_) => unreachable!(),
             EvaluationResult::Snippet(res) => res.result,
@@ -1190,8 +1351,8 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_execution_result_value(
-        result: Result<ExecutionResult, ContractCallError>,
+    fn assert_execution_result_value<E: std::fmt::Debug>(
+        result: Result<ExecutionResult, E>,
         expected_value: Value,
     ) {
         let result = get_evaluation_result(result);
@@ -1359,6 +1520,59 @@ mod tests {
         PrincipalData::parse_standard_principal(addr)
             .expect("valid principal")
             .into()
+    }
+
+    /// Pin both directions of the delegation to `clarity`.
+    ///
+    /// The end-to-end nonce tests in `session.rs` only reach *included*
+    /// failures, because the rejected ones — cost overruns, resource-budget
+    /// exhaustion, `rejectable_in_epoch` errors — are impractical to provoke
+    /// from ordinary contract source. Without this test, mapping every failure
+    /// to `Included` would pass the whole suite.
+    ///
+    /// This asserts that clarinet asks the right classifier and reads the
+    /// answer the right way round. Which specific variants fall on which side
+    /// is upstream's business, and is tested there.
+    #[test]
+    fn block_inclusion_delegates_to_clarity() {
+        use clarity::vm::analysis::errors::{StaticCheckError, StaticCheckErrorKind};
+        use clarity::vm::errors::{RuntimeError, VmExecutionError};
+
+        let epoch = StacksEpochId::latest();
+
+        // Included: an ordinary runtime failure is mined, and pays for itself.
+        assert!(BlockInclusion::from_runtime_error(
+            ClarityError::Interpreter(VmExecutionError::Runtime(
+                RuntimeError::ArithmeticOverflow,
+                None
+            )),
+            epoch,
+        )
+        .is_included());
+
+        // Rejected: a cost overrun would invalidate the block, so the
+        // transaction never lands and consumes nothing.
+        assert!(!BlockInclusion::from_runtime_error(
+            ClarityError::CostError(ExecutionCost::ZERO, ExecutionCost::max_value()),
+            epoch,
+        )
+        .is_included());
+
+        // Included: an ordinary type error is mined as a failed deploy.
+        assert!(BlockInclusion::from_analysis_error(
+            ClarityError::StaticCheck(StaticCheckError::new(
+                StaticCheckErrorKind::UnknownFunction("no-such-fn".into())
+            )),
+            epoch,
+        )
+        .is_included());
+
+        // Rejected: analysis that exhausts its resource budget is not mineable.
+        assert!(!BlockInclusion::from_analysis_error(
+            ClarityError::AnalysisResourceBudgetExceeded("too slow".into()),
+            epoch,
+        )
+        .is_included());
     }
 
     #[test]
@@ -1556,7 +1770,7 @@ mod tests {
             .build();
         let result = interpreter.run(&contract, None, false, None);
         assert!(result.is_err());
-        let diagnostics = result.unwrap_err();
+        let diagnostics = result.unwrap_err().diagnostics;
         assert_eq!(diagnostics.len(), 1);
     }
 
@@ -1571,7 +1785,7 @@ mod tests {
         let result = interpreter.run(&contract, None, false, None);
         assert!(result.is_err());
 
-        let diagnostics = result.unwrap_err();
+        let diagnostics = result.unwrap_err().diagnostics;
         assert_eq!(diagnostics.len(), 1);
 
         let message = format!("Runtime Error: Runtime error while interpreting {}.{}: Runtime(DivisionByZero, Some([FunctionIdentifier {{ identifier: \"_native_:native_div\" }}]))", StandardPrincipalData::transient(), contract.name);
@@ -2252,7 +2466,10 @@ mod tests {
         );
 
         assert!(result.is_err());
-        matches!(result.unwrap_err(), ContractCallError::NoSuchFunction(_));
+        matches!(
+            result.unwrap_err().error,
+            ContractCallError::NoSuchFunction(_)
+        );
 
         let result = interpreter.call_contract_fn(
             &QualifiedContractIdentifier {
@@ -2269,7 +2486,10 @@ mod tests {
         );
 
         assert!(result.is_err());
-        matches!(result.unwrap_err(), ContractCallError::NoSuchContract(_));
+        matches!(
+            result.unwrap_err().error,
+            ContractCallError::NoSuchContract(_)
+        );
     }
 
     #[test]
@@ -2325,7 +2545,7 @@ mod tests {
         );
 
         assert!(result.is_err());
-        let err = result.unwrap_err();
+        let err = result.unwrap_err().error;
         match err {
             ContractCallError::NoSuchFunction(ref function_name) => {
                 assert!(function_name.contains("private-func"));

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -45,13 +45,8 @@ use crate::repl::datastore::{ClarityDatastore, Datastore};
 use crate::repl::session::AnnotatedExecutionResult;
 use crate::repl::Settings;
 
-/// Whether mainnet would still include the transaction that produced a
-/// failure — and therefore charge its fee and advance its nonces.
-///
-/// Never decide this by matching `ClarityError` variants here: the rule is
-/// consensus-critical and moves as variants are added upstream. Delegate to
-/// `clarity`'s `handle_clarity_runtime_error` / `handle_clarity_analysis_error`,
-/// which the node itself calls on the block-assembly path.
+/// Whether mainnet includes a failed transaction and consumes its nonce.
+/// Classification is delegated to the upstream `clarity` handlers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockInclusion {
     /// The transaction is included: it consumes a nonce even though it failed.
@@ -89,16 +84,10 @@ impl From<bool> for BlockInclusion {
     }
 }
 
-/// Whose nonce an execution consumes, if it consumes one.
-///
-/// Passed *into* execution rather than applied after it. A bump issued
-/// afterwards is a second database transaction that can fail on its own,
-/// leaving committed state behind a nonce that never moved — and since the next
-/// transaction then reuses the stale value, a caller retrying the reported
-/// error would apply the state changes twice.
+/// The nonce charge to include in an execution's database transaction.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum NonceCharge {
-    /// Not a transaction: a read-only call, or bare snippet evaluation.
+    /// An operation that does not consume a sender nonce.
     #[default]
     Free,
     /// A transaction sent by this principal, consuming one of its nonces.
@@ -106,8 +95,7 @@ pub enum NonceCharge {
 }
 
 impl NonceCharge {
-    /// Write the charge into `db`'s open transaction, so it lands or is
-    /// discarded with everything else that transaction holds.
+    /// Write the charge into `db`'s open transaction.
     fn apply(&self, db: &mut ClarityDatabase) -> Result<(), String> {
         let NonceCharge::Sender(principal) = self else {
             return Ok(());
@@ -121,13 +109,8 @@ impl NonceCharge {
             .map_err(|e| format!("failed to set nonce for {principal}: {e}"))
     }
 
-    /// Commit the charge as the *only* write in `global_context`'s open
-    /// transaction, for a failure mainnet would still have mined.
-    ///
-    /// `GlobalContext::execute` rolls its own context back before returning an
-    /// error, and nothing else writes to the enclosing one, so this commit
-    /// carries the nonce alone. That is what makes charging a failed
-    /// transaction safe here: there is no half-applied state to pair it with.
+    /// Commit only the charge after an included execution failure.
+    /// `GlobalContext::execute` has already rolled back the nested execution.
     fn commit_alone(&self, global_context: &mut GlobalContext) -> Result<(), String> {
         self.apply(&mut global_context.database)?;
         global_context
@@ -176,11 +159,7 @@ fn runtime_diagnostic(message: impl std::fmt::Display) -> Diagnostic {
     }
 }
 
-/// A failed contract call.
-///
-/// The two fields answer different questions and are derived from the VM error
-/// independently: `error` decides which message the user sees, `inclusion`
-/// decides whether a nonce is consumed. Neither may be inferred from the other.
+/// A failed contract call and its block-inclusion disposition.
 #[derive(Debug, Clone)]
 pub struct ContractCallFailure {
     /// What to tell the user went wrong.
@@ -205,11 +184,8 @@ pub enum ContractCallError {
 }
 
 impl ContractCallError {
-    /// Classify a VM failure by the typed error, never by `message`.
-    ///
-    /// `message` is the `Debug` rendering of the whole error, so it embeds the
-    /// text of any nested error too: searching it for a variant name matches
-    /// unrelated failures that merely mention one.
+    /// Classify the typed error; the formatted message may contain unrelated
+    /// nested error names.
     fn from_vm_error(error: &VmExecutionError, message: String) -> Self {
         match error {
             // Either the function is absent, or it exists but is not callable
@@ -230,13 +206,7 @@ impl ContractCallError {
     }
 }
 
-/// Whether this failure is simnet's way of saying the contract is not deployed.
-///
-/// A `contract-call?` resolves the contract name first and raises
-/// `NoSuchContract`. `call_contract_fn` enters with a contract id already in
-/// hand, so the metadata read fails before any name resolution and `clarity`
-/// reports a failed internal expectation instead. Scoped to the one variant
-/// that can carry it, rather than searched for in the whole formatted message.
+/// Detect simnet's internal-error representation of a missing contract.
 fn is_missing_contract_metadata(error: &VmExecutionError) -> bool {
     matches!(
         error,
@@ -246,13 +216,8 @@ fn is_missing_contract_metadata(error: &VmExecutionError) -> bool {
 }
 
 impl ContractCallFailure {
-    /// Classify a VM failure from `ClarityInterpreter::call_contract_fn`.
-    ///
-    /// The disposition normally comes straight from `clarity`, but the route
-    /// described on [`is_missing_contract_metadata`] hands it a
-    /// `VmInternalError`, which it rejects. Mainnet raises `NoSuchContract`
-    /// there — a non-rejectable `RuntimeCheck` — and mines the transaction, so
-    /// the nonce is charged. Follow mainnet rather than the route simnet took.
+    /// Classify a call failure, correcting simnet's missing-contract internal
+    /// error to the included `NoSuchContract` disposition mainnet produces.
     fn from_vm_error(error: VmExecutionError, message: String, epoch: StacksEpochId) -> Self {
         if is_missing_contract_metadata(&error) {
             return Self {
@@ -408,11 +373,9 @@ impl ClarityInterpreter {
                 ));
             }
         };
-        // Note the ordering, which predates the inclusion work: analysis runs
-        // before the parse result is consulted, so a source that fails both
-        // reports the *analysis* verdict. Mainnet parses first and would report
-        // the parse one. Both go through `handle_clarity_analysis_error`, so
-        // the two agree unless exactly one of them is `rejectable_in_epoch`.
+        // Analysis currently runs before the parse result is checked. Mainnet
+        // checks parsing first, so a source failing both may get a different
+        // verdict when only one error is rejectable in this epoch.
         if !success {
             let inclusion = self.classify_parse_failure(contract);
             return Err(self.fail_before_execution(diagnostics, inclusion, charge));
@@ -437,14 +400,7 @@ impl ClarityInterpreter {
         })
     }
 
-    /// Build the error for a transaction that failed before reaching the VM,
-    /// charging its nonce if mainnet would still have mined it.
-    ///
-    /// Parse and analysis failures never enter `execute`, so there is no
-    /// execution transaction for the charge to ride along in. A standalone
-    /// commit is safe precisely because nothing ran: it cannot leave a nonce
-    /// paired with half-applied state, and if it fails, nothing happened at all
-    /// and the transaction becomes a rejection.
+    /// Charge an included parse or analysis failure, for which no VM state exists.
     fn fail_before_execution(
         &mut self,
         mut diagnostics: Vec<Diagnostic>,
@@ -508,14 +464,8 @@ impl ClarityInterpreter {
         )
     }
 
-    /// Whether a deploy that failed to parse is still included in a block.
-    ///
-    /// Ordinary syntax errors are included on mainnet — the deploy is mined and
-    /// fails — while `rejectable_in_epoch` errors invalidate the transaction.
-    /// `build_ast_with_diagnostics` reports every diagnostic but discards the
-    /// typed `ParseError` that distinction needs, so re-parse here to recover
-    /// it. This runs only on the failure path, and the diagnostics the caller
-    /// reports still come from the richer pass.
+    /// Recover the typed parse error discarded by the diagnostic AST builder
+    /// and ask upstream whether it is rejectable in this epoch.
     fn classify_parse_failure(&self, contract: &ClarityContract) -> BlockInclusion {
         let epoch = contract.epoch.resolve();
         let contract_id = contract.expect_resolved_contract_identifier(Some(&self.tx_sender));
@@ -903,10 +853,8 @@ impl ClarityInterpreter {
                     BlockInclusion::from_runtime_error(ClarityError::Interpreter(e), epoch);
                 let mut diagnostics = vec![runtime_diagnostic(err)];
 
-                // The execution left nothing behind, but mainnet still mines an
-                // included failure and charges it. Nothing else is pending, so
-                // this commit carries the nonce alone; if it fails, nothing at
-                // all happened and the operation is a rejection.
+                // The nested execution was rolled back; an included failure
+                // commits only its nonce.
                 if inclusion.is_included() {
                     if let Err(e) = charge.commit_alone(&mut global_context) {
                         diagnostics.push(runtime_diagnostic(e));
@@ -981,8 +929,7 @@ impl ClarityInterpreter {
             EvaluationResult::Snippet(SnippetEvaluationResult { result })
         };
 
-        // The nonce joins the execution's own transaction, so the commit below
-        // either lands both or lands neither.
+        // Commit the nonce and execution state atomically.
         if let Err(e) = charge.apply(&mut global_context.database) {
             return Err(ExecutionError::rejected(vec![runtime_diagnostic(e)]));
         }
@@ -1113,10 +1060,8 @@ impl ClarityInterpreter {
         let value = match value {
             Ok(value) => value,
             Err(failure) => {
-                // The call left nothing behind, but mainnet still mines an
-                // included failure and charges it. Nothing else is pending, so
-                // this commit carries the nonce alone; if it fails, nothing at
-                // all happened and the call is a rejection.
+                // The nested call was rolled back; an included failure commits
+                // only its nonce.
                 if failure.inclusion.is_included() {
                     if let Err(e) = charge.commit_alone(&mut global_context) {
                         return Err(ContractCallFailure {
@@ -1131,8 +1076,7 @@ impl ClarityInterpreter {
 
         let eval_result = EvaluationResult::Snippet(SnippetEvaluationResult { result: value });
 
-        // The nonce joins the call's own transaction, so the commit below
-        // either lands both or lands neither.
+        // Commit the nonce and call state atomically.
         if let Err(e) = charge.apply(&mut global_context.database) {
             return Err(ContractCallFailure {
                 error: ContractCallError::Uncategorized(e),
@@ -1479,15 +1423,9 @@ impl ClarityInterpreter {
 
     /// Read the transaction nonce of `principal`.
     ///
-    /// Nonces live where mainnet keeps them — behind the `ClarityBackingStore`,
-    /// under `make_key_for_account_nonce` — rather than beside the `tokens`
-    /// map, which is a reporting mirror the VM cannot see. Keeping them in the
-    /// backing store is what will let a future post-condition abort roll a
-    /// nonce back with the transaction that set it; today the bump is a
-    /// separate commit made after execution, so nothing rolls it back yet.
-    ///
-    /// Takes `&mut self` because every `ClarityBackingStore` read does, and
-    /// because a remote-data session may fetch the value over the network.
+    /// Stored in the `ClarityBackingStore`, so transaction rollback also rolls
+    /// back its nonce. The mutable borrow is required because remote reads may
+    /// populate the local cache.
     pub fn get_nonce(&mut self, principal: &PrincipalData) -> Result<u64, String> {
         let mut conn = ClarityDatabase::new(
             &mut self.clarity_datastore,
@@ -1505,11 +1443,7 @@ impl ClarityInterpreter {
         nonce
     }
 
-    /// Bump the transaction nonce of `principal`, returning the new value.
-    ///
-    /// Errors if the nonce would overflow. Saturating instead would report
-    /// success while leaving the nonce unchanged, so every later transaction
-    /// would silently reuse it.
+    /// Increment `principal`'s nonce, returning an error on overflow.
     pub fn increment_nonce(&mut self, principal: &PrincipalData) -> Result<u64, String> {
         let mut conn = ClarityDatabase::new(
             &mut self.clarity_datastore,
@@ -1529,11 +1463,7 @@ impl ClarityInterpreter {
         Ok(next)
     }
 
-    /// Drive a principal's nonce straight to `nonce`.
-    ///
-    /// Nothing reachable from the public API can do this — the only writer is
-    /// `increment_nonce`, one step at a time — so the failure paths that depend
-    /// on a nonce's value are otherwise unreachable from a test.
+    /// Set a nonce directly so tests can exercise overflow handling.
     #[cfg(test)]
     pub(crate) fn force_nonce(&mut self, principal: &PrincipalData, nonce: u64) {
         let mut conn = ClarityDatabase::new(
@@ -1804,16 +1734,10 @@ mod tests {
         ));
     }
 
-    /// Pin both directions of the delegation to `clarity`.
-    ///
-    /// Rejected failures — cost overruns, resource-budget exhaustion — are
-    /// impractical to provoke from contract source, so the end-to-end tests
-    /// reach only included ones: without this, mapping *everything* to
-    /// `Included` would pass the whole suite. Which variants fall on which
-    /// side is upstream's business; this only checks that clarinet asks the
-    /// right classifier and reads the answer the right way round.
     #[test]
     fn block_inclusion_delegates_to_clarity() {
+        // Cover both classifier outcomes; end-to-end tests cannot easily
+        // provoke rejected cost/resource failures from contract source.
         use clarity::vm::analysis::errors::{StaticCheckError, StaticCheckErrorKind};
         use clarity::vm::errors::{RuntimeError, VmExecutionError};
 

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -69,6 +69,19 @@ impl BlockInclusion {
         Self::from(handle_clarity_analysis_error(error, epoch).is_included_in_block())
     }
 
+    /// Classify a preflight rejection as the equivalent VM error.
+    pub fn from_uncallable_function(contract: &str, function: &str, epoch: StacksEpochId) -> Self {
+        Self::from_runtime_error(
+            ClarityError::Interpreter(VmExecutionError::RuntimeCheck(
+                RuntimeCheckErrorKind::NoSuchPublicFunction(
+                    contract.to_string(),
+                    function.to_string(),
+                ),
+            )),
+            epoch,
+        )
+    }
+
     pub fn is_included(self) -> bool {
         self == BlockInclusion::Included
     }

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -2339,6 +2339,79 @@ mod tests {
     }
 
     #[test]
+    fn a_rejectable_parse_error_outranks_a_non_rejectable_analysis_error() {
+        // Before epoch 3.4, excessive nesting is rejectable but a type error is
+        // included. Parsing must therefore determine the nonce disposition.
+        // Put the nesting second so the partial AST also contains the type error;
+        // otherwise the test would pass even if analysis ran first.
+        let deep = format!("{}u1{}", "(+ u1 ".repeat(200), ")".repeat(200));
+        let bad_types = "(define-read-only (b) (no-such-function u1))";
+
+        let deploy = |epoch: StacksEpochId, name: &str, source: &str| {
+            let mut session = Session::new(SessionSettings::default());
+            let deployer = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+            session.update_epoch(epoch);
+            let addr = principal(deployer);
+            let before = session.get_nonce(&addr).unwrap();
+            let contract = ClarityContractBuilder::new()
+                .name(name)
+                .deployer(deployer)
+                .epoch(epoch)
+                .clarity_version(ClarityVersion::default_for_epoch(epoch))
+                .code_source(source.to_string())
+                .build();
+            let result = session.deploy_contract(&contract, false, None);
+            let after = session.get_nonce(&addr).unwrap();
+            assert!(
+                result.is_err(),
+                "{epoch} {name}: the deploy must fail, or the nonce assertion is vacuous"
+            );
+            after - before
+        };
+
+        for epoch in [StacksEpochId::Epoch25, StacksEpochId::Epoch30] {
+            // Ensure the individual errors receive different dispositions.
+            assert_eq!(
+                deploy(epoch, "types-only", bad_types),
+                1,
+                "{epoch}: a type error alone is not rejectable, so mainnet mines it"
+            );
+            assert_eq!(
+                deploy(
+                    epoch,
+                    "deep-only",
+                    &format!("(define-read-only (d) {deep})")
+                ),
+                0,
+                "{epoch}: a depth error alone is rejectable, so mainnet drops it"
+            );
+
+            // Parsing takes precedence when both errors are present.
+            assert_eq!(
+                deploy(
+                    epoch,
+                    "both",
+                    &format!("{bad_types}\n(define-read-only (d) {deep})")
+                ),
+                0,
+                "{epoch}: the rejectable parse error must outrank the analysis error"
+            );
+        }
+
+        // From epoch 3.4, this depth error is included and consumes a nonce.
+        let epoch = StacksEpochId::Epoch34;
+        assert_eq!(
+            deploy(
+                epoch,
+                "both-late-epoch",
+                &format!("{bad_types}\n(define-read-only (d) {deep})")
+            ),
+            1,
+            "{epoch}: depth errors are no longer rejectable, so this is mined"
+        );
+    }
+
+    #[test]
     fn test_eval_clarity_string() {
         let mut session = Session::new(SessionSettings::default());
         let epoch = StacksEpochId::Epoch25;

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use super::diagnostic::output_diagnostic;
 use super::hooks::logger::LoggerHook;
 use super::hooks::perf::{CostField, PerfHook};
-use super::interpreter::ContractCallError;
+use super::interpreter::{ContractCallError, ExecutionError};
 use super::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Epoch,
     SessionSettings,
@@ -120,14 +120,14 @@ fn deploy_boot_contracts(
         }
         let result = interpreter.run(contract, Some(ast), false, None);
         if let Err(errs) = &result {
-            for e in errs {
+            for e in &errs.diagnostics {
                 ueprint!(
                     "Error deploying sbtc boot contract {contract_id}: {}",
                     e.message
                 );
             }
         }
-        boot_contracts.insert(contract_id.clone(), result);
+        boot_contracts.insert(contract_id.clone(), result.map_err(Vec::from));
     }
 
     // Load boot contracts (with custom overrides if specified)
@@ -147,11 +147,11 @@ fn deploy_boot_contracts(
         }
         let result = interpreter.run(&contract, Some(&ast), false, None);
         if let Err(errs) = &result {
-            for e in errs {
+            for e in &errs.diagnostics {
                 ueprint!("Error deploying boot contract {contract_id}: {}", e.message);
             }
         }
-        boot_contracts.insert(contract_id, result);
+        boot_contracts.insert(contract_id, result.map_err(Vec::from));
     }
     boot_contracts
 }
@@ -187,14 +187,14 @@ fn deploy_boot_contracts_for_range(
         }
         let result = interpreter.run(contract, Some(ast), false, None);
         if let Err(errs) = &result {
-            for e in errs {
+            for e in &errs.diagnostics {
                 ueprint!(
                     "Error deploying sbtc boot contract {contract_id}: {}",
                     e.message
                 );
             }
         }
-        newly_deployed.insert(contract_id.clone(), result);
+        newly_deployed.insert(contract_id.clone(), result.map_err(Vec::from));
     }
 
     // Deploy regular boot contracts that fall in the range
@@ -215,11 +215,11 @@ fn deploy_boot_contracts_for_range(
             }
             let result = interpreter.run(&contract, Some(&ast), false, None);
             if let Err(errs) = &result {
-                for e in errs {
+                for e in &errs.diagnostics {
                     ueprint!("Error deploying boot contract {contract_id}: {}", e.message);
                 }
             }
-            newly_deployed.insert(contract_id, result);
+            newly_deployed.insert(contract_id, result.map_err(Vec::from));
         }
     }
 
@@ -702,8 +702,16 @@ impl Session {
         amount: u64,
         recipient: &str,
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
+        let sender = self.interpreter.get_tx_sender();
         let snippet = format!("(stx-transfer? u{amount} tx-sender '{recipient})");
-        self.eval(snippet, false)
+        let result = self.eval_with_inclusion(snippet, false);
+
+        // An STX transfer is a transaction and consumes a nonce. The bump lives
+        // here rather than in `eval`, which also backs bare snippets and
+        // function-argument evaluation — neither of which is a transaction.
+        self.bump_nonce_if_included(sender.into(), &result);
+
+        result.map_err(Vec::from)
     }
 
     pub fn deploy_contract(
@@ -755,12 +763,21 @@ impl Session {
 
         let result = self.interpreter.run(contract, ast, cost_track, Some(hooks));
 
-        result.inspect(|result| {
-            if let EvaluationResult::Contract(contract_result) = &result.result {
-                self.contracts
-                    .insert(contract_id.clone(), contract_result.contract.clone());
-            }
-        })
+        // A contract deploy is a transaction and consumes a nonce. This covers
+        // both the boot deployment plan and `simnet.deployContract`. System boot
+        // contracts (pox, sbtc, …) bypass this method and call `interpreter.run`
+        // directly, so they correctly stay at nonce 0 — on mainnet they are
+        // genesis state, not transactions.
+        self.bump_nonce_if_included(contract_id.issuer.clone().into(), &result);
+
+        result
+            .inspect(|result| {
+                if let EvaluationResult::Contract(contract_result) = &result.result {
+                    self.contracts
+                        .insert(contract_id.clone(), contract_result.contract.clone());
+                }
+            })
+            .map_err(Vec::from)
     }
 
     pub fn call_contract_fn(
@@ -771,16 +788,17 @@ impl Session {
         sender: &str,
         allow_private: bool,
         track_costs: bool,
-    ) -> Result<ExecutionResult, Vec<Diagnostic>> {
+    ) -> Result<ExecutionResult, ExecutionError> {
         let initial_tx_sender = self.get_tx_sender();
 
+        // An unresolvable contract id never became a transaction at all.
         let contract_id = Self::desugar_contract_id(&initial_tx_sender, contract).map_err(|e| {
-            vec![Diagnostic {
+            ExecutionError::rejected(vec![Diagnostic {
                 level: Level::Error,
                 message: e,
                 spans: vec![],
                 suggestion: None,
-            }]
+            }])
         })?;
 
         self.set_tx_sender(sender);
@@ -811,13 +829,13 @@ impl Session {
         self.set_tx_sender(&initial_tx_sender);
         self.last_contract_call_trace = Some(tracer_hook.output.join("\n"));
 
-        contract_call_result.map_err(|e| {
+        contract_call_result.map_err(|failure| {
             ueprint!("{}", tracer_hook.output.join("\n"));
             if let Some(traced_error) = tracer_hook.error {
                 ueprint!("{}", traced_error);
             }
             let contract_id_str = contract_id.to_string();
-            let user_friendly_message = match e {
+            let user_friendly_message = match failure.error {
                 ContractCallError::NoSuchContract(_) => {
                     format!("Contract '{contract_id_str}' does not exist")
                 }
@@ -828,12 +846,15 @@ impl Session {
                     format!("Error calling contract function '{method}': {message}")
                 }
             };
-            vec![Diagnostic {
-                level: Level::Error,
-                message: user_friendly_message,
-                spans: vec![],
-                suggestion: None,
-            }]
+            ExecutionError {
+                diagnostics: vec![Diagnostic {
+                    level: Level::Error,
+                    message: user_friendly_message,
+                    spans: vec![],
+                    suggestion: None,
+                }],
+                inclusion: failure.inclusion,
+            }
         })
     }
 
@@ -843,6 +864,22 @@ impl Session {
         snippet: String,
         cost_track: bool,
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
+        self.eval_with_inclusion(snippet, cost_track)
+            .map_err(Vec::from)
+    }
+
+    /// `eval`, but keeping the block-inclusion verdict of a failure.
+    ///
+    /// Only callers that know they are running a *transaction* need this —
+    /// today just `stx_transfer`. `eval` also backs bare REPL snippets and
+    /// function-argument evaluation, which are not transactions, so its public
+    /// signature stays diagnostics-only rather than inviting callers to make
+    /// that judgement.
+    fn eval_with_inclusion(
+        &mut self,
+        snippet: String,
+        cost_track: bool,
+    ) -> Result<AnnotatedExecutionResult, ExecutionError> {
         let current_epoch = self.interpreter.datastore.get_current_epoch();
         let contract = ClarityContract {
             code_source: ClarityCodeSource::ContractInMemory(snippet),
@@ -918,7 +955,7 @@ impl Session {
                 };
                 Ok(result)
             }
-            Err(res) => Err(res),
+            Err(res) => Err(res.into()),
         }
     }
 
@@ -1182,6 +1219,25 @@ impl Session {
     pub fn bump_nonce(&mut self, principal: PrincipalData) {
         if let Err(e) = self.interpreter.increment_nonce(&principal) {
             ueprint!("Failed to bump nonce for {principal}: {e}");
+        }
+    }
+
+    /// Bump `sender`'s nonce if the operation made it into a block.
+    ///
+    /// A failure is not the same as a rejection: mainnet mines a transaction
+    /// that reverts, charging its fee and consuming its nonce. Which failures
+    /// those are is decided by `clarity`, not here — see [`BlockInclusion`].
+    fn bump_nonce_if_included<T>(
+        &mut self,
+        sender: PrincipalData,
+        result: &Result<T, ExecutionError>,
+    ) {
+        let included = match result {
+            Ok(_) => true,
+            Err(e) => e.inclusion.is_included(),
+        };
+        if included {
+            self.bump_nonce(sender);
         }
     }
 
@@ -1649,8 +1705,8 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_execution_result_value(
-        result: &Result<ExecutionResult, Vec<Diagnostic>>,
+    fn assert_execution_result_value<E: std::fmt::Debug>(
+        result: &Result<ExecutionResult, E>,
         expected_value: Value,
     ) {
         assert!(result.is_ok());
@@ -1921,6 +1977,258 @@ mod tests {
             err.first().unwrap().message,
             "contract epoch (2.5) does not match current epoch (2.4)"
         );
+    }
+
+    #[track_caller]
+    fn principal(addr: &str) -> PrincipalData {
+        PrincipalData::parse_standard_principal(addr)
+            .expect("valid principal")
+            .into()
+    }
+
+    /// Deploy `source` as a fresh contract and report the deployer's nonce
+    /// before and after. Each call uses a distinct contract name so a test can
+    /// deploy repeatedly without tripping the duplicate-contract rule.
+    #[track_caller]
+    fn deploy_and_read_nonce(
+        session: &mut Session,
+        deployer: &str,
+        name: &str,
+        source: &str,
+    ) -> (u64, u64, Result<AnnotatedExecutionResult, Vec<Diagnostic>>) {
+        let addr = principal(deployer);
+        let before = session.get_nonce(&addr).unwrap();
+        let contract = ClarityContractBuilder::new()
+            .name(name)
+            .deployer(deployer)
+            .code_source(source.to_string())
+            .build();
+        let result = session.deploy_contract(&contract, false, None);
+        let after = session.get_nonce(&addr).unwrap();
+        (before, after, result)
+    }
+
+    #[test]
+    fn deploying_a_contract_bumps_the_deployer_nonce() {
+        let mut session = Session::new(SessionSettings::default());
+        let deployer = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let addr = principal(deployer);
+
+        // Match the epoch `ClarityContractBuilder` defaults to.
+        session.update_epoch(DEFAULT_EPOCH);
+
+        assert_eq!(session.get_nonce(&addr).unwrap(), 0);
+
+        for expected_nonce in 1..=2 {
+            let contract = ClarityContractBuilder::new()
+                .name(&format!("counter-{expected_nonce}"))
+                .deployer(deployer)
+                .build();
+            session.deploy_contract(&contract, false, None).unwrap();
+
+            assert_eq!(session.get_nonce(&addr).unwrap(), expected_nonce);
+        }
+    }
+
+    #[test]
+    fn a_rejected_deploy_does_not_bump_the_deployer_nonce() {
+        let mut session = Session::new(SessionSettings::default());
+        let deployer = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let addr = principal(deployer);
+
+        session.update_epoch(StacksEpochId::Epoch24);
+
+        // An epoch mismatch is rejected before execution, which is the simnet
+        // analogue of an invalid transaction: mainnet consumes no nonce.
+        let contract = ClarityContractBuilder::new()
+            .deployer(deployer)
+            .epoch(StacksEpochId::Epoch25)
+            .clarity_version(ClarityVersion::Clarity2)
+            .build();
+        assert!(session.deploy_contract(&contract, false, None).is_err());
+
+        assert_eq!(session.get_nonce(&addr).unwrap(), 0);
+    }
+
+    #[test]
+    fn boot_contracts_do_not_bump_a_nonce() {
+        // Boot contracts are genesis state on mainnet, not transactions, and
+        // they bypass `deploy_contract` entirely.
+        let mut session = Session::new(SessionSettings::default());
+
+        for addr in [BOOT_MAINNET_ADDRESS, BOOT_TESTNET_ADDRESS] {
+            assert_eq!(session.get_nonce(&principal(addr)).unwrap(), 0);
+        }
+    }
+
+    #[test]
+    fn calling_a_contract_function_does_not_bump_a_nonce_on_its_own() {
+        // `Session::call_contract_fn` is a primitive shared by transactions and
+        // read-only queries, so it must stay nonce-neutral — the bump is the
+        // caller's job (see `Session::bump_nonce_if_included`). This is what
+        // makes `simnet.callReadOnlyFn` safe. If this test fails because a bump
+        // was added here, read-only calls have started consuming nonces.
+        let mut session = Session::new(SessionSettings::default());
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let addr = principal(sender);
+
+        session.update_epoch(DEFAULT_EPOCH);
+
+        let contract = ClarityContractBuilder::new().deployer(sender).build();
+        session.deploy_contract(&contract, false, None).unwrap();
+        let after_deploy = session.get_nonce(&addr).unwrap();
+        assert_eq!(after_deploy, 1, "the deploy itself is a transaction");
+
+        // `get-x` is read-only and `incr` is public: neither bumps from here.
+        for (method, expected) in [
+            ("get-x", Value::UInt(0)),
+            ("incr", Value::okay(Value::UInt(1)).unwrap()),
+        ] {
+            let result = session
+                .call_contract_fn(
+                    &format!("{sender}.contract"),
+                    method,
+                    &[],
+                    sender,
+                    false,
+                    false,
+                )
+                .unwrap_or_else(|e| panic!("{method} should execute: {e:?}"));
+
+            // Assert the call really ran, so the nonce check below is not
+            // vacuously true.
+            match result.result {
+                EvaluationResult::Snippet(res) => assert_eq!(res.result, expected),
+                EvaluationResult::Contract(_) => unreachable!("not a deploy"),
+            }
+            assert_eq!(session.get_nonce(&addr).unwrap(), after_deploy);
+        }
+    }
+
+    #[test]
+    fn evaluating_a_snippet_does_not_bump_a_nonce() {
+        // `eval` also backs bare REPL snippets and function-argument
+        // evaluation, neither of which is a transaction.
+        let mut session = Session::new(SessionSettings::default());
+        let sender = principal(&session.get_tx_sender());
+
+        let before = session.get_nonce(&sender).unwrap();
+        session.eval_clarity_string("u1");
+        let _ = session.eval("(+ 1 2)".to_string(), false);
+
+        assert_eq!(session.get_nonce(&sender).unwrap(), before);
+    }
+
+    #[test]
+    fn stx_transfer_bumps_the_sender_nonce() {
+        let mut session = Session::new(SessionSettings::default());
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
+        let addr = principal(sender);
+
+        session
+            .interpreter
+            .mint_stx_balance(addr.clone(), 1_000_000)
+            .unwrap();
+        session.set_tx_sender(sender);
+
+        assert_eq!(session.get_nonce(&addr).unwrap(), 0);
+
+        session.stx_transfer(1000, recipient).unwrap();
+
+        assert_eq!(session.get_nonce(&addr).unwrap(), 1);
+        // The recipient sent nothing, so it owes no nonce.
+        assert_eq!(session.get_nonce(&principal(recipient)).unwrap(), 0);
+    }
+
+    #[test]
+    fn a_failed_stx_transfer_bumps_the_sender_nonce() {
+        // `stx-transfer?` reports insufficient funds as an `(err …)` response,
+        // not a VM failure, so the transaction succeeded as far as the chain is
+        // concerned. Mainnet mines it and charges the nonce.
+        let mut session = Session::new(SessionSettings::default());
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let addr = principal(sender);
+
+        session.set_tx_sender(sender);
+        assert_eq!(session.get_nonce(&addr).unwrap(), 0);
+
+        let result = session
+            .stx_transfer(1000, "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG")
+            .expect("an underfunded transfer still executes");
+        match result.execution_result.result {
+            EvaluationResult::Snippet(res) => {
+                assert!(
+                    matches!(res.result, Value::Response(ref r) if !r.committed),
+                    "expected an (err …) response, got {:?}",
+                    res.result
+                );
+            }
+            EvaluationResult::Contract(_) => unreachable!("not a deploy"),
+        }
+
+        assert_eq!(session.get_nonce(&addr).unwrap(), 1);
+    }
+
+    /// The three cases below are the divergences the old nonce implementation
+    /// got wrong by keying the bump off `result.is_ok()`. Clarinet reports a
+    /// failure for each, but mainnet still mines the transaction, so each must
+    /// consume a nonce. The verdict comes from `clarity`'s classifiers — see
+    /// `BlockInclusion`.
+    #[test]
+    fn a_deploy_that_fails_at_runtime_bumps_the_deployer_nonce() {
+        let mut session = Session::new(SessionSettings::default());
+        let deployer = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        session.update_epoch(DEFAULT_EPOCH);
+
+        // Divide by zero at the top level: `Runtime` → `Acceptable` → included.
+        let (before, after, result) =
+            deploy_and_read_nonce(&mut session, deployer, "div-zero", "(/ u1 u0)");
+        assert!(result.is_err(), "the deploy must still be reported failed");
+        assert_eq!(after, before + 1, "divide-by-zero is included in a block");
+
+        // `unwrap-panic` on `none`: `EarlyReturn` → `Acceptable` → included.
+        let (before, after, result) =
+            deploy_and_read_nonce(&mut session, deployer, "panics", "(unwrap-panic none)");
+        assert!(result.is_err(), "the deploy must still be reported failed");
+        assert_eq!(after, before + 1, "unwrap-panic is included in a block");
+    }
+
+    #[test]
+    fn a_deploy_that_fails_analysis_bumps_the_deployer_nonce() {
+        let mut session = Session::new(SessionSettings::default());
+        let deployer = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        session.update_epoch(DEFAULT_EPOCH);
+
+        // An ordinary type error is not `rejectable_in_epoch`, so mainnet mines
+        // the deploy and it fails. This is the case the deploy path gets wrong
+        // without `handle_clarity_analysis_error`, since it never routes through
+        // the runtime classifier.
+        let (before, after, result) = deploy_and_read_nonce(
+            &mut session,
+            deployer,
+            "bad-types",
+            "(define-read-only (f) (no-such-function u1))",
+        );
+        assert!(result.is_err(), "the deploy must still be reported failed");
+        assert_eq!(after, before + 1, "an analysis failure is included");
+    }
+
+    #[test]
+    fn a_deploy_that_fails_to_parse_bumps_the_deployer_nonce() {
+        let mut session = Session::new(SessionSettings::default());
+        let deployer = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        session.update_epoch(DEFAULT_EPOCH);
+
+        // An ordinary syntax error is not `rejectable_in_epoch` either.
+        let (before, after, result) = deploy_and_read_nonce(
+            &mut session,
+            deployer,
+            "unbalanced",
+            "(define-read-only (f)",
+        );
+        assert!(result.is_err(), "the deploy must still be reported failed");
+        assert_eq!(after, before + 1, "an ordinary parse failure is included");
     }
 
     #[test]
@@ -2380,7 +2688,7 @@ mod tests {
         );
 
         assert!(result.is_err());
-        let diagnostics = result.unwrap_err();
+        let diagnostics = result.unwrap_err().diagnostics;
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
             diagnostics[0].message,

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -238,9 +238,10 @@ impl AnnotatedExecutionResult {
 pub enum CallKind {
     /// A transaction sent by `sender`, consuming one of its nonces.
     Transaction,
-    /// Not a transaction: a read-only query, or session setup that stands in
-    /// for genesis state rather than for something anyone sent.
-    Free,
+    /// Not a transaction, so no nonce moves: a read-only query, or session
+    /// setup that stands in for genesis state rather than for something
+    /// anyone sent.
+    NonceFree,
 }
 
 #[derive(Clone)]
@@ -834,7 +835,7 @@ impl Session {
         // charged is exactly the one the call runs as.
         let charge = match kind {
             CallKind::Transaction => NonceCharge::Sender(self.interpreter.get_tx_sender().into()),
-            CallKind::Free => NonceCharge::Free,
+            CallKind::NonceFree => NonceCharge::Free,
         };
 
         let current_epoch = self.interpreter.datastore.get_current_epoch();
@@ -2079,7 +2080,7 @@ mod tests {
                     sender,
                     false,
                     false,
-                    CallKind::Free,
+                    CallKind::NonceFree,
                 )
                 .unwrap_or_else(|e| panic!("{method} should execute: {e:?}"));
 
@@ -2175,7 +2176,7 @@ mod tests {
                 sender,
                 false,
                 false,
-                CallKind::Free,
+                CallKind::NonceFree,
             )
             .expect_err("a call to a missing contract must fail");
 
@@ -2268,7 +2269,7 @@ mod tests {
                 sender,
                 false,
                 false,
-                CallKind::Free,
+                CallKind::NonceFree,
             )
             .expect("a read-only call charges nothing and still works");
         match result.result {
@@ -2476,7 +2477,7 @@ mod tests {
             BOOT_TESTNET_ADDRESS,
             false,
             false,
-            CallKind::Free,
+            CallKind::NonceFree,
         );
         assert_execution_result_value(
             &result,
@@ -2540,7 +2541,7 @@ mod tests {
             BOOT_MAINNET_ADDRESS,
             false,
             false,
-            CallKind::Free,
+            CallKind::NonceFree,
         );
         assert_execution_result_value(&result, Value::okay(Value::Bool(true)).unwrap());
 
@@ -2552,7 +2553,7 @@ mod tests {
             BOOT_MAINNET_ADDRESS,
             false,
             false,
-            CallKind::Free,
+            CallKind::NonceFree,
         );
         assert_execution_result_value(&result, Value::UInt(1));
 
@@ -2564,7 +2565,7 @@ mod tests {
             BOOT_MAINNET_ADDRESS,
             false,
             false,
-            CallKind::Free,
+            CallKind::NonceFree,
         );
         assert!(result.is_ok());
     }
@@ -2586,7 +2587,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
-            CallKind::Free,
+            CallKind::NonceFree,
         );
         assert_execution_result_value(&result, Value::okay(Value::UInt(1)).unwrap());
 
@@ -2597,7 +2598,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
-            CallKind::Free,
+            CallKind::NonceFree,
         );
         assert_execution_result_value(&result, Value::UInt(1));
     }
@@ -2797,7 +2798,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
-            CallKind::Free,
+            CallKind::NonceFree,
         );
 
         assert!(result.is_err());

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -7,9 +7,10 @@ use clarity::codec::StacksMessageCodec;
 use clarity::types::StacksEpochId;
 use clarity::vm::ast::ContractAST;
 use clarity::vm::diagnostic::{Diagnostic, Level};
+use clarity::vm::hooks::EvalHook;
 use clarity::vm::{
-    ClarityName, ClarityVersion, CostSynthesis, EvalHook, EvaluationResult, ExecutionResult,
-    ParsedContract, SymbolicExpression,
+    ClarityName, ClarityVersion, CostSynthesis, EvaluationResult, ExecutionResult, ParsedContract,
+    SymbolicExpression,
 };
 use clarity_types::types::{AssetIdentifier, PrincipalData, QualifiedContractIdentifier};
 use clarity_types::Value;
@@ -1773,11 +1774,33 @@ mod tests {
             initial_block_height + 1
         );
 
-        // ensure latest epoch is correctly handled
-        let latest_epoch = StacksEpochId::latest().to_string();
-        session.handle_command(&format!("::set_epoch {latest_epoch}"));
+        // The latest epoch clarinet supports, which deliberately trails
+        // `StacksEpochId::latest()` until an epoch is adopted here — adoption
+        // means `epoch_from_str`, `EpochSpec`, and the devnet config, not just
+        // the interpreter.
+        let supported_latest = DEFAULT_EPOCH.to_string();
+        session.handle_command(&format!("::set_epoch {supported_latest}"));
         let current_epoch = session.handle_command("::get_epoch");
-        assert_eq!(current_epoch, format!("Current epoch: {latest_epoch}"));
+        assert_eq!(current_epoch, format!("Current epoch: {supported_latest}"));
+
+        // Canary for upstream adding an epoch. Clarinet supports through 4.0;
+        // 4.1 exists upstream but is not adopted here. If this fails, upstream
+        // has moved again — adopt the pending epoch, or re-pin this and say why.
+        assert_eq!(
+            StacksEpochId::latest(),
+            StacksEpochId::Epoch41,
+            "upstream added an epoch past the one clarinet knows is pending"
+        );
+
+        // An unadopted epoch is reported as unusable rather than silently
+        // ignored, so the session never lands somewhere the caller didn't ask for.
+        let result = session.handle_command("::set_epoch 4.1");
+        assert!(
+            result.contains("Usage:"),
+            "expected usage error, got: {result}"
+        );
+        let current_epoch = session.handle_command("::get_epoch");
+        assert_eq!(current_epoch, format!("Current epoch: {supported_latest}"));
     }
 
     #[test]

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use super::diagnostic::output_diagnostic;
 use super::hooks::logger::LoggerHook;
 use super::hooks::perf::{CostField, PerfHook};
-use super::interpreter::{BlockInclusion, ContractCallError, ExecutionError};
+use super::interpreter::{ContractCallError, ExecutionError, NonceCharge};
 use super::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Epoch,
     SessionSettings,
@@ -231,6 +231,19 @@ impl AnnotatedExecutionResult {
     pub fn into_inner(self) -> ExecutionResult {
         self.execution_result
     }
+}
+
+/// Whether a [`Session::call_contract_fn`] is a transaction from its sender.
+///
+/// The same primitive backs `simnet.callPublicFn` and `simnet.callReadOnlyFn`,
+/// and only the first sends anything, so the caller has to say which it is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallKind {
+    /// A transaction sent by `sender`, consuming one of its nonces.
+    Transaction,
+    /// Not a transaction: a read-only query, or session setup that stands in
+    /// for genesis state rather than for something anyone sent.
+    Free,
 }
 
 #[derive(Clone)]
@@ -704,15 +717,12 @@ impl Session {
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
         let sender = self.interpreter.get_tx_sender();
         let snippet = format!("(stx-transfer? u{amount} tx-sender '{recipient})");
-        let result = self.eval_with_inclusion(snippet, false);
 
-        // An STX transfer is a transaction and consumes a nonce. The bump lives
-        // here rather than in `eval`, which also backs bare snippets and
-        // function-argument evaluation — neither of which is a transaction.
-        self.bump_nonce_if_included(sender.into(), &result)
-            .map_err(Self::nonce_failure)?;
-
-        result.map_err(Vec::from)
+        // An STX transfer is a transaction and consumes a nonce. `eval` also
+        // backs bare snippets and function-argument evaluation, neither of
+        // which is one, so the charge is named here.
+        self.eval_with_inclusion(snippet, false, NonceCharge::Sender(sender.into()))
+            .map_err(Vec::from)
     }
 
     pub fn deploy_contract(
@@ -762,15 +772,18 @@ impl Session {
         let contract_id =
             contract.expect_resolved_contract_identifier(Some(&self.interpreter.get_tx_sender()));
 
-        let result = self.interpreter.run(contract, ast, cost_track, Some(hooks));
-
         // A contract deploy is a transaction and consumes a nonce. This covers
         // both the boot deployment plan and `simnet.deployContract`. System boot
         // contracts (pox, sbtc, …) bypass this method and call `interpreter.run`
         // directly, so they correctly stay at nonce 0 — on mainnet they are
         // genesis state, not transactions.
-        self.bump_nonce_if_included(contract_id.issuer.clone().into(), &result)
-            .map_err(Self::nonce_failure)?;
+        let result = self.interpreter.run_transaction(
+            contract,
+            ast,
+            cost_track,
+            Some(hooks),
+            contract_id.issuer.clone().into(),
+        );
 
         result
             .inspect(|result| {
@@ -782,6 +795,14 @@ impl Session {
             .map_err(Vec::from)
     }
 
+    /// Call `method` on `contract` as `sender`.
+    ///
+    /// `kind` decides whether this is a transaction: the same primitive backs
+    /// `simnet.callPublicFn` and `simnet.callReadOnlyFn`, and only the first
+    /// sends anything. The nonce is charged inside the call's own database
+    /// transaction, so it can never be recorded without the call's effects or
+    /// the other way round.
+    #[allow(clippy::too_many_arguments)]
     pub fn call_contract_fn(
         &mut self,
         contract: &str,
@@ -790,6 +811,7 @@ impl Session {
         sender: &str,
         allow_private: bool,
         track_costs: bool,
+        kind: CallKind,
     ) -> Result<ExecutionResult, ExecutionError> {
         let initial_tx_sender = self.get_tx_sender();
 
@@ -817,6 +839,13 @@ impl Session {
             hooks.push(perf_hook);
         }
 
+        // Taken from the interpreter rather than re-parsed, so the principal
+        // charged is exactly the one the call runs as.
+        let charge = match kind {
+            CallKind::Transaction => NonceCharge::Sender(self.interpreter.get_tx_sender().into()),
+            CallKind::Free => NonceCharge::Free,
+        };
+
         let current_epoch = self.interpreter.datastore.get_current_epoch();
         let contract_call_result = self.interpreter.call_contract_fn(
             &contract_id,
@@ -827,6 +856,7 @@ impl Session {
             track_costs,
             allow_private,
             hooks,
+            &charge,
         );
         self.set_tx_sender(&initial_tx_sender);
         self.last_contract_call_trace = Some(tracer_hook.output.join("\n"));
@@ -866,7 +896,7 @@ impl Session {
         snippet: String,
         cost_track: bool,
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
-        self.eval_with_inclusion(snippet, cost_track)
+        self.eval_with_inclusion(snippet, cost_track, NonceCharge::Free)
             .map_err(Vec::from)
     }
 
@@ -881,6 +911,7 @@ impl Session {
         &mut self,
         snippet: String,
         cost_track: bool,
+        charge: NonceCharge,
     ) -> Result<AnnotatedExecutionResult, ExecutionError> {
         let current_epoch = self.interpreter.datastore.get_current_epoch();
         let contract = ClarityContract {
@@ -905,9 +936,9 @@ impl Session {
             hooks.push(perf_hook);
         }
 
-        let result = self
-            .interpreter
-            .run(&contract, None, cost_track, Some(hooks));
+        let result =
+            self.interpreter
+                .run_with_charge(&contract, None, cost_track, Some(hooks), &charge);
 
         result.inspect(|result| {
             if let EvaluationResult::Contract(contract_result) = &result.result {
@@ -1208,47 +1239,18 @@ impl Session {
         self.interpreter.get_nonce(principal)
     }
 
-    /// Bump the nonce of `principal` after a transaction it sent.
+    /// Charge `principal` a nonce for a transaction that never reached the VM.
     ///
-    /// Callers are the ones that know whether an operation is a transaction:
-    /// `call_contract_fn` is deliberately not one of them, because it also
-    /// backs `simnet.callReadOnlyFn`, and a read-only call is not a
-    /// transaction. See `inner_call_public_fn` / `inner_call_private_fn` in
-    /// `clarinet-sdk-wasm`, which do know.
-    pub fn bump_nonce(&mut self, principal: PrincipalData) -> Result<u64, String> {
-        self.interpreter.increment_nonce(&principal)
-    }
-
-    /// Bump `sender`'s nonce if the operation made it into a block.
-    ///
-    /// A failure is not the same as a rejection: mainnet mines a transaction
-    /// that reverts, charging its fee and consuming its nonce. Which failures
-    /// those are is decided by `clarity`, not here — see [`BlockInclusion`].
-    ///
-    /// The bump itself can fail — a remote-data session reads the nonce of a
-    /// non-local principal over the network. That is a broken session, not a
-    /// rejected transaction, but it must not be swallowed: the operation has
-    /// already committed, so a dropped bump leaves the next transaction
-    /// reusing this one's nonce.
-    fn bump_nonce_if_included<T>(
+    /// The only caller is the SDK's access preflight, which rejects a call
+    /// mainnet would have mined before any execution happens. Nothing is
+    /// pending when this runs, so it cannot leave a nonce paired with
+    /// half-applied state — unlike a bump issued *after* an execution, which is
+    /// why every other path names a [`NonceCharge`] up front instead.
+    pub fn charge_nonce_without_execution(
         &mut self,
-        sender: PrincipalData,
-        result: &Result<T, ExecutionError>,
-    ) -> Result<(), String> {
-        if BlockInclusion::of_result(result).is_included() {
-            self.bump_nonce(sender)?;
-        }
-        Ok(())
-    }
-
-    /// Report a nonce bump that failed after its transaction had committed.
-    pub fn nonce_failure(error: String) -> Vec<Diagnostic> {
-        vec![Diagnostic {
-            level: Level::Error,
-            message: format!("Transaction succeeded but its nonce was not recorded: {error}"),
-            spans: vec![],
-            suggestion: None,
-        }]
+        principal: PrincipalData,
+    ) -> Result<u64, String> {
+        self.interpreter.increment_nonce(&principal)
     }
 
     pub fn get_contract_ast(
@@ -2100,6 +2102,7 @@ mod tests {
                     sender,
                     false,
                     false,
+                    CallKind::Free,
                 )
                 .unwrap_or_else(|e| panic!("{method} should execute: {e:?}"));
 
@@ -2202,6 +2205,7 @@ mod tests {
                 sender,
                 false,
                 false,
+                CallKind::Free,
             )
             .expect_err("a call to a missing contract must fail");
 
@@ -2211,30 +2215,112 @@ mod tests {
         );
     }
 
+    /// A transaction whose nonce cannot be written must not commit either.
+    ///
+    /// A charge can fail for real: a remote-data session reads the nonce of a
+    /// non-local principal over the network. Overflow is the one failure
+    /// reachable without a network, and it takes the same path — the charge is
+    /// applied to the transfer's own database transaction, just before the
+    /// commit that would have made both durable.
+    ///
+    /// The balances are what this test is really about. Reporting an error is
+    /// not enough: if the transfer had already moved STX, a caller retrying the
+    /// error would move it twice, and against a nonce that never advanced.
     #[test]
-    fn a_transaction_whose_nonce_cannot_be_recorded_is_not_reported_as_a_success() {
-        // A bump can fail for real: a remote-data session reads the nonce of a
-        // non-local principal over the network. Overflow is the one failure
-        // reachable without a network, and it exercises the same path — the
-        // transfer below commits, then the bump fails.
+    fn a_transaction_whose_nonce_cannot_be_recorded_does_not_commit() {
+        let mut session = Session::new(SessionSettings::default());
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
+        let addr = principal(sender);
+
+        session
+            .interpreter
+            .mint_stx_balance(addr.clone(), 1_000_000)
+            .unwrap();
+        session.set_tx_sender(sender);
+        session.interpreter.force_nonce(&addr, u64::MAX);
+
+        let sender_before = session.interpreter.get_balance_for_account(sender, "STX");
+
+        let diagnostics = session
+            .stx_transfer(1000, recipient)
+            .expect_err("a transfer whose nonce cannot be recorded is not a success");
+
+        let message = &diagnostics.last().expect("a diagnostic").message;
+        assert!(
+            message.contains("nonce overflow"),
+            "the failure must name its cause, got: {message}"
+        );
+
+        assert_eq!(
+            session.interpreter.get_balance_for_account(sender, "STX"),
+            sender_before,
+            "the transfer must be rolled back with the nonce, not left committed"
+        );
+        assert_eq!(
+            session
+                .interpreter
+                .get_balance_for_account(recipient, "STX"),
+            0,
+            "the recipient must not have been paid by a transaction that failed"
+        );
+        assert_eq!(
+            session.get_nonce(&addr).unwrap(),
+            u64::MAX,
+            "and the nonce must not have moved either"
+        );
+    }
+
+    /// The contract-call path has its own database transaction, so it needs its
+    /// own proof that a failed charge takes the call's state changes with it.
+    #[test]
+    fn a_contract_call_whose_nonce_cannot_be_recorded_does_not_commit() {
         let mut session = Session::new(SessionSettings::default());
         let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
         let addr = principal(sender);
 
-        session.set_tx_sender(sender);
+        session.update_epoch(DEFAULT_EPOCH);
+
+        let contract = ClarityContractBuilder::new().deployer(sender).build();
+        session.deploy_contract(&contract, false, None).unwrap();
+        let contract_id = format!("{sender}.contract");
+
+        // Only now, so the deploy above is unaffected.
         session.interpreter.force_nonce(&addr, u64::MAX);
 
-        let diagnostics = session
-            .stx_transfer(1000, "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG")
-            .expect_err("a transfer whose nonce cannot be recorded is not a success");
+        session
+            .call_contract_fn(
+                &contract_id,
+                "incr",
+                &[],
+                sender,
+                false,
+                false,
+                CallKind::Transaction,
+            )
+            .expect_err("a call whose nonce cannot be recorded is not a success");
 
-        // Silently swallowing this would leave the next transaction reusing
-        // this one's nonce, with nothing in the result to say so.
-        let message = &diagnostics.first().expect("a diagnostic").message;
-        assert!(
-            message.contains("nonce was not recorded"),
-            "the failure must name its cause, got: {message}"
-        );
+        // `incr` bumps a data var. If the call had committed while the nonce
+        // did not, this would read 1 and the next call would reuse the nonce.
+        let result = session
+            .call_contract_fn(
+                &contract_id,
+                "get-x",
+                &[],
+                sender,
+                false,
+                false,
+                CallKind::Free,
+            )
+            .expect("a read-only call charges nothing and still works");
+        match result.result {
+            EvaluationResult::Snippet(res) => assert_eq!(
+                res.result,
+                Value::UInt(0),
+                "the call must be rolled back with the nonce it could not record"
+            ),
+            EvaluationResult::Contract(_) => unreachable!("not a deploy"),
+        }
     }
 
     /// The three cases below are the divergences the old nonce implementation
@@ -2437,6 +2523,7 @@ mod tests {
             BOOT_TESTNET_ADDRESS,
             false,
             false,
+            CallKind::Free,
         );
         assert_execution_result_value(
             &result,
@@ -2500,6 +2587,7 @@ mod tests {
             BOOT_MAINNET_ADDRESS,
             false,
             false,
+            CallKind::Free,
         );
         assert_execution_result_value(&result, Value::okay(Value::Bool(true)).unwrap());
 
@@ -2511,6 +2599,7 @@ mod tests {
             BOOT_MAINNET_ADDRESS,
             false,
             false,
+            CallKind::Free,
         );
         assert_execution_result_value(&result, Value::UInt(1));
 
@@ -2522,6 +2611,7 @@ mod tests {
             BOOT_MAINNET_ADDRESS,
             false,
             false,
+            CallKind::Free,
         );
         assert!(result.is_ok());
     }
@@ -2543,6 +2633,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
+            CallKind::Free,
         );
         assert_execution_result_value(&result, Value::okay(Value::UInt(1)).unwrap());
 
@@ -2553,6 +2644,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
+            CallKind::Free,
         );
         assert_execution_result_value(&result, Value::UInt(1));
     }
@@ -2752,6 +2844,7 @@ mod tests {
             &session.get_tx_sender(),
             false,
             false,
+            CallKind::Free,
         );
 
         assert!(result.is_err());

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use super::diagnostic::output_diagnostic;
 use super::hooks::logger::LoggerHook;
 use super::hooks::perf::{CostField, PerfHook};
-use super::interpreter::{ContractCallError, ExecutionError};
+use super::interpreter::{BlockInclusion, ContractCallError, ExecutionError};
 use super::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Epoch,
     SessionSettings,
@@ -709,7 +709,8 @@ impl Session {
         // An STX transfer is a transaction and consumes a nonce. The bump lives
         // here rather than in `eval`, which also backs bare snippets and
         // function-argument evaluation — neither of which is a transaction.
-        self.bump_nonce_if_included(sender.into(), &result);
+        self.bump_nonce_if_included(sender.into(), &result)
+            .map_err(Self::nonce_failure)?;
 
         result.map_err(Vec::from)
     }
@@ -768,7 +769,8 @@ impl Session {
         // contracts (pox, sbtc, …) bypass this method and call `interpreter.run`
         // directly, so they correctly stay at nonce 0 — on mainnet they are
         // genesis state, not transactions.
-        self.bump_nonce_if_included(contract_id.issuer.clone().into(), &result);
+        self.bump_nonce_if_included(contract_id.issuer.clone().into(), &result)
+            .map_err(Self::nonce_failure)?;
 
         result
             .inspect(|result| {
@@ -1213,13 +1215,8 @@ impl Session {
     /// backs `simnet.callReadOnlyFn`, and a read-only call is not a
     /// transaction. See `inner_call_public_fn` / `inner_call_private_fn` in
     /// `clarinet-sdk-wasm`, which do know.
-    ///
-    /// A failure here means the datastore is unhealthy, not that the
-    /// transaction was invalid, so it is reported rather than propagated.
-    pub fn bump_nonce(&mut self, principal: PrincipalData) {
-        if let Err(e) = self.interpreter.increment_nonce(&principal) {
-            ueprint!("Failed to bump nonce for {principal}: {e}");
-        }
+    pub fn bump_nonce(&mut self, principal: PrincipalData) -> Result<u64, String> {
+        self.interpreter.increment_nonce(&principal)
     }
 
     /// Bump `sender`'s nonce if the operation made it into a block.
@@ -1227,18 +1224,31 @@ impl Session {
     /// A failure is not the same as a rejection: mainnet mines a transaction
     /// that reverts, charging its fee and consuming its nonce. Which failures
     /// those are is decided by `clarity`, not here — see [`BlockInclusion`].
+    ///
+    /// The bump itself can fail — a remote-data session reads the nonce of a
+    /// non-local principal over the network. That is a broken session, not a
+    /// rejected transaction, but it must not be swallowed: the operation has
+    /// already committed, so a dropped bump leaves the next transaction
+    /// reusing this one's nonce.
     fn bump_nonce_if_included<T>(
         &mut self,
         sender: PrincipalData,
         result: &Result<T, ExecutionError>,
-    ) {
-        let included = match result {
-            Ok(_) => true,
-            Err(e) => e.inclusion.is_included(),
-        };
-        if included {
-            self.bump_nonce(sender);
+    ) -> Result<(), String> {
+        if BlockInclusion::of_result(result).is_included() {
+            self.bump_nonce(sender)?;
         }
+        Ok(())
+    }
+
+    /// Report a nonce bump that failed after its transaction had committed.
+    pub fn nonce_failure(error: String) -> Vec<Diagnostic> {
+        vec![Diagnostic {
+            level: Level::Error,
+            message: format!("Transaction succeeded but its nonce was not recorded: {error}"),
+            spans: vec![],
+            suggestion: None,
+        }]
     }
 
     pub fn get_contract_ast(
@@ -2063,11 +2073,9 @@ mod tests {
 
     #[test]
     fn calling_a_contract_function_does_not_bump_a_nonce_on_its_own() {
-        // `Session::call_contract_fn` is a primitive shared by transactions and
-        // read-only queries, so it must stay nonce-neutral — the bump is the
-        // caller's job (see `Session::bump_nonce_if_included`). This is what
-        // makes `simnet.callReadOnlyFn` safe. If this test fails because a bump
-        // was added here, read-only calls have started consuming nonces.
+        // `Session::call_contract_fn` is shared by transactions and read-only
+        // queries, so it must stay nonce-neutral: the bump is the caller's job.
+        // A bump added here would make `simnet.callReadOnlyFn` consume nonces.
         let mut session = Session::new(SessionSettings::default());
         let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
         let addr = principal(sender);
@@ -2168,6 +2176,65 @@ mod tests {
         }
 
         assert_eq!(session.get_nonce(&addr).unwrap(), 1);
+    }
+
+    /// A contract-call naming a contract that was never deployed fails with
+    /// `NoSuchContract` on mainnet — a non-rejectable `RuntimeCheck`, so the
+    /// transaction is mined and charged.
+    ///
+    /// Simnet reaches that failure by a different route: `call_contract_fn`
+    /// enters with a contract id already in hand, so the metadata read fails
+    /// before any name resolution and `clarity` reports a `VmInternalError`,
+    /// which `handle_clarity_runtime_error` rejects. The disposition has to be
+    /// corrected for the route, or the call consumes nothing.
+    #[test]
+    fn a_call_to_a_contract_that_was_never_deployed_is_still_included() {
+        let mut session = Session::new(SessionSettings::default());
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+
+        session.update_epoch(DEFAULT_EPOCH);
+
+        let failure = session
+            .call_contract_fn(
+                &format!("{sender}.never-deployed"),
+                "whatever",
+                &[],
+                sender,
+                false,
+                false,
+            )
+            .expect_err("a call to a missing contract must fail");
+
+        assert!(
+            failure.inclusion.is_included(),
+            "mainnet mines a call to a missing contract and charges its nonce"
+        );
+    }
+
+    #[test]
+    fn a_transaction_whose_nonce_cannot_be_recorded_is_not_reported_as_a_success() {
+        // A bump can fail for real: a remote-data session reads the nonce of a
+        // non-local principal over the network. Overflow is the one failure
+        // reachable without a network, and it exercises the same path — the
+        // transfer below commits, then the bump fails.
+        let mut session = Session::new(SessionSettings::default());
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let addr = principal(sender);
+
+        session.set_tx_sender(sender);
+        session.interpreter.force_nonce(&addr, u64::MAX);
+
+        let diagnostics = session
+            .stx_transfer(1000, "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG")
+            .expect_err("a transfer whose nonce cannot be recorded is not a success");
+
+        // Silently swallowing this would leave the next transaction reusing
+        // this one's nonce, with nothing in the result to say so.
+        let message = &diagnostics.first().expect("a diagnostic").message;
+        assert!(
+            message.contains("nonce was not recorded"),
+            "the failure must name its cause, got: {message}"
+        );
     }
 
     /// The three cases below are the divergences the old nonce implementation

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -233,10 +233,7 @@ impl AnnotatedExecutionResult {
     }
 }
 
-/// Whether a [`Session::call_contract_fn`] is a transaction from its sender.
-///
-/// The same primitive backs `simnet.callPublicFn` and `simnet.callReadOnlyFn`,
-/// and only the first sends anything, so the caller has to say which it is.
+/// Whether a [`Session::call_contract_fn`] consumes a sender nonce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CallKind {
     /// A transaction sent by `sender`, consuming one of its nonces.
@@ -772,11 +769,8 @@ impl Session {
         let contract_id =
             contract.expect_resolved_contract_identifier(Some(&self.interpreter.get_tx_sender()));
 
-        // A contract deploy is a transaction and consumes a nonce. This covers
-        // both the boot deployment plan and `simnet.deployContract`. System boot
-        // contracts (pox, sbtc, …) bypass this method and call `interpreter.run`
-        // directly, so they correctly stay at nonce 0 — on mainnet they are
-        // genesis state, not transactions.
+        // Boot contracts bypass this transaction path because they are genesis
+        // state and consume no nonce.
         let result = self.interpreter.run_transaction(
             contract,
             ast,
@@ -797,11 +791,8 @@ impl Session {
 
     /// Call `method` on `contract` as `sender`.
     ///
-    /// `kind` decides whether this is a transaction: the same primitive backs
-    /// `simnet.callPublicFn` and `simnet.callReadOnlyFn`, and only the first
-    /// sends anything. The nonce is charged inside the call's own database
-    /// transaction, so it can never be recorded without the call's effects or
-    /// the other way round.
+    /// `kind` controls whether the call consumes a nonce. The nonce and call
+    /// state share one database transaction.
     #[allow(clippy::too_many_arguments)]
     pub fn call_contract_fn(
         &mut self,
@@ -900,13 +891,7 @@ impl Session {
             .map_err(Vec::from)
     }
 
-    /// `eval`, but keeping the block-inclusion verdict of a failure.
-    ///
-    /// Only callers that know they are running a *transaction* need this —
-    /// today just `stx_transfer`. `eval` also backs bare REPL snippets and
-    /// function-argument evaluation, which are not transactions, so its public
-    /// signature stays diagnostics-only rather than inviting callers to make
-    /// that judgement.
+    /// Evaluate a snippet while preserving failure inclusion and nonce policy.
     fn eval_with_inclusion(
         &mut self,
         snippet: String,
@@ -1239,13 +1224,7 @@ impl Session {
         self.interpreter.get_nonce(principal)
     }
 
-    /// Charge `principal` a nonce for a transaction that never reached the VM.
-    ///
-    /// The only caller is the SDK's access preflight, which rejects a call
-    /// mainnet would have mined before any execution happens. Nothing is
-    /// pending when this runs, so it cannot leave a nonce paired with
-    /// half-applied state — unlike a bump issued *after* an execution, which is
-    /// why every other path names a [`NonceCharge`] up front instead.
+    /// Charge an included transaction rejected before VM execution.
     pub fn charge_nonce_without_execution(
         &mut self,
         principal: PrincipalData,
@@ -2075,9 +2054,7 @@ mod tests {
 
     #[test]
     fn calling_a_contract_function_does_not_bump_a_nonce_on_its_own() {
-        // `Session::call_contract_fn` is shared by transactions and read-only
-        // queries, so it must stay nonce-neutral: the bump is the caller's job.
-        // A bump added here would make `simnet.callReadOnlyFn` consume nonces.
+        // A free call executes without consuming a nonce.
         let mut session = Session::new(SessionSettings::default());
         let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
         let addr = principal(sender);
@@ -2181,17 +2158,10 @@ mod tests {
         assert_eq!(session.get_nonce(&addr).unwrap(), 1);
     }
 
-    /// A contract-call naming a contract that was never deployed fails with
-    /// `NoSuchContract` on mainnet — a non-rejectable `RuntimeCheck`, so the
-    /// transaction is mined and charged.
-    ///
-    /// Simnet reaches that failure by a different route: `call_contract_fn`
-    /// enters with a contract id already in hand, so the metadata read fails
-    /// before any name resolution and `clarity` reports a `VmInternalError`,
-    /// which `handle_clarity_runtime_error` rejects. The disposition has to be
-    /// corrected for the route, or the call consumes nothing.
     #[test]
     fn a_call_to_a_contract_that_was_never_deployed_is_still_included() {
+        // Simnet reports this through an internal metadata error, but mainnet's
+        // equivalent `NoSuchContract` failure is included.
         let mut session = Session::new(SessionSettings::default());
         let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
 
@@ -2215,19 +2185,10 @@ mod tests {
         );
     }
 
-    /// A transaction whose nonce cannot be written must not commit either.
-    ///
-    /// A charge can fail for real: a remote-data session reads the nonce of a
-    /// non-local principal over the network. Overflow is the one failure
-    /// reachable without a network, and it takes the same path — the charge is
-    /// applied to the transfer's own database transaction, just before the
-    /// commit that would have made both durable.
-    ///
-    /// The balances are what this test is really about. Reporting an error is
-    /// not enough: if the transfer had already moved STX, a caller retrying the
-    /// error would move it twice, and against a nonce that never advanced.
     #[test]
     fn a_transaction_whose_nonce_cannot_be_recorded_does_not_commit() {
+        // Overflow injects a charge failure without requiring remote data. The
+        // transfer and nonce must roll back together.
         let mut session = Session::new(SessionSettings::default());
         let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
         let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
@@ -2271,8 +2232,6 @@ mod tests {
         );
     }
 
-    /// The contract-call path has its own database transaction, so it needs its
-    /// own proof that a failed charge takes the call's state changes with it.
     #[test]
     fn a_contract_call_whose_nonce_cannot_be_recorded_does_not_commit() {
         let mut session = Session::new(SessionSettings::default());
@@ -2300,8 +2259,7 @@ mod tests {
             )
             .expect_err("a call whose nonce cannot be recorded is not a success");
 
-        // `incr` bumps a data var. If the call had committed while the nonce
-        // did not, this would read 1 and the next call would reuse the nonce.
+        // A failed nonce charge must also roll back `incr`'s data-var update.
         let result = session
             .call_contract_fn(
                 &contract_id,
@@ -2323,11 +2281,6 @@ mod tests {
         }
     }
 
-    /// The three cases below are the divergences the old nonce implementation
-    /// got wrong by keying the bump off `result.is_ok()`. Clarinet reports a
-    /// failure for each, but mainnet still mines the transaction, so each must
-    /// consume a nonce. The verdict comes from `clarity`'s classifiers — see
-    /// `BlockInclusion`.
     #[test]
     fn a_deploy_that_fails_at_runtime_bumps_the_deployer_nonce() {
         let mut session = Session::new(SessionSettings::default());

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1164,6 +1164,27 @@ impl Session {
         self.interpreter.get_assets_maps()
     }
 
+    /// Read the transaction nonce of `principal`. Unknown principals are at 0.
+    pub fn get_nonce(&mut self, principal: &PrincipalData) -> Result<u64, String> {
+        self.interpreter.get_nonce(principal)
+    }
+
+    /// Bump the nonce of `principal` after a transaction it sent.
+    ///
+    /// Callers are the ones that know whether an operation is a transaction:
+    /// `call_contract_fn` is deliberately not one of them, because it also
+    /// backs `simnet.callReadOnlyFn`, and a read-only call is not a
+    /// transaction. See `inner_call_public_fn` / `inner_call_private_fn` in
+    /// `clarinet-sdk-wasm`, which do know.
+    ///
+    /// A failure here means the datastore is unhealthy, not that the
+    /// transaction was invalid, so it is reported rather than propagated.
+    pub fn bump_nonce(&mut self, principal: PrincipalData) {
+        if let Err(e) = self.interpreter.increment_nonce(&principal) {
+            ueprint!("Failed to bump nonce for {principal}: {e}");
+        }
+    }
+
     pub fn get_contract_ast(
         &mut self,
         contract_id: &QualifiedContractIdentifier,

--- a/components/clarity-static-cost/src/static_cost/cost_functions.rs
+++ b/components/clarity-static-cost/src/static_cost/cost_functions.rs
@@ -39,7 +39,7 @@ impl CostModel {
             | StacksEpochId::Epoch31
             | StacksEpochId::Epoch32 => CostModel::Costs3,
             StacksEpochId::Epoch33 | StacksEpochId::Epoch34 => CostModel::Costs4,
-            StacksEpochId::Epoch40 => CostModel::Costs5,
+            StacksEpochId::Epoch40 | StacksEpochId::Epoch41 => CostModel::Costs5,
         }
     }
 

--- a/components/clarity-static-cost/src/static_cost/mod.rs
+++ b/components/clarity-static-cost/src/static_cost/mod.rs
@@ -6,7 +6,7 @@ mod trait_counter;
 
 use std::collections::HashMap;
 
-use clarity::vm::callables::CallableType;
+use clarity::vm::callables::{BuiltinKind, CallableType};
 use clarity::vm::costs::cost_functions::ClarityCostFunction;
 use clarity::vm::costs::ExecutionCost;
 use clarity::vm::functions::{lookup_reserved_functions, NativeFunctions};
@@ -122,7 +122,10 @@ pub(crate) fn calculate_function_cost_from_native_function(
     }
 
     match lookup_reserved_functions(native_function.to_string().as_str(), &clarity_version) {
-        Some(CallableType::NativeFunction(_, _, cost_fn)) => {
+        Some(CallableType::Builtin {
+            kind: BuiltinKind::Native(_, _, cost_fn),
+            ..
+        }) => {
             let cost = cost_fn
                 .eval_for_epoch(arg_count, epoch)
                 .map_err(|e| StaticCostError::CostCalculation(format!("{e:?}")))?;
@@ -132,7 +135,10 @@ pub(crate) fn calculate_function_cost_from_native_function(
                 max: cost_with_lookup,
             })
         }
-        Some(CallableType::NativeFunction205(_, _, cost_fn, _)) => {
+        Some(CallableType::Builtin {
+            kind: BuiltinKind::Native205(_, _, cost_fn, _),
+            ..
+        }) => {
             let cost = cost_fn
                 .eval_for_epoch(arg_count, epoch)
                 .map_err(|e| StaticCostError::CostCalculation(format!("{e:?}")))?;
@@ -142,7 +148,10 @@ pub(crate) fn calculate_function_cost_from_native_function(
                 max: cost_with_lookup,
             })
         }
-        Some(CallableType::SpecialFunction(_, _)) => {
+        Some(CallableType::Builtin {
+            kind: BuiltinKind::Special(_, _),
+            ..
+        }) => {
             let cost = get_cost_for_special_function(native_function, args, epoch, user_args, env);
             let cost_with_lookup_min = add_lookup_cost(cost.min.clone(), epoch);
             let cost_with_lookup_max = add_lookup_cost(cost.max.clone(), epoch);

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
         # Hash for clarity git dependency - update this when Cargo.lock changes
         # Run `nix run .#check-git-dependencies-hash` to verify or get the new hash
-        clarityHash = "sha256-VQvWCsMum0tE376iBDx2JI1uXslsUW4sMTFS6NShaJg=";
+        clarityHash = "sha256-4pk+Iq706MOkJqW6L88l0Z7kqEkCv8xLhuyFOnnGYkU=";
 
         clarinet = rustPlatform.buildRustPackage {
           inherit pname version;


### PR DESCRIPTION
### Description

Track nonces for each account in simnet

In the context of a Stacks account, a nonce is a unique identifier for each transaction sent, which starts at 0 and increments by one for each sent transaction that ends up on-chain (all successful transactions, and certain failed ones)

### Related Issues

- Part of: #2185
- Requires: stacks-network/stacks-core#7486
  - Merge and update `stacks-core` commit ID before merging this PR

---

### Checklist

- [x] Tests added in this PR (if applicable)

