### PR TITLE
feat: Add single-file support to LSP

### DIFF
--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -94,6 +94,58 @@ async fn resolve_manifest_location(
     }
 }
 
+async fn process_standalone_contract(
+    contract_location: PathBuf,
+    editor_state: &mut EditorStateInput,
+    file_accessor: Option<&dyn FileAccessor>,
+    reload: bool,
+) -> Result<LspNotificationResponse, String> {
+    let is_active =
+        editor_state.try_read(|es| es.active_contracts.contains_key(&contract_location))?;
+    if reload || !is_active {
+        let source = match file_accessor {
+            None => paths::read_content_as_utf8(&contract_location),
+            Some(file_accessor) => {
+                file_accessor
+                    .read_file(contract_location.to_string_lossy().into_owned())
+                    .await
+            }
+        }?;
+
+        editor_state.try_write(|es| {
+            if is_active {
+                es.update_active_contract(&contract_location, &source, true)
+            } else {
+                es.insert_standalone_contract(contract_location.clone(), source);
+                Ok(())
+            }
+        })??;
+    }
+
+    let aggregated_diagnostics = editor_state.try_read(|es| {
+        let diagnostics = es
+            .active_contracts
+            .get(&contract_location)
+            .and_then(|contract| contract.diagnostic.clone())
+            .map(LintDiagnostic::from)
+            .into_iter()
+            .collect();
+        vec![(contract_location.clone(), diagnostics)]
+    })?;
+    let env_simnet_diagnostics = editor_state.try_read(|es| {
+        es.get_env_simnet_diagnostics()
+            .into_iter()
+            .filter(|(path, _)| path == &contract_location)
+            .collect()
+    })?;
+
+    Ok(LspNotificationResponse {
+        aggregated_diagnostics,
+        env_simnet_diagnostics,
+        notification: None,
+    })
+}
+
 #[derive(Debug, Clone)]
 // The `Owned` variant contains the full `EditorState` (several HashMaps,
 // now including an AST cache). Boxing it would force an extra indirection
@@ -201,7 +253,18 @@ pub async fn process_notification(
 
         LspNotification::ContractOpened(contract_location) => {
             let manifest_location =
-                resolve_manifest_location(&contract_location, file_accessor).await?;
+                match resolve_manifest_location(&contract_location, file_accessor).await {
+                    Ok(manifest_location) => manifest_location,
+                    Err(_) => {
+                        return process_standalone_contract(
+                            contract_location,
+                            editor_state,
+                            file_accessor,
+                            false,
+                        )
+                        .await;
+                    }
+                };
 
             // store the contract in the active_contracts map
             if !editor_state.try_read(|es| es.active_contracts.contains_key(&contract_location))? {
@@ -258,10 +321,13 @@ pub async fn process_notification(
                                     get_boot_contract_epoch_and_clarity_version(contract_name);
                                 version
                             } else {
-                                return Err(format!(
-                                    "No Clarinet.toml is associated to the contract {}",
-                                    contract_location.display()
-                                ));
+                                return process_standalone_contract(
+                                    contract_location,
+                                    editor_state,
+                                    file_accessor,
+                                    false,
+                                )
+                                .await;
                             }
                         }
                     }
@@ -300,8 +366,19 @@ pub async fn process_notification(
             let existing_manifest = editor_state
                 .try_write(|es| es.clear_protocol_associated_with_contract(&contract_location))?;
             let manifest_location = match existing_manifest {
-                Some(m) => m,
-                None => resolve_manifest_location(&contract_location, file_accessor).await?,
+                Some(manifest_location) => manifest_location,
+                None => match resolve_manifest_location(&contract_location, file_accessor).await {
+                    Ok(manifest_location) => manifest_location,
+                    Err(_) => {
+                        return process_standalone_contract(
+                            contract_location,
+                            editor_state,
+                            file_accessor,
+                            true,
+                        )
+                        .await;
+                    }
+                },
             };
             build_and_commit(
                 editor_state,
@@ -677,6 +754,10 @@ pub fn process_mutating_request(
         )),
     }
 }
