### PR TITLE
chore: release 3.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [3.23.2](https://github.com/stx-labs/clarinet/compare/v3.23.1...v3.23.2) (2026-08-26)
+
+##### Bug Fixes
+
+*  Vitest-helper path derivation (#2505) (00fb51b3)
+*  Update testnet sBTC contract address (#2504) (f39e1a52)
+*  Use komac for winget release with new stxlabs scoping (#2486) (0239c797)
+*  Update testnet heights (#2494) (6debe450)
+* **static-cost:**  Price epoch 4.0 with costs-5 (#2495) (98ca35c9)
+
 # [3.23.1](https://github.com/stx-labs/clarinet/compare/v3.23.0...v3.23.1) (2026-07-31)
 
 ##### Refactors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "chrono",
  "clap",
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "clarinet-defaults"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "clarity",
 ]
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "bitcoin",
  "clarinet-defaults",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-static-cost"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "clarity",
  "clarity-types",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "observer"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "axum",
  "base58",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["components/clarinet-cli"]
 opt-level = 3
 
 [workspace.package]
-version = "3.23.1"
+version = "3.23.2"
 
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "private": true,
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",


### PR DESCRIPTION
##### Bug Fixes

*  Vitest-helper path derivation (#2505) (00fb51b3)
*  Update testnet sBTC contract address (#2504) (f39e1a52)
*  Use komac for winget release with new stxlabs scoping (#2486) (0239c797)
*  Update testnet heights (#2494) (6debe450)
* **static-cost:**  Price epoch 4.0 with costs-5 (#2495) (98ca35c9)