+
+#[cfg(test)]
+#[path = "backend_standalone_tests.rs"]
+mod standalone_tests;
 
 #[cfg(test)]
 mod lsp_tests {

--- a/components/clarity-lsp/src/common/backend_standalone_tests.rs
+++ b/components/clarity-lsp/src/common/backend_standalone_tests.rs
@@ -1,0 +1,187 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use clarinet_files::FileAccessor;
+use ls_types::{GotoDefinitionParams, Position, TextDocumentIdentifier, WorkDoneProgressParams};
+
+use super::*;
+use crate::common::state::EditorState;
+
+fn root_path() -> PathBuf {
+    if cfg!(windows) {
+        PathBuf::from(std::env::var("SystemDrive").unwrap_or_else(|_| "C:".to_string()) + "\\")
+    } else {
+        PathBuf::from("/")
+    }
+}
+
+struct TestFileAccessor {
+    contract: String,
+    has_manifest: bool,
+}
+
+impl TestFileAccessor {
+    fn standalone(contract: &str) -> Self {
+        Self {
+            contract: contract.to_string(),
+            has_manifest: false,
+        }
+    }
+
+    fn project(contract: &str) -> Self {
+        Self {
+            contract: contract.to_string(),
+            has_manifest: true,
+        }
+    }
+}
+
+impl FileAccessor for TestFileAccessor {
+    fn file_exists(&self, path: String) -> clarinet_files::FileAccessorResult<bool> {
+        let exists = self.has_manifest || !path.ends_with("Clarinet.toml");
+        Box::pin(async move { Ok(exists) })
+    }
+
+    fn read_file(&self, path: String) -> clarinet_files::FileAccessorResult<String> {
+        let content = if path.ends_with("Clarinet.toml") {
+            "[project]\nname = 'test-project'\n\n[contracts.counter]\npath = 'counter.clar'\nclarity_version = 3\nepoch = 'latest'\n".to_string()
+        } else {
+            self.contract.clone()
+        };
+        Box::pin(async move { Ok(content) })
+    }
+
+    fn read_files(
+        &self,
+        contracts_paths: Vec<String>,
+    ) -> clarinet_files::FileAccessorResult<HashMap<String, String>> {
+        let contract = self.contract.clone();
+        Box::pin(async move {
+            Ok(contracts_paths
+                .into_iter()
+                .map(|path| (path, contract.clone()))
+                .collect())
+        })
+    }
+
+    fn write_file(&self, _path: String, _content: &[u8]) -> clarinet_files::FileAccessorResult<()> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[tokio::test]
+async fn test_unlisted_contract_opened_as_standalone() {
+    let source = "(define-constant N u1)\n(define-read-only (get-n) N)";
+    let file_accessor = TestFileAccessor::project(source);
+    let mut editor_state = EditorStateInput::Owned(EditorState::new());
+    let contract_location = root_path().join("standalone.clar");
+
+    let response = process_notification(
+        LspNotification::ContractOpened(contract_location.clone()),
+        &mut editor_state,
+        Some(&file_accessor),
+    )
+    .await
+    .expect("opening a standalone contract should not error");
+    assert!(response.notification.is_none());
+
+    editor_state
+        .try_read(|state| {
+            let contract = state.active_contracts.get(&contract_location).unwrap();
+            let symbols = state.get_document_symbols_for_contract(&contract_location);
+            assert!(symbols.iter().any(|symbol| symbol.name == "get-n"));
+            assert!(state.protocols.is_empty());
+            assert_eq!(
+                contract.clarity_version,
+                clarinet_defaults::DEFAULT_CLARITY_VERSION
+            );
+            assert_eq!(contract.epoch, clarinet_defaults::DEFAULT_EPOCH);
+        })
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_standalone_go_to_definition_without_manifest() {
+    let source = "(define-constant N u1)\n(define-read-only (get-n) N)";
+    let file_accessor = TestFileAccessor::standalone(source);
+    let mut editor_state = EditorStateInput::Owned(EditorState::new());
+    let contract_location = root_path().join("standalone.clar");
+
+    process_notification(
+        LspNotification::ContractOpened(contract_location.clone()),
+        &mut editor_state,
+        Some(&file_accessor),
+    )
+    .await
+    .expect("opening a standalone contract should not error");
+
+    let params = GotoDefinitionParams {
+        text_document_position_params: ls_types::TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: paths::path_to_url_string(&contract_location)
+                    .unwrap()
+                    .parse()
+                    .unwrap(),
+            },
+            position: Position {
+                line: 1,
+                character: 26,
+            },
+        },
+        work_done_progress_params: WorkDoneProgressParams {
+            work_done_token: None,
+        },
+        partial_result_params: ls_types::PartialResultParams {
+            partial_result_token: None,
+        },
+    };
+
+    let response = process_request(LspRequest::Definition(params), &editor_state)
+        .expect("definition request should succeed");
+    let LspRequestResponse::Definition(Some(location)) = response else {
+        panic!("expected a definition location, got: {response:?}");
+    };
+    assert_eq!(location.range.start.line, 0);
+}
+
+#[tokio::test]
+async fn test_standalone_contract_saved_without_manifest() {
+    let file_accessor = TestFileAccessor::standalone("(define-data-var count uint u0)");
+    let mut editor_state = EditorStateInput::Owned(EditorState::new());
+    let contract_location = root_path().join("standalone.clar");
+
+    let response = process_notification(
+        LspNotification::ContractSaved(contract_location.clone()),
+        &mut editor_state,
+        Some(&file_accessor),
+    )
+    .await
+    .expect("saving a standalone contract should not error");
+    assert!(response.notification.is_none());
+    editor_state
+        .try_read(|state| assert!(state.active_contracts.contains_key(&contract_location)))
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_standalone_parse_error_surfaces_diagnostic() {
+    let file_accessor = TestFileAccessor::standalone("(define-data-var count uint u0");
+    let mut editor_state = EditorStateInput::Owned(EditorState::new());
+    let contract_location = root_path().join("standalone.clar");
+
+    let response = process_notification(
+        LspNotification::ContractOpened(contract_location),
+        &mut editor_state,
+        Some(&file_accessor),
+    )
+    .await
+    .expect("open should succeed even with a parse error");
+
+    assert!(
+        response
+            .aggregated_diagnostics
+            .iter()
+            .any(|(_, diagnostics)| !diagnostics.is_empty()),
+        "expected a parser diagnostic for the standalone file"
+    );
+}

--- a/components/clarity-lsp/src/common/state.rs
+++ b/components/clarity-lsp/src/common/state.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use std::path::{Path, PathBuf};
 use std::vec;
 
-use clarinet_defaults::DEFAULT_CLARITY_VERSION;
+use clarinet_defaults::{DEFAULT_CLARITY_VERSION, DEFAULT_EPOCH};
 pub use clarinet_deployments::CachedContractAST;
 use clarinet_deployments::{
     generate_default_deployment_with_cache, initiate_session_from_manifest,
@@ -753,6 +753,16 @@ impl EditorState {
     ) {
         let epoch = StacksEpochId::Epoch21;
         let contract = ActiveContractData::new(clarity_version, epoch, issuer, source);
+        self.active_contracts.insert(contract_location, contract);
+    }
+
+    /// Insert a contract that has no associated `Clarinet.toml`. It is parsed
+    /// with the default Clarity version and epoch so single-file features
+    /// (definitions, document symbols, hover, signature help, completion) work
+    /// without a configured project.
+    pub fn insert_standalone_contract(&mut self, contract_location: PathBuf, source: String) {
+        let contract =
+            ActiveContractData::new(DEFAULT_CLARITY_VERSION, DEFAULT_EPOCH, None, source);
         self.active_contracts.insert(contract_location, contract);
     }
 

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -53,7 +53,8 @@
     "vscode": "^1.64.0"
   },
   "activationEvents": [
-    "workspaceContains:Clarinet.toml"
+    "workspaceContains:Clarinet.toml",
+    "onLanguage:clarity"
   ],
   "main": "./client/dist/clientNode.js",
   "browser": "./client/dist/clientBrowser.js",


### PR DESCRIPTION
I don't often _write_ smart contract, but I _read_ them almost everyday. 
While reading, it's very nice to jump around by symbol.
However, I don't always work within a `clarinet` project. I sometimes pull something from the explorer, copy it in a scratch file, and start looking around.

The lack of a Clarinet project means that the LSP doesn't work.
This PR fixes that.

It isn't perfect. In particular, lack of a project means that Clarinet needs to make assumptions on the Clarity version, etc.
But it's good enough for my use cases. 

(I also had to [patch](https://github.com/aldur/dotfiles/commit/ea09b2be896a47ee3bdbf50b7b80de38834e198d) my `nvim` configuration to enable support for symbols).

I am submitting this PR as draft since I know from a chat with @hugo-stacks that it isn't production-ready, but might be useful to others and/or easy to industrialize.

So far, it's working pretty well for me -- this is a screen of symbols for `pox-5.clar` as a boot contract, which doesn't include the Clarinet project configuration: 
<img width="2531" height="1341" alt="Screenshot 2026-08-27 at 14 36 14" src="https://github.com/user-attachments/assets/593bdf89-e626-45b1-b155-456640e4ea8a" />
