### PR TITLE
feat: Post-conditions in simnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2 0.10.9",
+ "stacks-codec",
+ "stacks-transactions",
  "strum",
  "tempfile",
  "test-case",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 [[package]]
 name = "clarity"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "clarity-types",
  "integer-sqrt",
@@ -917,7 +917,7 @@ dependencies = [
 [[package]]
 name = "clarity-types"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2490,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "libsigner"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "clarity",
  "hashbrown 0.15.5",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "libstackerdb"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "clarity",
  "serde",
@@ -3063,7 +3063,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 [[package]]
 name = "pox-locking"
 version = "2.4.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "clarity",
  "slog",
@@ -4240,7 +4240,7 @@ dependencies = [
 [[package]]
 name = "stacks-codec"
 version = "0.1.0"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "clarity-types",
  "serde",
@@ -4251,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "stacks-common"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "chrono",
  "curve25519-dalek",
@@ -4337,9 +4337,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stacks-transactions"
+version = "0.1.0"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
+dependencies = [
+ "clarity-types",
+ "stacks-codec",
+ "stacks-common",
+]
+
+[[package]]
 name = "stackslib"
 version = "0.0.1"
-source = "git+https://github.com/stacks-network/stacks-core.git?rev=6eece30c6da8b9ff8581f201a1d4ecec735b1625#6eece30c6da8b9ff8581f201a1d4ecec735b1625"
+source = "git+https://github.com/stacks-network/stacks-core.git?rev=ab048f9c1b96cbe47572b789e947fe42b0465154#ab048f9c1b96cbe47572b789e947fe42b0465154"
 dependencies = [
  "clarity",
  "ed25519-dalek",
@@ -4364,6 +4374,7 @@ dependencies = [
  "slog",
  "stacks-codec",
  "stacks-common",
+ "stacks-transactions",
  "time",
  "toml",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "
 pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "pox-locking", default-features = false }
 stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "stacks-codec" }
 stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "stacks-common", default-features = false }
+stacks-transactions = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "stacks-transactions", default-features = false }
 stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "stackslib", default-features = false }
 
 # Internal crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ version = "3.23.2"
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]
 # stacks-core git dependencies
-clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "clarity", default-features = false }
-clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "clarity-types" }
-libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "libsigner", default-features = false }
-pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "pox-locking", default-features = false }
-stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "stacks-codec" }
-stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "stacks-common", default-features = false }
-stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "6eece30c6da8b9ff8581f201a1d4ecec735b1625", package = "stackslib", default-features = false }
+clarity = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "clarity", default-features = false }
+clarity-types = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "clarity-types" }
+libsigner = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "libsigner", default-features = false }
+pox-locking = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "pox-locking", default-features = false }
+stacks-codec = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "stacks-codec" }
+stacks-common = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "stacks-common", default-features = false }
+stackslib = { git = "https://github.com/stacks-network/stacks-core.git", rev = "ab048f9c1b96cbe47572b789e947fe42b0465154", package = "stackslib", default-features = false }
 
 # Internal crates
 clarinet-defaults = { path = "components/clarinet-defaults" }

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -24,6 +24,7 @@ use clarity_repl::repl::boot::{
     SBTC_DEPOSIT_MAINNET_ADDRESS, SBTC_MAINNET_ADDRESS, SBTC_TESTNET_ADDRESS_PRINCIPAL,
 };
 use clarity_repl::repl::clarity_values::value_to_string;
+use clarity_repl::repl::post_conditions::PostConditionCheck;
 use clarity_repl::repl::session::{AnnotatedExecutionResult, CallKind, ExecutionResultMap};
 use clarity_repl::repl::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Session,
@@ -246,6 +247,7 @@ fn fund_genesis_accounts_with_sbtc(session: &mut Session, deployment: &Deploymen
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
 
         // A silent failure here is indistinguishable from a mint that never
@@ -348,7 +350,11 @@ fn handle_stx_transfer(session: &mut Session, tx: &StxTransferSpecification) {
     let default_tx_sender = session.get_tx_sender();
     session.set_tx_sender(&tx.expected_sender.to_string());
 
-    let _ = session.stx_transfer(tx.mstx_amount, &tx.recipient.to_string());
+    let _ = session.stx_transfer(
+        tx.mstx_amount,
+        &tx.recipient.to_string(),
+        PostConditionCheck::Unchecked,
+    );
 
     session.set_tx_sender(&default_tx_sender);
 }
@@ -371,7 +377,12 @@ fn handle_emulated_contract_publish(
         skip_analysis: tx.skip_analysis,
     };
 
-    let result = session.deploy_contract(&contract, false, contract_ast);
+    let result = session.deploy_contract(
+        &contract,
+        false,
+        contract_ast,
+        PostConditionCheck::Unchecked,
+    );
 
     session.set_tx_sender(&default_tx_sender);
     result
@@ -398,6 +409,7 @@ fn handle_emulated_contract_call(
         true,
         false,
         CallKind::Transaction,
+        PostConditionCheck::Unchecked,
     );
     if let Err(errors) = &result {
         clarity_repl::ueprint!("error: {:?}", errors.diagnostics.first().unwrap().message);

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -22,6 +22,7 @@ use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExp
 use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::hooks::perf::CostField;
 use clarity_repl::repl::interpreter::BlockInclusion;
+use clarity_repl::repl::post_conditions::{parse_post_condition_mode, PostConditionCheck};
 use clarity_repl::repl::session::{CallKind, CostsReport};
 use clarity_repl::repl::settings::RemoteDataSettings;
 use clarity_repl::repl::{
@@ -81,6 +82,10 @@ struct CallContractArgsJSON {
     method: String,
     args_maps: Vec<HashMap<usize, u8>>,
     sender: String,
+    #[serde(rename = "postConditions", default)]
+    post_conditions: Option<Vec<String>>,
+    #[serde(rename = "postConditionMode", default)]
+    post_condition_mode: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,6 +95,11 @@ pub struct CallFnArgs {
     method: String,
     args: Vec<Vec<u8>>,
     sender: String,
+    /// Consensus-serialized post-conditions, hex-encoded. `None` means the
+    /// caller asked for no enforcement, which is not the same as an empty
+    /// list — that forbids the sender from moving anything under `Deny`.
+    post_conditions: Option<Vec<String>>,
+    post_condition_mode: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -100,12 +110,16 @@ impl CallFnArgs {
         method: String,
         args: Vec<js_sys::Uint8Array>,
         sender: String,
+        post_conditions: Option<Vec<String>>,
+        post_condition_mode: Option<String>,
     ) -> Self {
         Self {
             contract,
             method,
             args: args.into_iter().map(|a| a.to_vec()).collect(),
             sender,
+            post_conditions,
+            post_condition_mode,
         }
     }
 
@@ -132,6 +146,8 @@ impl CallFnArgs {
             method: json_args.method,
             args,
             sender: json_args.sender,
+            post_conditions: json_args.post_conditions,
+            post_condition_mode: json_args.post_condition_mode,
         }
     }
 }
@@ -171,16 +187,29 @@ pub struct DeployContractArgs {
     content: String,
     options: Option<ContractOptions>,
     sender: String,
+    #[serde(rename = "postConditions", default)]
+    post_conditions: Option<Vec<String>>,
+    #[serde(rename = "postConditionMode", default)]
+    post_condition_mode: Option<String>,
 }
 #[wasm_bindgen]
 impl DeployContractArgs {
     #[wasm_bindgen(constructor)]
-    pub fn new(name: String, content: String, options: ContractOptions, sender: String) -> Self {
+    pub fn new(
+        name: String,
+        content: String,
+        options: ContractOptions,
+        sender: String,
+        post_conditions: Option<Vec<String>>,
+        post_condition_mode: Option<String>,
+    ) -> Self {
         Self {
             name,
             content,
             options: Some(options),
             sender,
+            post_conditions,
+            post_condition_mode,
         }
     }
 }
@@ -191,18 +220,60 @@ pub struct TransferSTXArgs {
     amount: u64,
     recipient: String,
     sender: String,
+    #[serde(rename = "postConditions", default)]
+    post_conditions: Option<Vec<String>>,
+    #[serde(rename = "postConditionMode", default)]
+    post_condition_mode: Option<String>,
 }
 
 #[wasm_bindgen]
 impl TransferSTXArgs {
     #[wasm_bindgen(constructor)]
-    pub fn new(amount: u64, recipient: String, sender: String) -> Self {
+    pub fn new(
+        amount: u64,
+        recipient: String,
+        sender: String,
+        post_conditions: Option<Vec<String>>,
+        post_condition_mode: Option<String>,
+    ) -> Self {
         Self {
             amount,
             recipient,
             sender,
+            post_conditions,
+            post_condition_mode,
         }
     }
+}
+
+/// The mode a transaction gets when it carries post-conditions but does not
+/// name one. Matches what a wallet does on mainnet: anything the caller did not
+/// account for is a failure rather than a silent pass.
+const DEFAULT_POST_CONDITION_MODE: &str = "deny";
+
+/// Build the post-condition check for a transaction sent by `sender`.
+///
+/// Enforcement is off only when the caller supplied neither conditions nor a
+/// mode. That keeps an omitted argument distinct from an explicitly empty list,
+/// which under `Deny` forbids the sender from moving anything at all.
+fn post_condition_check(
+    post_conditions: Option<&Vec<String>>,
+    post_condition_mode: Option<&str>,
+    sender: &str,
+) -> Result<PostConditionCheck, String> {
+    if post_conditions.is_none() && post_condition_mode.is_none() {
+        return Ok(PostConditionCheck::Unchecked);
+    }
+
+    let mode = post_condition_mode.unwrap_or(DEFAULT_POST_CONDITION_MODE);
+    let origin = PrincipalData::parse_standard_principal(sender)
+        .map_err(|e| format!("Invalid sender address '{sender}': {e:?}"))?;
+
+    PostConditionCheck::from_hex(
+        post_conditions.map_or(&[], Vec::as_slice),
+        parse_post_condition_mode(mode)?,
+        origin.into(),
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -815,6 +886,8 @@ impl SDK {
             method,
             args,
             sender,
+            post_conditions,
+            post_condition_mode,
         }: &CallFnArgs,
         allow_private: bool,
         kind: CallKind,
@@ -832,6 +905,12 @@ impl SDK {
             .map(|a| SymbolicExpression::atom_value(uint8_to_value(a)))
             .collect::<Vec<SymbolicExpression>>();
 
+        let post_conditions = post_condition_check(
+            post_conditions.as_ref(),
+            post_condition_mode.as_deref(),
+            sender,
+        )?;
+
         let session = self.get_session_mut();
         let execution = session
             .call_contract_fn(
@@ -842,6 +921,7 @@ impl SDK {
                 allow_private,
                 track_costs,
                 kind,
+                post_conditions,
             )
             .map_err(|failure| {
                 let mut message = format!(
@@ -988,11 +1068,17 @@ impl SDK {
             return Err(format!("Invalid recipient address '{}'.", args.recipient));
         }
 
+        let post_conditions = post_condition_check(
+            args.post_conditions.as_ref(),
+            args.post_condition_mode.as_deref(),
+            &args.sender,
+        )?;
+
         let session = self.get_session_mut();
         let initial_tx_sender = session.get_tx_sender();
         session.set_tx_sender(&args.sender);
 
-        let execution = match session.stx_transfer(args.amount, &args.recipient) {
+        let execution = match session.stx_transfer(args.amount, &args.recipient, post_conditions) {
             Ok(res) => res,
             Err(diagnostics) => {
                 let mut message = format!("{}: {}", "STX transfer error", args.sender);
@@ -1020,11 +1106,24 @@ impl SDK {
         }
 
         let track_costs = self.options.track_costs;
+        let post_conditions = post_condition_check(
+            args.post_conditions.as_ref(),
+            args.post_condition_mode.as_deref(),
+            &args.sender,
+        )?;
         let execution = {
             let session = self.get_session_mut();
             if advance_chain_tip {
                 session.advance_chain_tip(1);
             }
+
+            // A contract's top-level body runs as the deployer, so the sender
+            // has to be in place before it executes — otherwise a deploy that
+            // moves assets debits whoever the session last acted as. Mirrors
+            // `inner_transfer_stx` and the deployment-plan path.
+            let initial_tx_sender = session.get_tx_sender();
+            session.set_tx_sender(&args.sender);
+
             let current_epoch = session.interpreter.datastore.get_current_epoch();
 
             let clarity_version = clarity_version_from_u32(
@@ -1041,7 +1140,10 @@ impl SDK {
                 skip_analysis: false,
             };
 
-            match session.deploy_contract(&contract, track_costs, None) {
+            let result = session.deploy_contract(&contract, track_costs, None, post_conditions);
+            session.set_tx_sender(&initial_tx_sender);
+
+            match result {
                 Ok(res) => res,
                 Err(diagnostics) => {
                     let mut message = format!(

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -95,8 +95,7 @@ pub struct CallFnArgs {
     method: String,
     args: Vec<Vec<u8>>,
     sender: String,
-    /// Consensus-serialized post-conditions, hex-encoded. See
-    /// [`post_condition_check`] for what `None` means.
+    /// Consensus-serialized post-conditions, hex-encoded.
     post_conditions: Option<Vec<String>>,
     post_condition_mode: Option<String>,
 }
@@ -245,18 +244,16 @@ impl TransferSTXArgs {
     }
 }
 
-/// The mode a transaction gets when it carries post-conditions but does not
-/// name one. Matches what a wallet does on mainnet: anything the caller did not
-/// account for is a failure rather than a silent pass.
+/// Default to rejecting asset movement that no condition covers.
 const DEFAULT_POST_CONDITION_MODE: &str = "deny";
 
 /// Build the post-condition check for a transaction sent by `sender`.
 ///
-/// Enforcement is off only when the caller supplied neither conditions nor a
-/// mode. That keeps an omitted argument distinct from an explicitly empty list,
-/// which under `Deny` forbids the sender from moving anything at all.
+/// An omitted list and mode preserve the SDK's historical unchecked behavior.
+/// An explicit empty list remains meaningful: in `deny` mode it rejects any
+/// asset movement by the originator.
 fn post_condition_check(
-    post_conditions: Option<&Vec<String>>,
+    post_conditions: Option<&[String]>,
     post_condition_mode: Option<&str>,
     sender: &str,
 ) -> Result<PostConditionCheck, String> {
@@ -269,7 +266,7 @@ fn post_condition_check(
         .map_err(|e| format!("Invalid sender address '{sender}': {e:?}"))?;
 
     PostConditionCheck::from_hex(
-        post_conditions.map_or(&[], Vec::as_slice),
+        post_conditions.unwrap_or_default(),
         parse_post_condition_mode(mode)?,
         origin.into(),
     )
@@ -905,7 +902,7 @@ impl SDK {
             .collect::<Vec<SymbolicExpression>>();
 
         let post_conditions = post_condition_check(
-            post_conditions.as_ref(),
+            post_conditions.as_deref(),
             post_condition_mode.as_deref(),
             sender,
         )?;
@@ -1068,7 +1065,7 @@ impl SDK {
         }
 
         let post_conditions = post_condition_check(
-            args.post_conditions.as_ref(),
+            args.post_conditions.as_deref(),
             args.post_condition_mode.as_deref(),
             &args.sender,
         )?;
@@ -1077,7 +1074,10 @@ impl SDK {
         let initial_tx_sender = session.get_tx_sender();
         session.set_tx_sender(&args.sender);
 
-        let execution = match session.stx_transfer(args.amount, &args.recipient, post_conditions) {
+        let result = session.stx_transfer(args.amount, &args.recipient, post_conditions);
+        session.set_tx_sender(&initial_tx_sender);
+
+        let execution = match result {
             Ok(res) => res,
             Err(diagnostics) => {
                 let mut message = format!("{}: {}", "STX transfer error", args.sender);
@@ -1091,7 +1091,6 @@ impl SDK {
         if advance_chain_tip {
             session.advance_chain_tip(1);
         }
-        session.set_tx_sender(&initial_tx_sender);
         Ok(execution_result_to_transaction_res(&execution))
     }
 
@@ -1106,7 +1105,7 @@ impl SDK {
 
         let track_costs = self.options.track_costs;
         let post_conditions = post_condition_check(
-            args.post_conditions.as_ref(),
+            args.post_conditions.as_deref(),
             args.post_condition_mode.as_deref(),
             &args.sender,
         )?;
@@ -1116,10 +1115,7 @@ impl SDK {
                 session.advance_chain_tip(1);
             }
 
-            // A contract's top-level body runs as the deployer, so the sender
-            // has to be in place before it executes — otherwise a deploy that
-            // moves assets debits whoever the session last acted as. Mirrors
-            // `inner_transfer_stx` and the deployment-plan path.
+            // A contract's top-level body runs as its declared deployer.
             let initial_tx_sender = session.get_tx_sender();
             session.set_tx_sender(&args.sender);
 

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -1115,10 +1115,6 @@ impl SDK {
                 session.advance_chain_tip(1);
             }
 
-            // A contract's top-level body runs as its declared deployer.
-            let initial_tx_sender = session.get_tx_sender();
-            session.set_tx_sender(&args.sender);
-
             let current_epoch = session.interpreter.datastore.get_current_epoch();
 
             let clarity_version = clarity_version_from_u32(
@@ -1135,10 +1131,7 @@ impl SDK {
                 skip_analysis: false,
             };
 
-            let result = session.deploy_contract(&contract, track_costs, None, post_conditions);
-            session.set_tx_sender(&initial_tx_sender);
-
-            match result {
+            match session.deploy_contract(&contract, track_costs, None, post_conditions) {
                 Ok(res) => res,
                 Err(diagnostics) => {
                     let mut message = format!(

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -22,7 +22,9 @@ use clarity::vm::{ClarityVersion, EvaluationResult, ExecutionResult, SymbolicExp
 use clarity_repl::repl::clarity_values::{uint8_to_string, uint8_to_value};
 use clarity_repl::repl::hooks::perf::CostField;
 use clarity_repl::repl::interpreter::BlockInclusion;
-use clarity_repl::repl::post_conditions::{parse_post_condition_mode, PostConditionCheck};
+use clarity_repl::repl::post_conditions::{
+    parse_post_condition_mode, PostConditionCheck, DEFAULT_POST_CONDITION_MODE,
+};
 use clarity_repl::repl::session::{CallKind, CostsReport};
 use clarity_repl::repl::settings::RemoteDataSettings;
 use clarity_repl::repl::{
@@ -244,9 +246,6 @@ impl TransferSTXArgs {
     }
 }
 
-/// Default to rejecting asset movement that no condition covers.
-const DEFAULT_POST_CONDITION_MODE: &str = "deny";
-
 /// Build the post-condition check for a transaction sent by `sender`.
 ///
 /// An omitted list and mode preserve the SDK's historical unchecked behavior.
@@ -261,15 +260,14 @@ fn post_condition_check(
         return Ok(PostConditionCheck::Unchecked);
     }
 
-    let mode = post_condition_mode.unwrap_or(DEFAULT_POST_CONDITION_MODE);
+    let mode = post_condition_mode
+        .map(parse_post_condition_mode)
+        .transpose()?
+        .unwrap_or(DEFAULT_POST_CONDITION_MODE);
     let origin = PrincipalData::parse_standard_principal(sender)
         .map_err(|e| format!("Invalid sender address '{sender}': {e:?}"))?;
 
-    PostConditionCheck::from_hex(
-        post_conditions.unwrap_or_default(),
-        parse_post_condition_mode(mode)?,
-        origin.into(),
-    )
+    PostConditionCheck::from_hex(post_conditions.unwrap_or_default(), mode, origin.into())
 }
 
 #[derive(Debug, Deserialize)]

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -95,9 +95,8 @@ pub struct CallFnArgs {
     method: String,
     args: Vec<Vec<u8>>,
     sender: String,
-    /// Consensus-serialized post-conditions, hex-encoded. `None` means the
-    /// caller asked for no enforcement, which is not the same as an empty
-    /// list — that forbids the sender from moving anything under `Deny`.
+    /// Consensus-serialized post-conditions, hex-encoded. See
+    /// [`post_condition_check`] for what `None` means.
     post_conditions: Option<Vec<String>>,
     post_condition_mode: Option<String>,
 }

--- a/components/clarinet-sdk-wasm/src/test_wasm.rs
+++ b/components/clarinet-sdk-wasm/src/test_wasm.rs
@@ -36,6 +36,8 @@ fn deploy_basic_contract(sdk: &mut SDK) -> TransactionRes {
         "(define-private (two) (+ u1 u1))".into(),
         ContractOptions::new(None),
         "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".into(),
+        None,
+        None,
     );
     sdk.deploy_contract(&contract).unwrap()
 }
@@ -74,6 +76,8 @@ async fn it_can_call_a_private_function() {
             "two".into(),
             vec![],
             "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".into(),
+            None,
+            None,
         ))
         .unwrap();
     let expected = format!("0x{}", ClarityValue::UInt(2).serialize_to_hex().unwrap());
@@ -91,6 +95,8 @@ async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
             method.into(),
             vec![],
             SENDER.into(),
+            None,
+            None,
         )
     };
 
@@ -105,6 +111,8 @@ async fn it_bumps_the_sender_nonce_only_for_contract_call_transactions() {
             .into(),
         ContractOptions::new(None),
         SENDER.into(),
+        None,
+        None,
     ))
     .unwrap();
 
@@ -161,6 +169,8 @@ async fn it_charges_a_nonce_for_a_call_the_access_preflight_rejects() {
             method.into(),
             vec![],
             SENDER.into(),
+            None,
+            None,
         )
     };
 
@@ -172,6 +182,8 @@ async fn it_charges_a_nonce_for_a_call_the_access_preflight_rejects() {
             .into(),
         ContractOptions::new(None),
         SENDER.into(),
+        None,
+        None,
     ))
     .unwrap();
     assert_eq!(sdk.get_account_nonce(SENDER).unwrap(), 1);
@@ -250,6 +262,8 @@ async fn it_gates_the_preflight_nonce_on_the_epoch_like_the_vm_does() {
                 .into(),
             ContractOptions::new(None),
             SENDER.into(),
+            None,
+            None,
         ))
         .unwrap();
 
@@ -259,6 +273,8 @@ async fn it_gates_the_preflight_nonce_on_the_epoch_like_the_vm_does() {
                 method.into(),
                 vec![],
                 SENDER.into(),
+                None,
+                None,
             )
         };
 
@@ -328,6 +344,8 @@ async fn it_handles_invalid_sender_address() {
         "two".into(),
         vec![],
         "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.basic-contract".into(), // Invalid: full contract address
+        None,
+        None,
     ));
 
     assert!(result.is_err());
@@ -343,6 +361,8 @@ async fn it_handles_contract_recipient_address() {
         1000,
         "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.basic-contract".into(), // valid: contract address
         "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".into(),
+        None,
+        None,
     ));
 
     // contract addresses are valid recipients
@@ -359,6 +379,8 @@ async fn it_handles_invalid_deployer_address() {
         "(define-private (two) (+ u1 u1))".into(),
         ContractOptions::new(None),
         "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.invalid-contract".into(), // Invalid: contract address
+        None,
+        None,
     );
 
     let result = sdk.deploy_contract(&contract);
@@ -378,6 +400,8 @@ async fn it_handles_contract_address_as_sender() {
         "two".into(),
         vec![],
         contract_address.into(), // Invalid: contract address instead of sender address
+        None,
+        None,
     ));
 
     assert!(result.is_err());
@@ -395,6 +419,8 @@ async fn it_handles_contract_address_as_recipient() {
         1000,
         contract_address.into(), // Valid: contract address instead of recipient address
         "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM".into(),
+        None,
+        None,
     ));
 
     // we support contract addresses as recipients

--- a/components/clarinet-sdk/browser/src/sdkProxy.ts
+++ b/components/clarinet-sdk/browser/src/sdkProxy.ts
@@ -1,196 +1,20 @@
-import { Cl, serializeCVBytes } from "@stacks/transactions";
 import {
   CallFnArgs,
+  ContractOptions,
   DeployContractArgs,
   TransferSTXArgs,
-  ContractOptions,
   type SDK,
-  type TransactionRes,
 } from "@stacks/clarinet-sdk-wasm-browser";
 
-import {
-  parseEvents,
-  serializePostConditions,
-  type CallFn,
-  type CallReadOnlyFn,
-  type DeployContract,
-  type GetDataVar,
-  type GetMapEntry,
-  type MineBlock,
-  type ParsedTransactionResult,
-  type Execute,
-  type TransferSTX,
-  parseCosts,
-} from "../../common/src/sdkProxyHelpers.js";
+import { createSessionProxy, type ProxiedSimnet } from "../../common/src/sdkProxy.js";
 
-/** @deprecated use `simnet.execute(command)` instead */
-type RunSnippet = SDK["runSnippet"];
+export type Simnet = ProxiedSimnet<SDK>;
 
-// because the session is wrapped in a proxy the types need to be hardcoded
-export type Simnet = {
-  [K in keyof SDK]: K extends "callReadOnlyFn"
-    ? CallReadOnlyFn
-    : K extends "callPublicFn" | "callPrivateFn"
-      ? CallFn
-      : K extends "execute"
-        ? Execute
-        : K extends "runSnippet"
-          ? RunSnippet
-          : K extends "deployContract"
-            ? DeployContract
-            : K extends "transferSTX"
-              ? TransferSTX
-              : K extends "mineBlock"
-                ? MineBlock
-                : K extends "getDataVar"
-                  ? GetDataVar
-                  : K extends "getMapEntry"
-                    ? GetMapEntry
-                    : SDK[K];
-};
-
-function parseTxResponse(response: TransactionRes): ParsedTransactionResult {
-  return {
-    result: Cl.deserialize(response.result),
-    events: parseEvents(response.events),
-    costs: parseCosts(response.costs),
-    performance: response.performance,
-  };
-}
-
-export function getSessionProxy() {
-  return {
-    get(session: SDK, prop: keyof SDK, receiver: any) {
-      // some of the WASM methods are proxied here to:
-      // - serialize clarity values input argument
-      // - deserialize output into clarity values
-
-      if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
-        const callFn: CallFn = (contract, method, args, sender, options) => {
-          const { postConditions, postConditionMode } = serializePostConditions(options);
-          const response = session[prop](
-            new CallFnArgs(
-              contract,
-              method,
-              args.map(serializeCVBytes),
-              sender,
-              postConditions,
-              postConditionMode,
-            ),
-          );
-          return parseTxResponse(response);
-        };
-        return callFn;
-      }
-
-      if (prop === "execute") {
-        const execute: Execute = (snippet) => {
-          const response = session.execute(snippet);
-          return parseTxResponse(response);
-        };
-        return execute;
-      }
-
-      if (prop === "deployContract") {
-        const callDeployContract: DeployContract = (
-          name,
-          content,
-          options,
-          sender,
-          postConditionOptions,
-        ) => {
-          const rustOptions = options
-            ? new ContractOptions(options.clarityVersion)
-            : new ContractOptions();
-          const { postConditions, postConditionMode } =
-            serializePostConditions(postConditionOptions);
-
-          const response = session.deployContract(
-            new DeployContractArgs(
-              name,
-              content,
-              rustOptions,
-              sender,
-              postConditions,
-              postConditionMode,
-            ),
-          );
-          return parseTxResponse(response);
-        };
-        return callDeployContract;
-      }
-
-      if (prop === "transferSTX") {
-        const callTransferSTX: TransferSTX = (amount, recipient, sender, options) => {
-          const { postConditions, postConditionMode } = serializePostConditions(options);
-          const response = session.transferSTX(
-            new TransferSTXArgs(
-              BigInt(amount),
-              recipient,
-              sender,
-              postConditions,
-              postConditionMode,
-            ),
-          );
-          return parseTxResponse(response);
-        };
-        return callTransferSTX;
-      }
-
-      if (prop === "mineBlock") {
-        const callMineBlock: MineBlock = (txs) => {
-          const serializedTxs = txs.map((tx) => {
-            if (tx.callPublicFn) {
-              return {
-                callPublicFn: {
-                  ...tx.callPublicFn,
-                  args_maps: tx.callPublicFn.args.map(serializeCVBytes),
-                },
-              };
-            }
-            if (tx.callPrivateFn) {
-              return {
-                callPrivateFn: {
-                  ...tx.callPrivateFn,
-                  args_maps: tx.callPrivateFn.args.map(serializeCVBytes),
-                },
-              };
-            }
-            if (tx.deployContract) {
-              return {
-                deployContract: {
-                  ...tx.deployContract,
-                },
-              };
-            }
-            return tx;
-          });
-
-          const responses: TransactionRes[] = session.mineBlock(serializedTxs);
-          return responses.map(parseTxResponse);
-        };
-        return callMineBlock;
-      }
-
-      if (prop === "getDataVar") {
-        const getDataVar: GetDataVar = (...args) => {
-          const response = session.getDataVar(...args);
-          const result = Cl.deserialize(response);
-          return result;
-        };
-        return getDataVar;
-      }
-
-      if (prop === "getMapEntry") {
-        const getMapEntry: GetMapEntry = (contract, mapName, mapKey) => {
-          const response = session.getMapEntry(contract, mapName, serializeCVBytes(mapKey));
-          const result = Cl.deserialize(response);
-          return result;
-        };
-        return getMapEntry;
-      }
-
-      return Reflect.get(session, prop, receiver);
-    },
-  };
+export function getSessionProxy(): ProxyHandler<SDK> {
+  return createSessionProxy<SDK, ContractOptions>({
+    CallFnArgs,
+    ContractOptions,
+    DeployContractArgs,
+    TransferSTXArgs,
+  });
 }

--- a/components/clarinet-sdk/browser/src/sdkProxy.ts
+++ b/components/clarinet-sdk/browser/src/sdkProxy.ts
@@ -10,7 +10,9 @@ import {
 
 import {
   parseEvents,
+  serializePostConditions,
   type CallFn,
+  type CallReadOnlyFn,
   type DeployContract,
   type GetDataVar,
   type GetMapEntry,
@@ -26,23 +28,25 @@ type RunSnippet = SDK["runSnippet"];
 
 // because the session is wrapped in a proxy the types need to be hardcoded
 export type Simnet = {
-  [K in keyof SDK]: K extends "callReadOnlyFn" | "callPublicFn" | "callPrivateFn"
-    ? CallFn
-    : K extends "execute"
-      ? Execute
-      : K extends "runSnippet"
-        ? RunSnippet
-        : K extends "deployContract"
-          ? DeployContract
-          : K extends "transferSTX"
-            ? TransferSTX
-            : K extends "mineBlock"
-              ? MineBlock
-              : K extends "getDataVar"
-                ? GetDataVar
-                : K extends "getMapEntry"
-                  ? GetMapEntry
-                  : SDK[K];
+  [K in keyof SDK]: K extends "callReadOnlyFn"
+    ? CallReadOnlyFn
+    : K extends "callPublicFn" | "callPrivateFn"
+      ? CallFn
+      : K extends "execute"
+        ? Execute
+        : K extends "runSnippet"
+          ? RunSnippet
+          : K extends "deployContract"
+            ? DeployContract
+            : K extends "transferSTX"
+              ? TransferSTX
+              : K extends "mineBlock"
+                ? MineBlock
+                : K extends "getDataVar"
+                  ? GetDataVar
+                  : K extends "getMapEntry"
+                    ? GetMapEntry
+                    : SDK[K];
 };
 
 function parseTxResponse(response: TransactionRes): ParsedTransactionResult {
@@ -62,9 +66,17 @@ export function getSessionProxy() {
       // - deserialize output into clarity values
 
       if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
-        const callFn: CallFn = (contract, method, args, sender) => {
+        const callFn: CallFn = (contract, method, args, sender, options) => {
+          const { postConditions, postConditionMode } = serializePostConditions(options);
           const response = session[prop](
-            new CallFnArgs(contract, method, args.map(serializeCVBytes), sender),
+            new CallFnArgs(
+              contract,
+              method,
+              args.map(serializeCVBytes),
+              sender,
+              postConditions,
+              postConditionMode,
+            ),
           );
           return parseTxResponse(response);
         };
@@ -80,13 +92,28 @@ export function getSessionProxy() {
       }
 
       if (prop === "deployContract") {
-        const callDeployContract: DeployContract = (name, content, options, sender) => {
+        const callDeployContract: DeployContract = (
+          name,
+          content,
+          options,
+          sender,
+          postConditionOptions,
+        ) => {
           const rustOptions = options
             ? new ContractOptions(options.clarityVersion)
             : new ContractOptions();
+          const { postConditions, postConditionMode } =
+            serializePostConditions(postConditionOptions);
 
           const response = session.deployContract(
-            new DeployContractArgs(name, content, rustOptions, sender),
+            new DeployContractArgs(
+              name,
+              content,
+              rustOptions,
+              sender,
+              postConditions,
+              postConditionMode,
+            ),
           );
           return parseTxResponse(response);
         };
@@ -94,8 +121,17 @@ export function getSessionProxy() {
       }
 
       if (prop === "transferSTX") {
-        const callTransferSTX: TransferSTX = (amount, ...args) => {
-          const response = session.transferSTX(new TransferSTXArgs(BigInt(amount), ...args));
+        const callTransferSTX: TransferSTX = (amount, recipient, sender, options) => {
+          const { postConditions, postConditionMode } = serializePostConditions(options);
+          const response = session.transferSTX(
+            new TransferSTXArgs(
+              BigInt(amount),
+              recipient,
+              sender,
+              postConditions,
+              postConditionMode,
+            ),
+          );
           return parseTxResponse(response);
         };
         return callTransferSTX;

--- a/components/clarinet-sdk/common/src/sdkProxy.ts
+++ b/components/clarinet-sdk/common/src/sdkProxy.ts
@@ -1,0 +1,221 @@
+import { Cl, serializeCVBytes } from "@stacks/transactions";
+
+import {
+  parseCosts,
+  parseEvents,
+  serializePostConditions,
+  type CallFn,
+  type CallReadOnlyFn,
+  type DeployContract,
+  type Execute,
+  type GetDataVar,
+  type GetMapEntry,
+  type MineBlock,
+  type ParsedTransactionResult,
+  type TransferSTX,
+} from "./sdkProxyHelpers.js";
+
+type WasmTransactionRes = {
+  result: string;
+  events: string;
+  costs: string;
+  performance?: string;
+};
+
+type ProxySdk = {
+  callReadOnlyFn(args: unknown): WasmTransactionRes;
+  callPublicFn(args: unknown): WasmTransactionRes;
+  callPrivateFn(args: unknown): WasmTransactionRes;
+  deployContract(args: unknown): WasmTransactionRes;
+  execute(snippet: string): WasmTransactionRes;
+  getDataVar(contract: string, varName: string): string;
+  getMapEntry(contract: string, mapName: string, mapKey: Uint8Array): string;
+  mineBlock(txs: unknown[]): WasmTransactionRes[];
+  runSnippet(snippet: string): string;
+  transferSTX(args: unknown): WasmTransactionRes;
+};
+
+/** @deprecated use `simnet.execute(command)` instead */
+type RunSnippet<S extends ProxySdk> = S["runSnippet"];
+
+export type ProxiedSimnet<S extends ProxySdk> = {
+  [K in keyof S]: K extends "callReadOnlyFn"
+    ? CallReadOnlyFn
+    : K extends "callPublicFn" | "callPrivateFn"
+      ? CallFn
+      : K extends "execute"
+        ? Execute
+        : K extends "runSnippet"
+          ? RunSnippet<S>
+          : K extends "deployContract"
+            ? DeployContract
+            : K extends "transferSTX"
+              ? TransferSTX
+              : K extends "mineBlock"
+                ? MineBlock
+                : K extends "getDataVar"
+                  ? GetDataVar
+                  : K extends "getMapEntry"
+                    ? GetMapEntry
+                    : S[K];
+};
+
+type ProxyBindings<ContractOptions> = {
+  CallFnArgs: new (
+    contract: string,
+    method: string,
+    args: Uint8Array[],
+    sender: string,
+    postConditions?: string[],
+    postConditionMode?: string,
+  ) => unknown;
+  ContractOptions: new (clarityVersion?: number) => ContractOptions;
+  DeployContractArgs: new (
+    name: string,
+    content: string,
+    options: ContractOptions,
+    sender: string,
+    postConditions?: string[],
+    postConditionMode?: string,
+  ) => unknown;
+  TransferSTXArgs: new (
+    amount: bigint,
+    recipient: string,
+    sender: string,
+    postConditions?: string[],
+    postConditionMode?: string,
+  ) => unknown;
+};
+
+function parseTxResponse(response: WasmTransactionRes): ParsedTransactionResult {
+  return {
+    result: Cl.deserialize(response.result),
+    events: parseEvents(response.events),
+    costs: parseCosts(response.costs),
+    performance: response.performance,
+  };
+}
+
+export function createSessionProxy<S extends ProxySdk, ContractOptions>(
+  bindings: ProxyBindings<ContractOptions>,
+): ProxyHandler<S> {
+  const { CallFnArgs, ContractOptions, DeployContractArgs, TransferSTXArgs } = bindings;
+
+  return {
+    get(session, prop, receiver) {
+      const sdk: ProxySdk = session;
+
+      if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
+        const callFn: CallFn = (contract, method, args, sender, options) => {
+          const { postConditions, postConditionMode } = serializePostConditions(options);
+          const response = sdk[prop](
+            new CallFnArgs(
+              contract,
+              method,
+              args.map(serializeCVBytes),
+              sender,
+              postConditions,
+              postConditionMode,
+            ),
+          );
+          return parseTxResponse(response);
+        };
+        return callFn;
+      }
+
+      if (prop === "execute") {
+        const execute: Execute = (snippet) => parseTxResponse(sdk.execute(snippet));
+        return execute;
+      }
+
+      if (prop === "deployContract") {
+        const deployContract: DeployContract = (
+          name,
+          content,
+          options,
+          sender,
+          postConditionOptions,
+        ) => {
+          const rustOptions = options
+            ? new ContractOptions(options.clarityVersion)
+            : new ContractOptions();
+          const { postConditions, postConditionMode } =
+            serializePostConditions(postConditionOptions);
+          return parseTxResponse(
+            sdk.deployContract(
+              new DeployContractArgs(
+                name,
+                content,
+                rustOptions,
+                sender,
+                postConditions,
+                postConditionMode,
+              ),
+            ),
+          );
+        };
+        return deployContract;
+      }
+
+      if (prop === "transferSTX") {
+        const transferSTX: TransferSTX = (amount, recipient, sender, options) => {
+          const { postConditions, postConditionMode } = serializePostConditions(options);
+          return parseTxResponse(
+            sdk.transferSTX(
+              new TransferSTXArgs(
+                BigInt(amount),
+                recipient,
+                sender,
+                postConditions,
+                postConditionMode,
+              ),
+            ),
+          );
+        };
+        return transferSTX;
+      }
+
+      if (prop === "mineBlock") {
+        const mineBlock: MineBlock = (txs) => {
+          const serializedTxs = txs.map((tx) => {
+            if (tx.callPublicFn) {
+              return {
+                callPublicFn: {
+                  ...tx.callPublicFn,
+                  args_maps: tx.callPublicFn.args.map(serializeCVBytes),
+                },
+              };
+            }
+            if (tx.callPrivateFn) {
+              return {
+                callPrivateFn: {
+                  ...tx.callPrivateFn,
+                  args_maps: tx.callPrivateFn.args.map(serializeCVBytes),
+                },
+              };
+            }
+            if (tx.deployContract) {
+              return { deployContract: { ...tx.deployContract } };
+            }
+            return tx;
+          });
+          return sdk.mineBlock(serializedTxs).map(parseTxResponse);
+        };
+        return mineBlock;
+      }
+
+      if (prop === "getDataVar") {
+        const getDataVar: GetDataVar = (...args) => Cl.deserialize(sdk.getDataVar(...args));
+        return getDataVar;
+      }
+
+      if (prop === "getMapEntry") {
+        const getMapEntry: GetMapEntry = (contract, mapName, mapKey) =>
+          Cl.deserialize(sdk.getMapEntry(contract, mapName, serializeCVBytes(mapKey)));
+        return getMapEntry;
+      }
+
+      return Reflect.get(session, prop, receiver);
+    },
+  };
+}

--- a/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
+++ b/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
@@ -2,8 +2,13 @@ import {
   Cl,
   ClarityValue,
   ClarityVersion,
+  ContractCallOptions,
   PostCondition,
+  PostConditionMode,
+  PostConditionModeName,
+  PostConditionWire,
   postConditionToHex,
+  serializePostConditionWire,
 } from "@stacks/transactions";
 
 export type ClarityEvent = {
@@ -33,28 +38,24 @@ export type ParsedTransactionResult = {
   performance: string | undefined;
 };
 
-/** How a transaction's asset movement is constrained. */
-export type PostConditionMode = "allow" | "deny" | "originator";
-
 /**
  * Post-conditions to enforce on a simnet transaction.
  *
- * A condition is either a stacks.js `PostCondition` or the hex encoding of one.
- * Hex is the escape hatch for the `Staking` and `Pox` conditions that stacks.js
- * cannot build yet.
+ * Conditions use the same builder, wire, and hex formats as stacks.js. Hex is
+ * also the escape hatch for conditions that stacks.js cannot build yet.
  *
  * Passing neither field preserves the SDK's unchecked behavior. Passing either
  * enables enforcement; `postConditionMode` defaults to `"deny"`.
  */
-export type PostConditionOptions = {
-  postConditions?: (PostCondition | string)[];
-  postConditionMode?: PostConditionMode;
-};
+export type PostConditionOptions = Pick<
+  ContractCallOptions,
+  "postConditions" | "postConditionMode"
+>;
 
 /** `PostConditionOptions` as the Wasm SDK takes it: conditions already encoded. */
 export type SerializedPostConditions = {
   postConditions?: string[];
-  postConditionMode?: PostConditionMode;
+  postConditionMode?: PostConditionModeName;
 };
 
 export function serializePostConditions(options?: PostConditionOptions): SerializedPostConditions {
@@ -64,11 +65,23 @@ export function serializePostConditions(options?: PostConditionOptions): Seriali
   // Preserve the distinction between an omitted list and an explicit empty one.
   return {
     ...(conditions !== undefined && {
-      postConditions: conditions.map((pc) =>
-        typeof pc === "string" ? pc : postConditionToHex(pc),
-      ),
+      postConditions: conditions.map((pc) => {
+        if (typeof pc === "string") return pc;
+        return typeof pc.type === "string"
+          ? postConditionToHex(pc as PostCondition)
+          : serializePostConditionWire(pc as PostConditionWire);
+      }),
     }),
-    ...(mode !== undefined && { postConditionMode: mode }),
+    ...(mode !== undefined && {
+      postConditionMode:
+        mode === PostConditionMode.Allow
+          ? "allow"
+          : mode === PostConditionMode.Deny
+            ? "deny"
+            : mode === PostConditionMode.Originator
+              ? "originator"
+              : mode,
+    }),
   };
 }
 

--- a/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
+++ b/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
@@ -63,8 +63,8 @@ export function serializePostConditions(options?: PostConditionOptions): Seriali
   const conditions = options?.postConditions;
   const mode = options?.postConditionMode;
 
-  // Absent keys, rather than explicit `undefined`, so an omitted argument stays
-  // distinguishable from an empty list once it reaches Rust.
+  // An omitted list disables enforcement entirely; an empty list denies every
+  // asset movement under the default mode. Both have to reach Rust intact.
   return {
     ...(conditions !== undefined && {
       postConditions: conditions.map((pc) =>

--- a/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
+++ b/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
@@ -43,10 +43,8 @@ export type PostConditionMode = "allow" | "deny" | "originator";
  * Hex is the escape hatch for the `Staking` and `Pox` conditions that stacks.js
  * cannot build yet.
  *
- * Passing neither field leaves asset movement unconstrained, as it has always
- * been. Passing either one turns enforcement on, and `postConditionMode`
- * defaults to `"deny"` — so anything you did not account for fails, which is
- * what a wallet does on mainnet.
+ * Passing neither field preserves the SDK's unchecked behavior. Passing either
+ * enables enforcement; `postConditionMode` defaults to `"deny"`.
  */
 export type PostConditionOptions = {
   postConditions?: (PostCondition | string)[];
@@ -63,8 +61,7 @@ export function serializePostConditions(options?: PostConditionOptions): Seriali
   const conditions = options?.postConditions;
   const mode = options?.postConditionMode;
 
-  // An omitted list disables enforcement entirely; an empty list denies every
-  // asset movement under the default mode. Both have to reach Rust intact.
+  // Preserve the distinction between an omitted list and an explicit empty one.
   return {
     ...(conditions !== undefined && {
       postConditions: conditions.map((pc) =>

--- a/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
+++ b/components/clarinet-sdk/common/src/sdkProxyHelpers.ts
@@ -1,4 +1,10 @@
-import { Cl, ClarityValue, ClarityVersion } from "@stacks/transactions";
+import {
+  Cl,
+  ClarityValue,
+  ClarityVersion,
+  PostCondition,
+  postConditionToHex,
+} from "@stacks/transactions";
 
 export type ClarityEvent = {
   event: string;
@@ -27,7 +33,58 @@ export type ParsedTransactionResult = {
   performance: string | undefined;
 };
 
+/** How a transaction's asset movement is constrained. */
+export type PostConditionMode = "allow" | "deny" | "originator";
+
+/**
+ * Post-conditions to enforce on a simnet transaction.
+ *
+ * A condition is either a stacks.js `PostCondition` or the hex encoding of one.
+ * Hex is the escape hatch for the `Staking` and `Pox` conditions that stacks.js
+ * cannot build yet.
+ *
+ * Passing neither field leaves asset movement unconstrained, as it has always
+ * been. Passing either one turns enforcement on, and `postConditionMode`
+ * defaults to `"deny"` — so anything you did not account for fails, which is
+ * what a wallet does on mainnet.
+ */
+export type PostConditionOptions = {
+  postConditions?: (PostCondition | string)[];
+  postConditionMode?: PostConditionMode;
+};
+
+/** `PostConditionOptions` as the Wasm SDK takes it: conditions already encoded. */
+export type SerializedPostConditions = {
+  postConditions?: string[];
+  postConditionMode?: PostConditionMode;
+};
+
+export function serializePostConditions(options?: PostConditionOptions): SerializedPostConditions {
+  const conditions = options?.postConditions;
+  const mode = options?.postConditionMode;
+
+  // Absent keys, rather than explicit `undefined`, so an omitted argument stays
+  // distinguishable from an empty list once it reaches Rust.
+  return {
+    ...(conditions !== undefined && {
+      postConditions: conditions.map((pc) =>
+        typeof pc === "string" ? pc : postConditionToHex(pc),
+      ),
+    }),
+    ...(mode !== undefined && { postConditionMode: mode }),
+  };
+}
+
 export type CallFn = (
+  contract: string,
+  method: string,
+  args: ClarityValue[],
+  sender: string,
+  options?: PostConditionOptions,
+) => ParsedTransactionResult;
+
+/** A read-only call moves no assets, so it takes no post-conditions. */
+export type CallReadOnlyFn = (
   contract: string,
   method: string,
   args: ClarityValue[],
@@ -42,14 +99,20 @@ export type DeployContract = (
   content: string,
   options: DeployContractOptions | null,
   sender: string,
+  postConditionOptions?: PostConditionOptions,
 ) => ParsedTransactionResult;
 
 export type TransferSTX = (
   amount: number | bigint,
   recipient: string,
   sender: string,
+  options?: PostConditionOptions,
 ) => ParsedTransactionResult;
 
+/**
+ * A transaction in a `mineBlock` batch. Post-conditions are already encoded,
+ * because the batch is handed to Wasm as plain JSON.
+ */
 export type Tx =
   | {
       callPublicFn: {
@@ -57,7 +120,7 @@ export type Tx =
         method: string;
         args: ClarityValue[];
         sender: string;
-      };
+      } & SerializedPostConditions;
       callPrivateFn?: never;
       deployContract?: never;
       transferSTX?: never;
@@ -69,7 +132,7 @@ export type Tx =
         method: string;
         args: ClarityValue[];
         sender: string;
-      };
+      } & SerializedPostConditions;
       deployContract?: never;
       transferSTX?: never;
     }
@@ -81,33 +144,61 @@ export type Tx =
         content: string;
         options: DeployContractOptions | null;
         sender: string;
-      };
+      } & SerializedPostConditions;
       transferSTX?: never;
     }
   | {
       callPublicFn?: never;
       callPrivateFn?: never;
       deployContract?: never;
-      transferSTX: { amount: number; recipient: string; sender: string };
+      transferSTX: {
+        amount: number;
+        recipient: string;
+        sender: string;
+      } & SerializedPostConditions;
     };
 
 export const tx = {
-  callPublicFn: (contract: string, method: string, args: ClarityValue[], sender: string): Tx => ({
-    callPublicFn: { contract, method, args, sender },
+  callPublicFn: (
+    contract: string,
+    method: string,
+    args: ClarityValue[],
+    sender: string,
+    options?: PostConditionOptions,
+  ): Tx => ({
+    callPublicFn: { contract, method, args, sender, ...serializePostConditions(options) },
   }),
-  callPrivateFn: (contract: string, method: string, args: ClarityValue[], sender: string): Tx => ({
-    callPrivateFn: { contract, method, args, sender },
+  callPrivateFn: (
+    contract: string,
+    method: string,
+    args: ClarityValue[],
+    sender: string,
+    options?: PostConditionOptions,
+  ): Tx => ({
+    callPrivateFn: { contract, method, args, sender, ...serializePostConditions(options) },
   }),
   deployContract: (
     name: string,
     content: string,
     options: DeployContractOptions | null,
     sender: string,
+    postConditionOptions?: PostConditionOptions,
   ): Tx => ({
-    deployContract: { name, content, options, sender },
+    deployContract: {
+      name,
+      content,
+      options,
+      sender,
+      ...serializePostConditions(postConditionOptions),
+    },
   }),
-  transferSTX: (amount: number, recipient: string, sender: string): Tx => ({
-    transferSTX: { amount, recipient, sender },
+  transferSTX: (
+    amount: number,
+    recipient: string,
+    sender: string,
+    options?: PostConditionOptions,
+  ): Tx => ({
+    transferSTX: { amount, recipient, sender, ...serializePostConditions(options) },
   }),
 };
 

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -40,8 +40,9 @@
     "clean": "rimraf dist",
     "compile": "tsc -b ./tsconfig.json ./tsconfig.cjs.json",
     "build": "pnpm run clean && pnpm run compile && node ./scripts/prepare-esm-package.js",
-    "pretest": "tsc -b ./tsconfig.json",
+    "pretest": "tsc -b ./tsconfig.json && pnpm run test:types",
     "test": "vitest run",
+    "test:types": "tsc -p ./type-tests/tsconfig.json",
     "test:no-mxs": "vitest run --exclude=tests/remote-data.test.ts",
     "prepublishOnly": "node ../../../scripts/require-pnpm.mjs && pnpm run build"
   },

--- a/components/clarinet-sdk/node/src/sdkProxy.ts
+++ b/components/clarinet-sdk/node/src/sdkProxy.ts
@@ -10,7 +10,9 @@ import {
 
 import {
   parseEvents,
+  serializePostConditions,
   type CallFn,
+  type CallReadOnlyFn,
   type DeployContract,
   type GetDataVar,
   type GetMapEntry,
@@ -26,23 +28,25 @@ type RunSnippet = SDK["runSnippet"];
 
 // because the session is wrapped in a proxy the types need to be hardcoded
 export type Simnet = {
-  [K in keyof SDK]: K extends "callReadOnlyFn" | "callPublicFn" | "callPrivateFn"
-    ? CallFn
-    : K extends "execute"
-      ? Execute
-      : K extends "runSnippet"
-        ? RunSnippet
-        : K extends "deployContract"
-          ? DeployContract
-          : K extends "transferSTX"
-            ? TransferSTX
-            : K extends "mineBlock"
-              ? MineBlock
-              : K extends "getDataVar"
-                ? GetDataVar
-                : K extends "getMapEntry"
-                  ? GetMapEntry
-                  : SDK[K];
+  [K in keyof SDK]: K extends "callReadOnlyFn"
+    ? CallReadOnlyFn
+    : K extends "callPublicFn" | "callPrivateFn"
+      ? CallFn
+      : K extends "execute"
+        ? Execute
+        : K extends "runSnippet"
+          ? RunSnippet
+          : K extends "deployContract"
+            ? DeployContract
+            : K extends "transferSTX"
+              ? TransferSTX
+              : K extends "mineBlock"
+                ? MineBlock
+                : K extends "getDataVar"
+                  ? GetDataVar
+                  : K extends "getMapEntry"
+                    ? GetMapEntry
+                    : SDK[K];
 };
 
 function parseTxResponse(response: TransactionRes): ParsedTransactionResult {
@@ -62,9 +66,17 @@ export function getSessionProxy() {
       // - deserialize output into clarity values
 
       if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
-        const callFn: CallFn = (contract, method, args, sender) => {
+        const callFn: CallFn = (contract, method, args, sender, options) => {
+          const { postConditions, postConditionMode } = serializePostConditions(options);
           const response = session[prop](
-            new CallFnArgs(contract, method, args.map(serializeCVBytes), sender),
+            new CallFnArgs(
+              contract,
+              method,
+              args.map(serializeCVBytes),
+              sender,
+              postConditions,
+              postConditionMode,
+            ),
           );
           return parseTxResponse(response);
         };
@@ -80,13 +92,28 @@ export function getSessionProxy() {
       }
 
       if (prop === "deployContract") {
-        const callDeployContract: DeployContract = (name, content, options, sender) => {
+        const callDeployContract: DeployContract = (
+          name,
+          content,
+          options,
+          sender,
+          postConditionOptions,
+        ) => {
           const rustOptions = options
             ? new ContractOptions(options.clarityVersion)
             : new ContractOptions();
+          const { postConditions, postConditionMode } =
+            serializePostConditions(postConditionOptions);
 
           const response = session.deployContract(
-            new DeployContractArgs(name, content, rustOptions, sender),
+            new DeployContractArgs(
+              name,
+              content,
+              rustOptions,
+              sender,
+              postConditions,
+              postConditionMode,
+            ),
           );
           return parseTxResponse(response);
         };
@@ -94,8 +121,17 @@ export function getSessionProxy() {
       }
 
       if (prop === "transferSTX") {
-        const callTransferSTX: TransferSTX = (amount, ...args) => {
-          const response = session.transferSTX(new TransferSTXArgs(BigInt(amount), ...args));
+        const callTransferSTX: TransferSTX = (amount, recipient, sender, options) => {
+          const { postConditions, postConditionMode } = serializePostConditions(options);
+          const response = session.transferSTX(
+            new TransferSTXArgs(
+              BigInt(amount),
+              recipient,
+              sender,
+              postConditions,
+              postConditionMode,
+            ),
+          );
           return parseTxResponse(response);
         };
         return callTransferSTX;

--- a/components/clarinet-sdk/node/src/sdkProxy.ts
+++ b/components/clarinet-sdk/node/src/sdkProxy.ts
@@ -1,196 +1,20 @@
-import { Cl, serializeCVBytes } from "@stacks/transactions";
 import {
   CallFnArgs,
+  ContractOptions,
   DeployContractArgs,
   TransferSTXArgs,
-  ContractOptions,
   type SDK,
-  type TransactionRes,
 } from "@stacks/clarinet-sdk-wasm";
 
-import {
-  parseEvents,
-  serializePostConditions,
-  type CallFn,
-  type CallReadOnlyFn,
-  type DeployContract,
-  type GetDataVar,
-  type GetMapEntry,
-  type MineBlock,
-  type ParsedTransactionResult,
-  type Execute,
-  type TransferSTX,
-  parseCosts,
-} from "../../common/src/sdkProxyHelpers.js";
+import { createSessionProxy, type ProxiedSimnet } from "../../common/src/sdkProxy.js";
 
-/** @deprecated use `simnet.execute(command)` instead */
-type RunSnippet = SDK["runSnippet"];
+export type Simnet = ProxiedSimnet<SDK>;
 
-// because the session is wrapped in a proxy the types need to be hardcoded
-export type Simnet = {
-  [K in keyof SDK]: K extends "callReadOnlyFn"
-    ? CallReadOnlyFn
-    : K extends "callPublicFn" | "callPrivateFn"
-      ? CallFn
-      : K extends "execute"
-        ? Execute
-        : K extends "runSnippet"
-          ? RunSnippet
-          : K extends "deployContract"
-            ? DeployContract
-            : K extends "transferSTX"
-              ? TransferSTX
-              : K extends "mineBlock"
-                ? MineBlock
-                : K extends "getDataVar"
-                  ? GetDataVar
-                  : K extends "getMapEntry"
-                    ? GetMapEntry
-                    : SDK[K];
-};
-
-function parseTxResponse(response: TransactionRes): ParsedTransactionResult {
-  return {
-    result: Cl.deserialize(response.result),
-    events: parseEvents(response.events),
-    costs: parseCosts(response.costs),
-    performance: response.performance,
-  };
-}
-
-export function getSessionProxy() {
-  return {
-    get(session: SDK, prop: keyof SDK, receiver: any) {
-      // some of the WASM methods are proxied here to:
-      // - serialize clarity values input argument
-      // - deserialize output into clarity values
-
-      if (prop === "callReadOnlyFn" || prop === "callPublicFn" || prop === "callPrivateFn") {
-        const callFn: CallFn = (contract, method, args, sender, options) => {
-          const { postConditions, postConditionMode } = serializePostConditions(options);
-          const response = session[prop](
-            new CallFnArgs(
-              contract,
-              method,
-              args.map(serializeCVBytes),
-              sender,
-              postConditions,
-              postConditionMode,
-            ),
-          );
-          return parseTxResponse(response);
-        };
-        return callFn;
-      }
-
-      if (prop === "execute") {
-        const execute: Execute = (snippet) => {
-          const response = session.execute(snippet);
-          return parseTxResponse(response);
-        };
-        return execute;
-      }
-
-      if (prop === "deployContract") {
-        const callDeployContract: DeployContract = (
-          name,
-          content,
-          options,
-          sender,
-          postConditionOptions,
-        ) => {
-          const rustOptions = options
-            ? new ContractOptions(options.clarityVersion)
-            : new ContractOptions();
-          const { postConditions, postConditionMode } =
-            serializePostConditions(postConditionOptions);
-
-          const response = session.deployContract(
-            new DeployContractArgs(
-              name,
-              content,
-              rustOptions,
-              sender,
-              postConditions,
-              postConditionMode,
-            ),
-          );
-          return parseTxResponse(response);
-        };
-        return callDeployContract;
-      }
-
-      if (prop === "transferSTX") {
-        const callTransferSTX: TransferSTX = (amount, recipient, sender, options) => {
-          const { postConditions, postConditionMode } = serializePostConditions(options);
-          const response = session.transferSTX(
-            new TransferSTXArgs(
-              BigInt(amount),
-              recipient,
-              sender,
-              postConditions,
-              postConditionMode,
-            ),
-          );
-          return parseTxResponse(response);
-        };
-        return callTransferSTX;
-      }
-
-      if (prop === "mineBlock") {
-        const callMineBlock: MineBlock = (txs) => {
-          const serializedTxs = txs.map((tx) => {
-            if (tx.callPublicFn) {
-              return {
-                callPublicFn: {
-                  ...tx.callPublicFn,
-                  args_maps: tx.callPublicFn.args.map(serializeCVBytes),
-                },
-              };
-            }
-            if (tx.callPrivateFn) {
-              return {
-                callPrivateFn: {
-                  ...tx.callPrivateFn,
-                  args_maps: tx.callPrivateFn.args.map(serializeCVBytes),
-                },
-              };
-            }
-            if (tx.deployContract) {
-              return {
-                deployContract: {
-                  ...tx.deployContract,
-                },
-              };
-            }
-            return tx;
-          });
-
-          const responses: TransactionRes[] = session.mineBlock(serializedTxs);
-          return responses.map(parseTxResponse);
-        };
-        return callMineBlock;
-      }
-
-      if (prop === "getDataVar") {
-        const getDataVar: GetDataVar = (...args) => {
-          const response = session.getDataVar(...args);
-          const result = Cl.deserialize(response);
-          return result;
-        };
-        return getDataVar;
-      }
-
-      if (prop === "getMapEntry") {
-        const getMapEntry: GetMapEntry = (contract, mapName, mapKey) => {
-          const response = session.getMapEntry(contract, mapName, serializeCVBytes(mapKey));
-          const result = Cl.deserialize(response);
-          return result;
-        };
-        return getMapEntry;
-      }
-
-      return Reflect.get(session, prop, receiver);
-    },
-  };
+export function getSessionProxy(): ProxyHandler<SDK> {
+  return createSessionProxy<SDK, ContractOptions>({
+    CallFnArgs,
+    ContractOptions,
+    DeployContractArgs,
+    TransferSTXArgs,
+  });
 }

--- a/components/clarinet-sdk/node/tests/fixtures/contracts/counter.clar
+++ b/components/clarinet-sdk/node/tests/fixtures/contracts/counter.clar
@@ -51,7 +51,7 @@
 (define-public (withdraw (amount uint))
   (begin
     (asserts! (is-eq tx-sender OWNER) (err u1))
-    (stx-transfer? amount (as-contract tx-sender) OWNER)
+    (as-contract (stx-transfer? amount tx-sender OWNER))
   )
 )
 

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -175,32 +175,30 @@ describe("post-conditions on contract calls", () => {
 });
 
 describe("post-conditions on STX transfers", () => {
-  it("accepts a transfer that satisfies the conditions", () => {
-    const { result } = simnet.transferSTX(1000, address2, address1, {
-      postConditions: [Pc.principal(address1).willSendEq(1000).ustx()],
-    });
+  it("rejects the transaction before execution", () => {
+    const senderBalance = simnet.getAssetsMap().get("STX")?.get(address1);
+    const senderNonce = simnet.getAccountNonce(address1);
 
-    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
-  });
-
-  it("aborts a transfer that violates the conditions", () => {
     expect(() =>
       simnet.transferSTX(1000, address2, address1, {
-        postConditions: [Pc.principal(address1).willSendEq(999).ustx()],
+        postConditions: [Pc.principal(address1).willSendEq(1000).ustx()],
       }),
-    ).toThrow(/Post-condition check failure/);
+    ).toThrow(
+      /Invalid Stacks transaction: TokenTransfer transactions do not support post-conditions/,
+    );
 
-    expect(simnet.getAssetsMap().get("STX")?.get(address1)).toBe(100000000000000n);
+    expect(simnet.getAssetsMap().get("STX")?.get(address1)).toBe(senderBalance);
+    expect(simnet.getAccountNonce(address1)).toBe(senderNonce);
   });
 
-  it("restores the session sender after an aborted transfer", () => {
+  it("restores the session sender after a rejected transfer", () => {
     const initialSender = simnet.execute("tx-sender").result;
 
     expect(() =>
       simnet.transferSTX(1000, address2, address1, {
-        postConditions: [Pc.principal(address1).willSendEq(999).ustx()],
+        postConditions: [Pc.principal(address1).willSendEq(1000).ustx()],
       }),
-    ).toThrow(/Post-condition check failure/);
+    ).toThrow(/TokenTransfer transactions do not support post-conditions/);
 
     expect(simnet.execute("tx-sender").result).toStrictEqual(initialSender);
   });
@@ -423,14 +421,14 @@ describe("post-conditions in a mined block", () => {
     ).toThrow(/Post-condition check failure/);
   });
 
-  it("carries conditions through a transferSTX in mineBlock", () => {
-    const [ok] = simnet.mineBlock([
-      tx.transferSTX(1000, address2, address1, {
-        postConditions: [Pc.principal(address1).willSendEq(1000).ustx()],
-      }),
-    ]);
-
-    expect(ok.result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  it("rejects post-conditions on a transferSTX in mineBlock", () => {
+    expect(() =>
+      simnet.mineBlock([
+        tx.transferSTX(1000, address2, address1, {
+          postConditions: [Pc.principal(address1).willSendEq(1000).ustx()],
+        }),
+      ]),
+    ).toThrow(/TokenTransfer transactions do not support post-conditions/);
   });
 });
 

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -1,0 +1,251 @@
+import { Cl, Pc, postConditionToHex } from "@stacks/transactions";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// test the built package and not the source code
+// makes it simpler to handle wasm build
+import { Simnet, initSimnet, tx } from "..";
+
+const deployer = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
+const address1 = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+const address2 = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
+
+// `counter.increment` moves exactly this much STX from the sender to the contract.
+const INCREMENT_COST = 1_000_000;
+
+let simnet: Simnet;
+
+beforeEach(async () => {
+  simnet = await initSimnet("tests/fixtures/Clarinet.toml");
+});
+
+function getCount() {
+  const { result } = simnet.callReadOnlyFn("counter", "get-count", [], address1);
+  return result;
+}
+
+describe("post-conditions on contract calls", () => {
+  it("accepts a call whose asset movement satisfies the conditions", () => {
+    const { result } = simnet.callPublicFn("counter", "increment", [], address1, {
+      postConditions: [Pc.principal(address1).willSendEq(INCREMENT_COST).ustx()],
+    });
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+    expect(getCount()).toStrictEqual(Cl.ok(Cl.tuple({ count: Cl.uint(1) })));
+  });
+
+  it("aborts a call whose asset movement violates the conditions", () => {
+    expect(() =>
+      simnet.callPublicFn("counter", "increment", [], address1, {
+        postConditions: [
+          Pc.principal(address1)
+            .willSendEq(INCREMENT_COST + 1)
+            .ustx(),
+        ],
+      }),
+    ).toThrow(/Post-condition check failure/);
+  });
+
+  it("rolls back state when a post-condition aborts the call", () => {
+    expect(() =>
+      simnet.callPublicFn("counter", "increment", [], address1, {
+        postConditions: [Pc.principal(address1).willSendEq(1).ustx()],
+      }),
+    ).toThrow(/Post-condition check failure/);
+
+    // The counter never incremented and the sender kept its STX.
+    expect(getCount()).toStrictEqual(Cl.ok(Cl.tuple({ count: Cl.uint(0) })));
+    expect(simnet.getAssetsMap().get("STX")?.get(address1)).toBe(100000000000000n);
+  });
+
+  it("still consumes a nonce when a post-condition aborts the call", () => {
+    const before = simnet.getAccountNonce(address1);
+
+    expect(() =>
+      simnet.callPublicFn("counter", "increment", [], address1, {
+        postConditions: [Pc.principal(address1).willSendEq(1).ustx()],
+      }),
+    ).toThrow(/Post-condition check failure/);
+
+    // Mainnet includes a post-condition abort, so the nonce moves.
+    expect(simnet.getAccountNonce(address1)).toBe(before + 1n);
+  });
+
+  it("defaults to deny, so unlisted asset movement fails", () => {
+    expect(() =>
+      simnet.callPublicFn("counter", "increment", [], address1, { postConditions: [] }),
+    ).toThrow(/Post-condition check failure/);
+  });
+
+  it("permits unlisted asset movement in allow mode", () => {
+    const { result } = simnet.callPublicFn("counter", "increment", [], address1, {
+      postConditions: [],
+      postConditionMode: "allow",
+    });
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("turns enforcement on when only the mode is given", () => {
+    expect(() =>
+      simnet.callPublicFn("counter", "increment", [], address1, { postConditionMode: "deny" }),
+    ).toThrow(/Post-condition check failure/);
+  });
+
+  it("leaves asset movement unconstrained when no options are passed", () => {
+    const { result } = simnet.callPublicFn("counter", "increment", [], address1);
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("rejects originator mode before it is supported, without running the call", () => {
+    expect(() =>
+      simnet.callPublicFn("counter", "transfer-100", [Cl.principal(address2)], address1, {
+        postConditionMode: "originator",
+      }),
+    ).toThrow(/Originator post-condition mode is not supported before Stacks 3.4/);
+
+    // Rejected rather than aborted, so nothing moved and no nonce was consumed.
+    expect(simnet.getAccountNonce(address1)).toBe(0n);
+  });
+
+  it("constrains the origin in originator mode once the epoch supports it", () => {
+    simnet.setEpoch("4.0");
+
+    expect(() =>
+      simnet.callPublicFn("counter", "transfer-100", [Cl.principal(address2)], address1, {
+        postConditionMode: "originator",
+      }),
+    ).toThrow(/Post-condition check failure/);
+
+    const { result } = simnet.callPublicFn(
+      "counter",
+      "transfer-100",
+      [Cl.principal(address2)],
+      address1,
+      {
+        postConditions: [Pc.principal(address1).willSendEq(100).ustx()],
+        postConditionMode: "originator",
+      },
+    );
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("accepts a condition given as consensus hex", () => {
+    const hex = postConditionToHex(Pc.principal(address1).willSendEq(INCREMENT_COST).ustx());
+    expect(typeof hex).toBe("string");
+
+    const { result } = simnet.callPublicFn("counter", "increment", [], address1, {
+      postConditions: [hex],
+    });
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("rejects a malformed condition without running the call", () => {
+    expect(() =>
+      simnet.callPublicFn("counter", "increment", [], address1, {
+        postConditions: ["not-hex"],
+      }),
+    ).toThrow(/invalid post-condition hex/);
+
+    expect(getCount()).toStrictEqual(Cl.ok(Cl.tuple({ count: Cl.uint(0) })));
+  });
+
+  it("rejects an unknown mode", () => {
+    expect(() =>
+      // @ts-expect-error deliberately outside the union
+      simnet.callPublicFn("counter", "increment", [], address1, { postConditionMode: "maybe" }),
+    ).toThrow(/invalid post-condition mode 'maybe'/);
+  });
+});
+
+describe("post-conditions on STX transfers", () => {
+  it("accepts a transfer that satisfies the conditions", () => {
+    const { result } = simnet.transferSTX(1000, address2, address1, {
+      postConditions: [Pc.principal(address1).willSendEq(1000).ustx()],
+    });
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("aborts a transfer that violates the conditions", () => {
+    expect(() =>
+      simnet.transferSTX(1000, address2, address1, {
+        postConditions: [Pc.principal(address1).willSendEq(999).ustx()],
+      }),
+    ).toThrow(/Post-condition check failure/);
+
+    expect(simnet.getAssetsMap().get("STX")?.get(address1)).toBe(100000000000000n);
+  });
+});
+
+describe("post-conditions on contract deployments", () => {
+  const source = `(begin (unwrap-panic (stx-transfer? u500 tx-sender '${address2})))`;
+
+  it("accepts a deployment that satisfies the conditions", () => {
+    const { result } = simnet.deployContract("pays-on-deploy", source, null, address1, {
+      postConditions: [Pc.principal(address1).willSendEq(500).ustx()],
+    });
+
+    expect(result).toStrictEqual(Cl.bool(true));
+  });
+
+  it("aborts a deployment that violates the conditions", () => {
+    expect(() =>
+      simnet.deployContract("pays-on-deploy", source, null, address1, {
+        postConditions: [Pc.principal(address1).willSendEq(1).ustx()],
+      }),
+    ).toThrow(/Post-condition check failure/);
+
+    // The aborted deployment left no contract behind.
+    expect(simnet.getContractSource(`${address1}.pays-on-deploy`)).toBeUndefined();
+  });
+});
+
+describe("post-conditions in a mined block", () => {
+  it("carries conditions through mineBlock", () => {
+    const [ok] = simnet.mineBlock([
+      tx.callPublicFn("counter", "increment", [], address1, {
+        postConditions: [Pc.principal(address1).willSendEq(INCREMENT_COST).ustx()],
+      }),
+    ]);
+
+    expect(ok.result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("surfaces a violation in the batch as an error", () => {
+    expect(() =>
+      simnet.mineBlock([
+        tx.callPublicFn("counter", "increment", [], address1, {
+          postConditions: [Pc.principal(address1).willSendEq(INCREMENT_COST).ustx()],
+        }),
+        tx.callPublicFn("counter", "increment", [], address2, {
+          postConditions: [Pc.principal(address2).willSendEq(1).ustx()],
+        }),
+      ]),
+    ).toThrow(/Post-condition check failure/);
+  });
+
+  it("carries conditions through a transferSTX in mineBlock", () => {
+    const [ok] = simnet.mineBlock([
+      tx.transferSTX(1000, address2, address1, {
+        postConditions: [Pc.principal(address1).willSendEq(1000).ustx()],
+      }),
+    ]);
+
+    expect(ok.result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+});
+
+describe("read-only calls", () => {
+  it("takes no post-condition options", () => {
+    // @ts-expect-error read-only calls move no assets
+    simnet.callReadOnlyFn("counter", "get-count", [], address1, { postConditionMode: "deny" });
+  });
+});
+
+describe("deployer is unaffected", () => {
+  it("keeps existing behavior for calls with no options", () => {
+    const { result } = simnet.callPublicFn("counter", "add", [Cl.uint(2)], deployer);
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+});

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -221,23 +221,27 @@ describe("post-conditions on contract deployments", () => {
 });
 
 describe("post-conditions with multiple principals", () => {
-  it("accepts a condition for a contract principal", () => {
+  it("checks STX sent by a contract principal", () => {
     const contract = `${deployer}.counter`;
 
-    const { result } = simnet.callPublicFn(
-      "counter",
-      "transfer-100",
-      [Cl.principal(address2)],
-      address1,
-      {
-        postConditions: [
-          Pc.principal(address1).willSendEq(100).ustx(),
-          Pc.principal(contract).willSendEq(0).ustx(),
-        ],
-      },
-    );
+    simnet.callPublicFn("counter", "increment", [], deployer);
+    const contractBalance = simnet.getAssetsMap().get("STX")!.get(contract)!;
+
+    const { result } = simnet.callPublicFn("counter", "withdraw", [Cl.uint(100)], deployer, {
+      postConditions: [Pc.principal(contract).willSendEq(100).ustx()],
+    });
 
     expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+    expect(simnet.getAssetsMap().get("STX")!.get(contract)).toBe(contractBalance - 100n);
+
+    const nonce = simnet.getAccountNonce(deployer);
+    expect(() =>
+      simnet.callPublicFn("counter", "withdraw", [Cl.uint(100)], deployer, {
+        postConditions: [Pc.principal(contract).willSendEq(99).ustx()],
+      }),
+    ).toThrow(/Post-condition check failure/);
+    expect(simnet.getAssetsMap().get("STX")!.get(contract)).toBe(contractBalance - 100n);
+    expect(simnet.getAccountNonce(deployer)).toBe(nonce + 1n);
   });
 
   it("enforces every condition independently", () => {

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -175,6 +175,22 @@ describe("post-conditions on contract calls", () => {
 });
 
 describe("post-conditions on STX transfers", () => {
+  it("ignores deny mode when the post-condition list is empty", () => {
+    const senderBalance = simnet.getAssetsMap().get("STX")!.get(address1)!;
+    const recipientBalance = simnet.getAssetsMap().get("STX")!.get(address2)!;
+    const senderNonce = simnet.getAccountNonce(address1);
+
+    const { result } = simnet.transferSTX(1000, address2, address1, {
+      postConditions: [],
+      postConditionMode: "deny",
+    });
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+    expect(simnet.getAssetsMap().get("STX")!.get(address1)).toBe(senderBalance - 1000n);
+    expect(simnet.getAssetsMap().get("STX")!.get(address2)).toBe(recipientBalance + 1000n);
+    expect(simnet.getAccountNonce(address1)).toBe(senderNonce + 1n);
+  });
+
   it("rejects the transaction before execution", () => {
     const senderBalance = simnet.getAssetsMap().get("STX")?.get(address1);
     const senderNonce = simnet.getAccountNonce(address1);

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -176,6 +176,18 @@ describe("post-conditions on STX transfers", () => {
 
     expect(simnet.getAssetsMap().get("STX")?.get(address1)).toBe(100000000000000n);
   });
+
+  it("restores the session sender after an aborted transfer", () => {
+    const initialSender = simnet.execute("tx-sender").result;
+
+    expect(() =>
+      simnet.transferSTX(1000, address2, address1, {
+        postConditions: [Pc.principal(address1).willSendEq(999).ustx()],
+      }),
+    ).toThrow(/Post-condition check failure/);
+
+    expect(simnet.execute("tx-sender").result).toStrictEqual(initialSender);
+  });
 });
 
 describe("post-conditions on contract deployments", () => {

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -201,6 +201,52 @@ describe("post-conditions on contract deployments", () => {
   });
 });
 
+describe("post-conditions on fungible tokens", () => {
+  const source = `
+(define-fungible-token widget)
+(define-public (mint (amount uint) (to principal)) (ft-mint? widget amount to))
+(define-public (send (amount uint) (to principal)) (ft-transfer? widget amount tx-sender to))
+(define-read-only (balance-of (who principal)) (ft-get-balance widget who))
+`;
+
+  let token: string;
+
+  beforeEach(() => {
+    simnet.deployContract("widget", source, null, deployer);
+    token = `${deployer}.widget`;
+    simnet.callPublicFn("widget", "mint", [Cl.uint(1000), Cl.principal(address1)], deployer);
+  });
+
+  it("accepts a transfer that satisfies the conditions", () => {
+    const { result } = simnet.callPublicFn(
+      "widget",
+      "send",
+      [Cl.uint(50), Cl.principal(address2)],
+      address1,
+      { postConditions: [Pc.principal(address1).willSendEq(50).ft(token, "widget")] },
+    );
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("aborts a transfer that violates the conditions", () => {
+    expect(() =>
+      simnet.callPublicFn("widget", "send", [Cl.uint(50), Cl.principal(address2)], address1, {
+        postConditions: [Pc.principal(address1).willSendEq(49).ft(token, "widget")],
+      }),
+    ).toThrow(/Post-condition check failure/);
+
+    // The tokens never moved.
+    const { result } = simnet.callReadOnlyFn(
+      "widget",
+      "balance-of",
+      [Cl.principal(address1)],
+      address1,
+    );
+    expect(result).toStrictEqual(Cl.uint(1000));
+  });
+});
+
 describe("post-conditions in a mined block", () => {
   it("carries conditions through mineBlock", () => {
     const [ok] = simnet.mineBlock([
@@ -240,6 +286,20 @@ describe("read-only calls", () => {
   it("takes no post-condition options", () => {
     // @ts-expect-error read-only calls move no assets
     simnet.callReadOnlyFn("counter", "get-count", [], address1, { postConditionMode: "deny" });
+  });
+});
+
+describe("a contract body runs as its declared deployer", () => {
+  it("debits the deployer, not whoever the session last acted as", () => {
+    const source = `(begin (unwrap-panic (stx-transfer? u500 tx-sender '${address2})))`;
+    const before = simnet.getAssetsMap().get("STX")!;
+
+    simnet.deployContract("pays-on-deploy", source, null, address1);
+
+    const after = simnet.getAssetsMap().get("STX")!;
+    expect(after.get(address1)).toBe(before.get(address1)! - 500n);
+    expect(after.get(deployer)).toBe(before.get(deployer));
+    expect(after.get(address2)).toBe(before.get(address2)! + 500n);
   });
 });
 

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -202,6 +202,10 @@ describe("post-conditions on contract deployments", () => {
   });
 
   it("aborts a deployment that violates the conditions", () => {
+    const senderBalance = simnet.getAssetsMap().get("STX")!.get(address1)!;
+    const recipientBalance = simnet.getAssetsMap().get("STX")!.get(address2)!;
+    const nonce = simnet.getAccountNonce(address1);
+
     expect(() =>
       simnet.deployContract("pays-on-deploy", source, null, address1, {
         postConditions: [Pc.principal(address1).willSendEq(1).ustx()],
@@ -210,6 +214,49 @@ describe("post-conditions on contract deployments", () => {
 
     // The aborted deployment left no contract behind.
     expect(simnet.getContractSource(`${address1}.pays-on-deploy`)).toBeUndefined();
+    expect(simnet.getAssetsMap().get("STX")!.get(address1)).toBe(senderBalance);
+    expect(simnet.getAssetsMap().get("STX")!.get(address2)).toBe(recipientBalance);
+    expect(simnet.getAccountNonce(address1)).toBe(nonce + 1n);
+  });
+});
+
+describe("post-conditions with multiple principals", () => {
+  it("accepts a condition for a contract principal", () => {
+    const contract = `${deployer}.counter`;
+
+    const { result } = simnet.callPublicFn(
+      "counter",
+      "transfer-100",
+      [Cl.principal(address2)],
+      address1,
+      {
+        postConditions: [
+          Pc.principal(address1).willSendEq(100).ustx(),
+          Pc.principal(contract).willSendEq(0).ustx(),
+        ],
+      },
+    );
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("enforces every condition independently", () => {
+    const conditions = [
+      Pc.principal(address1).willSendEq(100).ustx(),
+      Pc.principal(address2).willSendEq(0).ustx(),
+    ];
+
+    expect(
+      simnet.callPublicFn("counter", "transfer-100", [Cl.principal(address2)], address1, {
+        postConditions: conditions,
+      }).result,
+    ).toStrictEqual(Cl.ok(Cl.bool(true)));
+
+    expect(() =>
+      simnet.callPublicFn("counter", "transfer-100", [Cl.principal(address2)], address1, {
+        postConditions: [conditions[0], Pc.principal(address2).willSendEq(1).ustx()],
+      }),
+    ).toThrow(/Post-condition check failure/);
   });
 });
 
@@ -266,6 +313,7 @@ describe("post-conditions on non-fungible tokens", () => {
 (define-non-fungible-token badge uint)
 (define-public (mint (id uint) (to principal)) (nft-mint? badge id to))
 (define-public (send (id uint) (to principal)) (nft-transfer? badge id tx-sender to))
+(define-read-only (owner-of (id uint)) (nft-get-owner? badge id))
 `;
 
   let token: string;
@@ -296,6 +344,10 @@ describe("post-conditions on non-fungible tokens", () => {
         postConditions: [Pc.principal(address1).willSendAsset().nft(token, "badge", Cl.uint(8))],
       }),
     ).toThrow(/Post-condition check failure/);
+
+    expect(simnet.callReadOnlyFn("badge", "owner-of", [Cl.uint(7)], address1).result).toStrictEqual(
+      Cl.some(Cl.principal(address1)),
+    );
   });
 });
 
@@ -311,6 +363,9 @@ describe("post-conditions in a mined block", () => {
   });
 
   it("surfaces a violation in the batch as an error", () => {
+    const address1Nonce = simnet.getAccountNonce(address1);
+    const address2Nonce = simnet.getAccountNonce(address2);
+
     expect(() =>
       simnet.mineBlock([
         tx.callPublicFn("counter", "increment", [], address1, {
@@ -321,6 +376,12 @@ describe("post-conditions in a mined block", () => {
         }),
       ]),
     ).toThrow(/Post-condition check failure/);
+
+    // Transactions before the abort remain committed; the aborted transaction
+    // rolls back its payload but still consumes its nonce.
+    expect(getCount()).toStrictEqual(Cl.ok(Cl.tuple({ count: Cl.uint(1) })));
+    expect(simnet.getAccountNonce(address1)).toBe(address1Nonce + 1n);
+    expect(simnet.getAccountNonce(address2)).toBe(address2Nonce + 1n);
   });
 
   it("carries conditions through a deployContract in mineBlock", () => {

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -1,4 +1,10 @@
-import { Cl, Pc, postConditionToHex } from "@stacks/transactions";
+import {
+  Cl,
+  Pc,
+  PostConditionMode,
+  postConditionToHex,
+  postConditionToWire,
+} from "@stacks/transactions";
 import { beforeEach, describe, expect, it } from "vitest";
 
 // test the built package and not the source code
@@ -76,10 +82,10 @@ describe("post-conditions on contract calls", () => {
     ).toThrow(/Post-condition check failure/);
   });
 
-  it("permits unlisted asset movement in allow mode", () => {
+  it("accepts the stacks.js mode enum", () => {
     const { result } = simnet.callPublicFn("counter", "increment", [], address1, {
       postConditions: [],
-      postConditionMode: "allow",
+      postConditionMode: PostConditionMode.Allow,
     });
 
     expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
@@ -99,7 +105,7 @@ describe("post-conditions on contract calls", () => {
   it("rejects originator mode before it is supported, without running the call", () => {
     expect(() =>
       simnet.callPublicFn("counter", "transfer-100", [Cl.principal(address2)], address1, {
-        postConditionMode: "originator",
+        postConditionMode: PostConditionMode.Originator,
       }),
     ).toThrow(/Originator post-condition mode is not supported before Stacks 3.4/);
 
@@ -135,6 +141,16 @@ describe("post-conditions on contract calls", () => {
 
     const { result } = simnet.callPublicFn("counter", "increment", [], address1, {
       postConditions: [hex],
+    });
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("accepts a stacks.js wire post-condition", () => {
+    const condition = postConditionToWire(Pc.principal(address1).willSendEq(INCREMENT_COST).ustx());
+
+    const { result } = simnet.callPublicFn("counter", "increment", [], address1, {
+      postConditions: [condition],
     });
 
     expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -418,13 +418,6 @@ describe("post-conditions in a mined block", () => {
   });
 });
 
-describe("read-only calls", () => {
-  it("takes no post-condition options", () => {
-    // @ts-expect-error read-only calls move no assets
-    simnet.callReadOnlyFn("counter", "get-count", [], address1, { postConditionMode: "deny" });
-  });
-});
-
 describe("a contract body runs as its declared deployer", () => {
   it("debits the deployer, not whoever the session last acted as", () => {
     const source = `(begin (unwrap-panic (stx-transfer? u500 tx-sender '${address2})))`;

--- a/components/clarinet-sdk/node/tests/post-conditions.test.ts
+++ b/components/clarinet-sdk/node/tests/post-conditions.test.ts
@@ -247,6 +247,46 @@ describe("post-conditions on fungible tokens", () => {
   });
 });
 
+describe("post-conditions on non-fungible tokens", () => {
+  // The `Nonfungible` variant embeds a Clarity value for the asset id, so this
+  // exercises value serialization inside a post-condition.
+  const source = `
+(define-non-fungible-token badge uint)
+(define-public (mint (id uint) (to principal)) (nft-mint? badge id to))
+(define-public (send (id uint) (to principal)) (nft-transfer? badge id tx-sender to))
+`;
+
+  let token: string;
+
+  beforeEach(() => {
+    simnet.deployContract("badge", source, null, deployer);
+    token = `${deployer}.badge`;
+    simnet.callPublicFn("badge", "mint", [Cl.uint(7), Cl.principal(address1)], deployer);
+  });
+
+  it("accepts a transfer that satisfies the conditions", () => {
+    const { result } = simnet.callPublicFn(
+      "badge",
+      "send",
+      [Cl.uint(7), Cl.principal(address2)],
+      address1,
+      {
+        postConditions: [Pc.principal(address1).willSendAsset().nft(token, "badge", Cl.uint(7))],
+      },
+    );
+
+    expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+  });
+
+  it("aborts when the condition names a different asset id", () => {
+    expect(() =>
+      simnet.callPublicFn("badge", "send", [Cl.uint(7), Cl.principal(address2)], address1, {
+        postConditions: [Pc.principal(address1).willSendAsset().nft(token, "badge", Cl.uint(8))],
+      }),
+    ).toThrow(/Post-condition check failure/);
+  });
+});
+
 describe("post-conditions in a mined block", () => {
   it("carries conditions through mineBlock", () => {
     const [ok] = simnet.mineBlock([
@@ -266,6 +306,25 @@ describe("post-conditions in a mined block", () => {
         }),
         tx.callPublicFn("counter", "increment", [], address2, {
           postConditions: [Pc.principal(address2).willSendEq(1).ustx()],
+        }),
+      ]),
+    ).toThrow(/Post-condition check failure/);
+  });
+
+  it("carries conditions through a deployContract in mineBlock", () => {
+    const source = `(begin (unwrap-panic (stx-transfer? u500 tx-sender '${address2})))`;
+
+    const [ok] = simnet.mineBlock([
+      tx.deployContract("pays-in-block", source, null, address1, {
+        postConditions: [Pc.principal(address1).willSendEq(500).ustx()],
+      }),
+    ]);
+    expect(ok.result).toStrictEqual(Cl.bool(true));
+
+    expect(() =>
+      simnet.mineBlock([
+        tx.deployContract("pays-again", source, null, address1, {
+          postConditions: [Pc.principal(address1).willSendEq(1).ustx()],
         }),
       ]),
     ).toThrow(/Post-condition check failure/);

--- a/components/clarinet-sdk/node/type-tests/read-only-calls.ts
+++ b/components/clarinet-sdk/node/type-tests/read-only-calls.ts
@@ -1,0 +1,16 @@
+import type { Simnet } from "../src/sdkProxy";
+
+declare const simnet: Simnet;
+
+simnet.callReadOnlyFn("counter", "get-count", [], "ST000000000000000000002AMW42H");
+
+// Public calls are transactions and accept post-condition options.
+simnet.callPublicFn("counter", "increment", [], "ST000000000000000000002AMW42H", {
+  postConditions: [],
+});
+
+// Read-only calls cannot move assets, so post-condition options are invalid.
+// @ts-expect-error callReadOnlyFn intentionally has no post-condition options parameter
+simnet.callReadOnlyFn("counter", "get-count", [], "ST000000000000000000002AMW42H", {
+  postConditionMode: "deny",
+});

--- a/components/clarinet-sdk/node/type-tests/tsconfig.json
+++ b/components/clarinet-sdk/node/type-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "target": "esnext"
+  },
+  "include": ["./**/*.ts"]
+}

--- a/components/clarity-repl/Cargo.toml
+++ b/components/clarity-repl/Cargo.toml
@@ -39,6 +39,8 @@ indoc = { workspace = true }
 clarity = { workspace = true, default-features = false, features = ["rusqlite", "developer-mode", "devtools"] }
 reqwest = { workspace = true, features = ["blocking"] }
 clarity-types = { workspace = true, features = ["developer-mode"] }
+stacks-codec = { workspace = true }
+stacks-transactions = { workspace = true }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 pox-locking = { workspace = true, default-features = true }
 
@@ -60,6 +62,8 @@ memchr = { version = "2.4.1", optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 clarity = { workspace = true, default-features = false, features = ["developer-mode", "devtools", "wasm-web"] }
 clarity-types = { workspace = true, features = ["developer-mode", "wasm-web"] }
+stacks-codec = { workspace = true, features = ["wasm-web"] }
+stacks-transactions = { workspace = true, features = ["wasm-web"] }
 pox-locking = { workspace = true, default-features = false }
 
 comfy-table = { version = "=7.2.2", default-features = false }

--- a/components/clarity-repl/benches/simnet.rs
+++ b/components/clarity-repl/benches/simnet.rs
@@ -2,6 +2,7 @@ use std::hint::black_box;
 
 use clarinet_defaults::{DEFAULT_CLARITY_VERSION, DEFAULT_EPOCH};
 use clarity::vm::{EvaluationResult, ExecutionResult, SymbolicExpression, Value as ClarityValue};
+use clarity_repl::repl::post_conditions::PostConditionCheck;
 use clarity_repl::repl::session::CallKind;
 use clarity_repl::repl::{
     ClarityCodeSource, ClarityContract, ContractDeployer, Epoch, Session, SessionSettings,
@@ -61,9 +62,9 @@ fn init_session() -> Session {
         skip_analysis: false,
     };
 
-    let _ = session.deploy_contract(&contract, false, None);
+    let _ = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
 
-    let _ = session.deploy_contract(&contract, false, None);
+    let _ = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
     session.advance_burn_chain_tip(1);
 
     assert_eq!(session.interpreter.get_block_height(), 3);
@@ -88,6 +89,7 @@ fn call_fn(
             false,
             false,
             CallKind::Transaction,
+            PostConditionCheck::Unchecked,
         )
         .unwrap();
 

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -135,11 +135,7 @@ impl NonceCharge {
     }
 }
 
-/// What an execution owes beyond running its payload.
-///
-/// Both obligations are settled together, in the payload's own database
-/// transaction — see [`Self::settle`]. The default is "not a transaction at
-/// all", which is what a read-only call or a bare snippet owes.
+/// Transaction-level obligations applied after executing a payload.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TransactionTerms {
     /// The sender nonce this execution consumes.
@@ -149,20 +145,14 @@ pub struct TransactionTerms {
 }
 
 impl TransactionTerms {
-    /// Settle these terms against the payload `global_context` has executed
-    /// but not yet committed.
-    ///
-    /// Mainnet checks post-conditions in an abort callback, so the decision
-    /// happens *before* the commit: a violation rolls the payload back rather
-    /// than undoing it afterwards. The nonce is charged either way, because a
-    /// post-condition abort is still an included transaction.
+    /// Commit a valid payload, or roll back a post-condition violation while
+    /// still charging the nonce of the included transaction.
     fn settle(
         &self,
         global_context: &mut GlobalContext,
         epoch: StacksEpochId,
     ) -> Result<Settlement, String> {
-        // Read the asset map only when something constrains it, so the path
-        // every pre-existing transaction takes cannot fail here at all.
+        // Preserve the pre-existing path when enforcement is disabled.
         let violation = match &self.post_conditions {
             PostConditionCheck::Unchecked => None,
             checked => {
@@ -195,8 +185,7 @@ impl TransactionTerms {
 enum Settlement {
     /// The payload and the nonce both committed.
     Committed,
-    /// A post-condition rejected the payload. It was rolled back and only the
-    /// nonce committed, the way mainnet handles `AbortedByCallback`.
+    /// The payload was rolled back and only its nonce committed.
     Aborted(String),
 }
 
@@ -442,8 +431,7 @@ impl ClarityInterpreter {
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
         terms: &TransactionTerms,
     ) -> Result<AnnotatedExecutionResult, ExecutionError> {
-        // Mainnet rejects post-conditions the epoch does not support before any
-        // of the transaction runs, so no nonce is consumed.
+        // Reject unsupported post-conditions before execution.
         if let Err(e) = terms
             .post_conditions
             .validate_for_epoch(contract.epoch.resolve())
@@ -1093,8 +1081,7 @@ impl ClarityInterpreter {
     ) -> Result<ExecutionResult, ContractCallFailure> {
         let tx_sender: PrincipalData = self.tx_sender.clone().into();
 
-        // Mainnet rejects post-conditions the epoch does not support before any
-        // of the transaction runs, so no nonce is consumed.
+        // Reject unsupported post-conditions before execution.
         if let Err(e) = terms.post_conditions.validate_for_epoch(epoch) {
             return Err(ContractCallFailure {
                 error: ContractCallError::Uncategorized(e),

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -29,6 +29,7 @@ use clarity::vm::{
     eval, eval_all, ClarityVersion, ContractEvaluationResult, CostSynthesis, EvaluationResult,
     ExecutionResult, ParsedContract, SnippetEvaluationResult,
 };
+use clarity_types::effects::AssetMap;
 use clarity_types::types::{
     AssetIdentifier, PrincipalData, QualifiedContractIdentifier, StandardPrincipalData,
 };
@@ -159,17 +160,22 @@ impl TransactionTerms {
                 let asset_map = global_context
                     .get_readonly_asset_map()
                     .map_err(|e| format!("failed to read the asset map: {e}"))?;
-                checked.evaluate(asset_map, epoch)?
+                checked
+                    .evaluate(asset_map, epoch)?
+                    .map(|reason| (reason, asset_map.clone()))
             }
         };
 
-        if let Some(reason) = violation {
+        if let Some((reason, assets_modified)) = violation {
             global_context
                 .roll_back()
                 .map_err(|e| format!("failed to roll back an aborted transaction: {e}"))?;
             global_context.begin();
             self.charge.commit_alone(global_context)?;
-            return Ok(Settlement::Aborted(reason));
+            return Ok(Settlement::Aborted {
+                reason,
+                assets_modified: Box::new(assets_modified),
+            });
         }
 
         self.charge.apply(&mut global_context.database)?;
@@ -186,7 +192,24 @@ enum Settlement {
     /// The payload and the nonce both committed.
     Committed,
     /// The payload was rolled back and only its nonce committed.
-    Aborted(String),
+    Aborted {
+        reason: String,
+        assets_modified: Box<AssetMap>,
+    },
+}
+
+fn post_condition_abort(
+    output: Option<Value>,
+    assets_modified: AssetMap,
+    tx_events: Vec<StacksTransactionEvent>,
+    reason: String,
+) -> ClarityError {
+    ClarityError::AbortedByCallback {
+        output: output.map(Box::new),
+        assets_modified: Box::new(assets_modified),
+        tx_events,
+        reason,
+    }
 }
 
 /// Report a failed execution to the eval hooks, leaving them installed.
@@ -1017,11 +1040,24 @@ impl ClarityInterpreter {
         // Settle the nonce and execution state atomically.
         match terms.settle(&mut global_context, epoch) {
             Ok(Settlement::Committed) => {}
-            Ok(Settlement::Aborted(reason)) => {
+            Ok(Settlement::Aborted {
+                reason,
+                assets_modified,
+            }) => {
                 notify_hooks_of_failure(&mut global_context, &reason);
+                let output = match &eval_result {
+                    EvaluationResult::Contract(_) => None,
+                    EvaluationResult::Snippet(result) => Some(result.result.clone()),
+                };
+                let clarity_error = post_condition_abort(
+                    output,
+                    *assets_modified,
+                    emitted_events.clone(),
+                    reason.clone(),
+                );
                 return Err(ExecutionError {
                     diagnostics: vec![runtime_diagnostic(reason)],
-                    inclusion: BlockInclusion::Included,
+                    inclusion: BlockInclusion::from_runtime_error(clarity_error, epoch),
                 });
             }
             Err(e) => return Err(ExecutionError::rejected(vec![runtime_diagnostic(e)])),
@@ -1174,11 +1210,23 @@ impl ClarityInterpreter {
         // Settle the nonce and call state atomically.
         match terms.settle(&mut global_context, epoch) {
             Ok(Settlement::Committed) => {}
-            Ok(Settlement::Aborted(reason)) => {
+            Ok(Settlement::Aborted {
+                reason,
+                assets_modified,
+            }) => {
                 notify_hooks_of_failure(&mut global_context, &reason);
+                let clarity_error = post_condition_abort(
+                    match &eval_result {
+                        EvaluationResult::Snippet(result) => Some(result.result.clone()),
+                        EvaluationResult::Contract(_) => None,
+                    },
+                    *assets_modified,
+                    emitted_events.clone(),
+                    reason.clone(),
+                );
                 return Err(ContractCallFailure {
                     error: ContractCallError::PostConditionAborted(reason),
-                    inclusion: BlockInclusion::Included,
+                    inclusion: BlockInclusion::from_runtime_error(clarity_error, epoch),
                 });
             }
             Err(e) => {
@@ -1602,6 +1650,36 @@ mod tests {
             settings.unwrap_or_default(),
             None,
         )
+    }
+
+    #[test]
+    fn post_condition_abort_uses_the_mainnet_error_shape() {
+        let output = Value::UInt(7);
+        let error = post_condition_abort(
+            Some(output.clone()),
+            AssetMap::new(),
+            vec![],
+            "condition failed".into(),
+        );
+
+        match &error {
+            ClarityError::AbortedByCallback {
+                output: actual_output,
+                assets_modified,
+                tx_events,
+                reason,
+            } => {
+                assert_eq!(actual_output.as_deref(), Some(&output));
+                assert_eq!(assets_modified.as_ref(), &AssetMap::new());
+                assert!(tx_events.is_empty());
+                assert_eq!(reason, "condition failed");
+            }
+            other => panic!("expected AbortedByCallback, got {other:?}"),
+        }
+        assert_eq!(
+            BlockInclusion::from_runtime_error(error, StacksEpochId::Epoch33),
+            BlockInclusion::Included
+        );
     }
 
     #[track_caller]

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -123,8 +123,9 @@ impl NonceCharge {
             .map_err(|e| format!("failed to set nonce for {principal}: {e}"))
     }
 
-    /// Commit only the charge after an included execution failure.
-    /// `GlobalContext::execute` has already rolled back the nested execution.
+    /// Commit only the charge, for an included failure whose state changes the
+    /// caller has already discarded. Expects an open transaction holding
+    /// nothing but the charge.
     fn commit_alone(&self, global_context: &mut GlobalContext) -> Result<(), String> {
         self.apply(&mut global_context.database)?;
         global_context
@@ -137,25 +138,14 @@ impl NonceCharge {
 /// What an execution owes beyond running its payload.
 ///
 /// Both obligations are settled together, in the payload's own database
-/// transaction — see [`ClarityInterpreter::settle`]. The default is "not a
-/// transaction at all", which is what a read-only call or a bare snippet owes.
+/// transaction — see [`Self::settle`]. The default is "not a transaction at
+/// all", which is what a read-only call or a bare snippet owes.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct TransactionTerms {
     /// The sender nonce this execution consumes.
     pub charge: NonceCharge,
     /// The constraint on this execution's asset movement.
     pub post_conditions: PostConditionCheck,
-}
-
-impl TransactionTerms {
-    /// The terms of a transaction sent by `sender` that carries no
-    /// post-conditions.
-    pub fn sent_by(sender: PrincipalData) -> Self {
-        Self {
-            charge: NonceCharge::Sender(sender),
-            post_conditions: PostConditionCheck::Unchecked,
-        }
-    }
 }
 
 impl TransactionTerms {
@@ -171,11 +161,16 @@ impl TransactionTerms {
         global_context: &mut GlobalContext,
         epoch: StacksEpochId,
     ) -> Result<Settlement, String> {
-        let violation = {
-            let asset_map = global_context
-                .get_readonly_asset_map()
-                .map_err(|e| format!("failed to read the asset map: {e}"))?;
-            self.post_conditions.evaluate(asset_map, epoch)?
+        // Read the asset map only when something constrains it, so the path
+        // every pre-existing transaction takes cannot fail here at all.
+        let violation = match &self.post_conditions {
+            PostConditionCheck::Unchecked => None,
+            checked => {
+                let asset_map = global_context
+                    .get_readonly_asset_map()
+                    .map_err(|e| format!("failed to read the asset map: {e}"))?;
+                checked.evaluate(asset_map, epoch)?
+            }
         };
 
         if let Some(reason) = violation {
@@ -195,6 +190,16 @@ impl TransactionTerms {
     }
 }
 
+/// How an execution's database transaction was settled.
+#[derive(Debug)]
+enum Settlement {
+    /// The payload and the nonce both committed.
+    Committed,
+    /// A post-condition rejected the payload. It was rolled back and only the
+    /// nonce committed, the way mainnet handles `AbortedByCallback`.
+    Aborted(String),
+}
+
 /// Report a failed execution to the eval hooks, leaving them installed.
 fn notify_hooks_of_failure(global_context: &mut GlobalContext, error: &str) {
     let Some(mut eval_hooks) = global_context.eval_hooks.take() else {
@@ -204,16 +209,6 @@ fn notify_hooks_of_failure(global_context: &mut GlobalContext, error: &str) {
         hook.did_complete(Err(error.to_string()));
     }
     global_context.eval_hooks = Some(eval_hooks);
-}
-
-/// How an execution's database transaction was settled.
-#[derive(Debug)]
-enum Settlement {
-    /// The payload and the nonce both committed.
-    Committed,
-    /// A post-condition rejected the payload. It was rolled back and only the
-    /// nonce committed, the way mainnet handles `AbortedByCallback`.
-    Aborted(String),
 }
 
 /// A failed `ClarityInterpreter::run`.

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -42,6 +42,7 @@ use crate::analysis::annotation::{Annotation, AnnotationKind};
 use crate::analysis::ast_dependency_detector::{ASTDependencyDetector, Dependency};
 use crate::analysis::{self, LintDiagnostic};
 use crate::repl::datastore::{ClarityDatastore, Datastore};
+use crate::repl::post_conditions::PostConditionCheck;
 use crate::repl::session::AnnotatedExecutionResult;
 use crate::repl::Settings;
 
@@ -133,6 +134,88 @@ impl NonceCharge {
     }
 }
 
+/// What an execution owes beyond running its payload.
+///
+/// Both obligations are settled together, in the payload's own database
+/// transaction — see [`ClarityInterpreter::settle`]. The default is "not a
+/// transaction at all", which is what a read-only call or a bare snippet owes.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TransactionTerms {
+    /// The sender nonce this execution consumes.
+    pub charge: NonceCharge,
+    /// The constraint on this execution's asset movement.
+    pub post_conditions: PostConditionCheck,
+}
+
+impl TransactionTerms {
+    /// The terms of a transaction sent by `sender` that carries no
+    /// post-conditions.
+    pub fn sent_by(sender: PrincipalData) -> Self {
+        Self {
+            charge: NonceCharge::Sender(sender),
+            post_conditions: PostConditionCheck::Unchecked,
+        }
+    }
+}
+
+impl TransactionTerms {
+    /// Settle these terms against the payload `global_context` has executed
+    /// but not yet committed.
+    ///
+    /// Mainnet checks post-conditions in an abort callback, so the decision
+    /// happens *before* the commit: a violation rolls the payload back rather
+    /// than undoing it afterwards. The nonce is charged either way, because a
+    /// post-condition abort is still an included transaction.
+    fn settle(
+        &self,
+        global_context: &mut GlobalContext,
+        epoch: StacksEpochId,
+    ) -> Result<Settlement, String> {
+        let violation = {
+            let asset_map = global_context
+                .get_readonly_asset_map()
+                .map_err(|e| format!("failed to read the asset map: {e}"))?;
+            self.post_conditions.evaluate(asset_map, epoch)?
+        };
+
+        if let Some(reason) = violation {
+            global_context
+                .roll_back()
+                .map_err(|e| format!("failed to roll back an aborted transaction: {e}"))?;
+            global_context.begin();
+            self.charge.commit_alone(global_context)?;
+            return Ok(Settlement::Aborted(reason));
+        }
+
+        self.charge.apply(&mut global_context.database)?;
+        global_context
+            .commit()
+            .map(|_| Settlement::Committed)
+            .map_err(|e| format!("failed to commit: {e}"))
+    }
+}
+
+/// Report a failed execution to the eval hooks, leaving them installed.
+fn notify_hooks_of_failure(global_context: &mut GlobalContext, error: &str) {
+    let Some(mut eval_hooks) = global_context.eval_hooks.take() else {
+        return;
+    };
+    for hook in eval_hooks.iter_mut() {
+        hook.did_complete(Err(error.to_string()));
+    }
+    global_context.eval_hooks = Some(eval_hooks);
+}
+
+/// How an execution's database transaction was settled.
+#[derive(Debug)]
+enum Settlement {
+    /// The payload and the nonce both committed.
+    Committed,
+    /// A post-condition rejected the payload. It was rolled back and only the
+    /// nonce committed, the way mainnet handles `AbortedByCallback`.
+    Aborted(String),
+}
+
 /// A failed `ClarityInterpreter::run`.
 #[derive(Debug, Clone)]
 pub struct ExecutionError {
@@ -193,6 +276,9 @@ impl std::error::Error for ContractCallFailure {}
 pub enum ContractCallError {
     NoSuchContract(String),
     NoSuchFunction(String),
+    /// A post-condition rejected the call's asset movement. The message is
+    /// already phrased for the user by the upstream checker.
+    PostConditionAborted(String),
     Uncategorized(String),
 }
 
@@ -264,6 +350,9 @@ impl std::fmt::Display for ContractCallError {
             ContractCallError::NoSuchFunction(function_name) => {
                 write!(f, "NoSuchFunction({function_name})")
             }
+            ContractCallError::PostConditionAborted(reason) => {
+                write!(f, "PostConditionAborted({reason})")
+            }
             ContractCallError::Uncategorized(message) => {
                 write!(f, "Uncategorized({message})")
             }
@@ -331,7 +420,7 @@ impl ClarityInterpreter {
     /// Execute `contract` without consuming anyone's nonce.
     ///
     /// For bare snippets and function-argument evaluation. A deploy or an STX
-    /// transfer is a transaction and must use [`Self::run_transaction`].
+    /// transfer is a transaction and must use [`Self::run_with_terms`].
     pub fn run(
         &mut self,
         contract: &ClarityContract,
@@ -339,42 +428,34 @@ impl ClarityInterpreter {
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
     ) -> Result<AnnotatedExecutionResult, ExecutionError> {
-        self.run_with_charge(
+        self.run_with_terms(
             contract,
             cached_ast,
             cost_track,
             eval_hooks,
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         )
     }
 
-    /// Execute `contract` as a transaction sent by `sender`, consuming one of
-    /// its nonces in the same commit as the execution's own state changes.
-    pub fn run_transaction(
+    /// Execute `contract` as a transaction, settling `terms` in the same
+    /// commit as the execution's own state changes.
+    pub fn run_with_terms(
         &mut self,
         contract: &ClarityContract,
         cached_ast: Option<&ContractAST>,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
-        sender: PrincipalData,
+        terms: &TransactionTerms,
     ) -> Result<AnnotatedExecutionResult, ExecutionError> {
-        self.run_with_charge(
-            contract,
-            cached_ast,
-            cost_track,
-            eval_hooks,
-            &NonceCharge::Sender(sender),
-        )
-    }
+        // Mainnet rejects post-conditions the epoch does not support before any
+        // of the transaction runs, so no nonce is consumed.
+        if let Err(e) = terms
+            .post_conditions
+            .validate_for_epoch(contract.epoch.resolve())
+        {
+            return Err(ExecutionError::rejected(vec![runtime_diagnostic(e)]));
+        }
 
-    pub(crate) fn run_with_charge(
-        &mut self,
-        contract: &ClarityContract,
-        cached_ast: Option<&ContractAST>,
-        cost_track: bool,
-        eval_hooks: Option<Vec<&mut dyn EvalHook>>,
-        charge: &NonceCharge,
-    ) -> Result<AnnotatedExecutionResult, ExecutionError> {
         let (ast, mut diagnostics, success) = match cached_ast {
             Some(ast) => (ast.clone(), vec![], true),
             None => self.build_ast(contract),
@@ -390,7 +471,7 @@ impl ClarityInterpreter {
         // nonce for a transaction rejected during parsing.
         if !success {
             let inclusion = self.classify_parse_failure(contract);
-            return Err(self.fail_before_execution(diagnostics, inclusion, charge));
+            return Err(self.fail_before_execution(diagnostics, inclusion, terms));
         }
 
         let (analysis, lint_diagnostics) = match self.run_analysis(contract, &ast, &annotations) {
@@ -400,22 +481,22 @@ impl ClarityInterpreter {
                 return Err(self.fail_before_execution(
                     diagnostics,
                     analysis_failure.inclusion,
-                    charge,
+                    terms,
                 ));
             }
         };
 
-        let mut result =
-            match self.execute(contract, &ast, analysis, cost_track, eval_hooks, charge) {
-                Ok(result) => result,
-                Err(mut runtime_failure) => {
-                    diagnostics.append(&mut runtime_failure.diagnostics);
-                    return Err(ExecutionError {
-                        diagnostics,
-                        inclusion: runtime_failure.inclusion,
-                    });
-                }
-            };
+        let mut result = match self.execute(contract, &ast, analysis, cost_track, eval_hooks, terms)
+        {
+            Ok(result) => result,
+            Err(mut runtime_failure) => {
+                diagnostics.append(&mut runtime_failure.diagnostics);
+                return Err(ExecutionError {
+                    diagnostics,
+                    inclusion: runtime_failure.inclusion,
+                });
+            }
+        };
 
         result.diagnostics = diagnostics.to_vec();
         Ok(AnnotatedExecutionResult {
@@ -429,9 +510,11 @@ impl ClarityInterpreter {
         &mut self,
         mut diagnostics: Vec<Diagnostic>,
         inclusion: BlockInclusion,
-        charge: &NonceCharge,
+        terms: &TransactionTerms,
     ) -> ExecutionError {
-        if let (BlockInclusion::Included, NonceCharge::Sender(principal)) = (inclusion, charge) {
+        if let (BlockInclusion::Included, NonceCharge::Sender(principal)) =
+            (inclusion, &terms.charge)
+        {
             if let Err(e) = self.increment_nonce(&principal.clone()) {
                 diagnostics.push(runtime_diagnostic(e));
                 return ExecutionError::rejected(diagnostics);
@@ -752,7 +835,7 @@ impl ClarityInterpreter {
         analysis: ContractAnalysis,
         cost_track: bool,
         eval_hooks: Option<Vec<&mut dyn EvalHook>>,
-        charge: &NonceCharge,
+        terms: &TransactionTerms,
     ) -> Result<ExecutionResult, ExecutionError> {
         let contract_id = contract.expect_resolved_contract_identifier(Some(&self.tx_sender));
         let snippet = contract.expect_in_memory_code_source();
@@ -867,12 +950,7 @@ impl ClarityInterpreter {
             Ok(value) => value,
             Err(e) => {
                 let err = format!("Runtime error while interpreting {contract_id}: {e:?}");
-                if let Some(mut eval_hooks) = global_context.eval_hooks.take() {
-                    for hook in eval_hooks.iter_mut() {
-                        hook.did_complete(Err(err.clone()));
-                    }
-                    global_context.eval_hooks = Some(eval_hooks);
-                }
+                notify_hooks_of_failure(&mut global_context, &err);
                 let inclusion =
                     BlockInclusion::from_runtime_error(ClarityError::Interpreter(e), epoch);
                 let mut diagnostics = vec![runtime_diagnostic(err)];
@@ -880,7 +958,7 @@ impl ClarityInterpreter {
                 // The nested execution was rolled back; an included failure
                 // commits only its nonce.
                 if inclusion.is_included() {
-                    if let Err(e) = charge.commit_alone(&mut global_context) {
+                    if let Err(e) = terms.charge.commit_alone(&mut global_context) {
                         diagnostics.push(runtime_diagnostic(e));
                         return Err(ExecutionError::rejected(diagnostics));
                     }
@@ -953,11 +1031,18 @@ impl ClarityInterpreter {
             EvaluationResult::Snippet(SnippetEvaluationResult { result })
         };
 
-        // Commit the nonce and execution state atomically.
-        if let Err(e) = charge.apply(&mut global_context.database) {
-            return Err(ExecutionError::rejected(vec![runtime_diagnostic(e)]));
+        // Settle the nonce and execution state atomically.
+        match terms.settle(&mut global_context, epoch) {
+            Ok(Settlement::Committed) => {}
+            Ok(Settlement::Aborted(reason)) => {
+                notify_hooks_of_failure(&mut global_context, &reason);
+                return Err(ExecutionError {
+                    diagnostics: vec![runtime_diagnostic(reason)],
+                    inclusion: BlockInclusion::Included,
+                });
+            }
+            Err(e) => return Err(ExecutionError::rejected(vec![runtime_diagnostic(e)])),
         }
-        global_context.commit().unwrap();
 
         let (events, accounts_to_credit, accounts_to_debit) =
             Self::process_events(&mut emitted_events);
@@ -1009,9 +1094,18 @@ impl ClarityInterpreter {
         track_costs: bool,
         allow_private: bool,
         eval_hooks: Vec<&mut dyn EvalHook>,
-        charge: &NonceCharge,
+        terms: &TransactionTerms,
     ) -> Result<ExecutionResult, ContractCallFailure> {
         let tx_sender: PrincipalData = self.tx_sender.clone().into();
+
+        // Mainnet rejects post-conditions the epoch does not support before any
+        // of the transaction runs, so no nonce is consumed.
+        if let Err(e) = terms.post_conditions.validate_for_epoch(epoch) {
+            return Err(ContractCallFailure {
+                error: ContractCallError::Uncategorized(e),
+                inclusion: BlockInclusion::Rejected,
+            });
+        }
 
         // Failing to stand up the VM is a simnet problem, not a transaction
         // outcome — mainnet would never have accepted the transaction at all.
@@ -1061,12 +1155,7 @@ impl ClarityInterpreter {
 
         let value = result.map_err(|e| {
             let err = format!("Runtime error while interpreting {contract_id}: {e:?}");
-            if let Some(mut eval_hooks) = global_context.eval_hooks.take() {
-                for hook in eval_hooks.iter_mut() {
-                    hook.did_complete(Err(err.clone()));
-                }
-                global_context.eval_hooks = Some(eval_hooks);
-            }
+            notify_hooks_of_failure(&mut global_context, &err);
             ContractCallFailure::from_vm_error(e, err, contract_id, epoch)
         });
 
@@ -1087,7 +1176,7 @@ impl ClarityInterpreter {
                 // The nested call was rolled back; an included failure commits
                 // only its nonce.
                 if failure.inclusion.is_included() {
-                    if let Err(e) = charge.commit_alone(&mut global_context) {
+                    if let Err(e) = terms.charge.commit_alone(&mut global_context) {
                         return Err(ContractCallFailure {
                             error: ContractCallError::Uncategorized(e),
                             inclusion: BlockInclusion::Rejected,
@@ -1100,14 +1189,23 @@ impl ClarityInterpreter {
 
         let eval_result = EvaluationResult::Snippet(SnippetEvaluationResult { result: value });
 
-        // Commit the nonce and call state atomically.
-        if let Err(e) = charge.apply(&mut global_context.database) {
-            return Err(ContractCallFailure {
-                error: ContractCallError::Uncategorized(e),
-                inclusion: BlockInclusion::Rejected,
-            });
+        // Settle the nonce and call state atomically.
+        match terms.settle(&mut global_context, epoch) {
+            Ok(Settlement::Committed) => {}
+            Ok(Settlement::Aborted(reason)) => {
+                notify_hooks_of_failure(&mut global_context, &reason);
+                return Err(ContractCallFailure {
+                    error: ContractCallError::PostConditionAborted(reason),
+                    inclusion: BlockInclusion::Included,
+                });
+            }
+            Err(e) => {
+                return Err(ContractCallFailure {
+                    error: ContractCallError::Uncategorized(e),
+                    inclusion: BlockInclusion::Rejected,
+                })
+            }
         }
-        global_context.commit().unwrap();
 
         let (events, accounts_to_credit, accounts_to_debit) =
             Self::process_events(&mut emitted_events);
@@ -1537,7 +1635,14 @@ mod tests {
             .run_analysis(contract, &ast, &annotations)
             .unwrap();
 
-        let result = interpreter.execute(contract, &ast, analysis, false, None, &NonceCharge::Free);
+        let result = interpreter.execute(
+            contract,
+            &ast,
+            analysis,
+            false,
+            None,
+            &TransactionTerms::default(),
+        );
         assert!(result.is_ok());
         result
     }
@@ -2083,8 +2188,14 @@ mod tests {
             .run_analysis(&contract, &ast, &annotations)
             .unwrap();
 
-        let result =
-            interpreter.execute(&contract, &ast, analysis, false, None, &NonceCharge::Free);
+        let result = interpreter.execute(
+            &contract,
+            &ast,
+            analysis,
+            false,
+            None,
+            &TransactionTerms::default(),
+        );
         assert!(result.is_ok());
         let ExecutionResult {
             diagnostics,
@@ -2333,7 +2444,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
         assert_execution_result_value(
             result,
@@ -2357,7 +2468,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
         assert_execution_result_value(
             result,
@@ -2414,7 +2525,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
         assert_execution_result_value(
             result,
@@ -2480,7 +2591,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
         assert_execution_result_value(
             result,
@@ -2507,7 +2618,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
         assert_execution_result_value(
             result,
@@ -2685,7 +2796,7 @@ mod tests {
             false,
             allow_private,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         assert!(result.is_ok());
@@ -2715,7 +2826,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         let failure = result.expect_err("calling an undefined function must fail");
@@ -2739,7 +2850,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         let failure = result.expect_err("calling a missing contract must fail");
@@ -2776,7 +2887,7 @@ mod tests {
                     false,
                     false,
                     vec![],
-                    &NonceCharge::Free,
+                    &TransactionTerms::default(),
                 )
                 .expect_err("calling a missing contract must fail");
 
@@ -2813,7 +2924,7 @@ mod tests {
             false,
             allow_private,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         assert!(result.is_ok());
@@ -2844,7 +2955,7 @@ mod tests {
             false,
             allow_private,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         assert!(result.is_err());
@@ -2887,7 +2998,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         // this hash changes if the contract id or the block height at which it is deployed changes
@@ -2928,7 +3039,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         let value = get_evaluation_result(get_time).expect_tuple().unwrap();
@@ -2969,7 +3080,7 @@ mod tests {
             false,
             false,
             vec![],
-            &NonceCharge::Free,
+            &TransactionTerms::default(),
         );
 
         assert_execution_result_value(

--- a/components/clarity-repl/src/repl/mod.rs
+++ b/components/clarity-repl/src/repl/mod.rs
@@ -6,6 +6,7 @@ pub mod diagnostic;
 mod docs;
 pub mod hooks;
 pub mod interpreter;
+pub mod post_conditions;
 pub mod remote_data;
 pub mod session;
 pub mod settings;

--- a/components/clarity-repl/src/repl/post_conditions.rs
+++ b/components/clarity-repl/src/repl/post_conditions.rs
@@ -18,18 +18,12 @@ pub fn parse_post_condition_mode(mode: &str) -> Result<TransactionPostConditionM
 }
 
 /// The post-condition check to apply to a transaction's asset movement.
-///
-/// Mirrors [`super::interpreter::NonceCharge`]: the caller names what the
-/// execution owes, and the interpreter applies it inside the execution's own
-/// database transaction.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum PostConditionCheck {
-    /// Asset movement is unconstrained, which is what a transaction carrying no
-    /// post-conditions gets.
+    /// Asset movement is unconstrained.
     #[default]
     Unchecked,
-    /// Constrain asset movement. A violation aborts the payload but still
-    /// consumes a nonce, the way mainnet treats an `AbortedByCallback`.
+    /// Constrain asset movement.
     Checked {
         conditions: Vec<TransactionPostCondition>,
         mode: TransactionPostConditionMode,
@@ -42,8 +36,7 @@ pub enum PostConditionCheck {
 impl PostConditionCheck {
     /// Decode consensus-serialized post-conditions.
     ///
-    /// The SDK sends the same bytes a wallet would put on the wire, so simnet
-    /// accepts exactly the input mainnet does.
+    /// The SDK sends the same encoding used on the transaction wire.
     pub fn from_hex(
         conditions: &[String],
         mode: TransactionPostConditionMode,
@@ -59,10 +52,7 @@ impl PostConditionCheck {
                 let condition = TransactionPostCondition::consensus_deserialize(&mut remaining)
                     .map_err(|e| format!("invalid post-condition: {e}"))?;
 
-                // On the wire a transaction's post-conditions are length-
-                // prefixed, so trailing bytes cannot occur. Here each one
-                // arrives on its own, and ignoring the remainder would accept
-                // input no node would.
+                // Each SDK value must contain exactly one condition.
                 if !remaining.is_empty() {
                     return Err(format!(
                         "invalid post-condition: {} trailing byte(s)",
@@ -82,9 +72,7 @@ impl PostConditionCheck {
 
     /// Reject a transaction whose post-conditions this epoch does not support.
     ///
-    /// Mainnet does this in `process_transaction_precheck`, before any of the
-    /// transaction runs, and treats a failure as `InvalidStacksTransaction` —
-    /// so the caller must reject rather than abort, consuming no nonce.
+    /// Unsupported conditions make the transaction invalid before execution.
     pub fn validate_for_epoch(&self, epoch: StacksEpochId) -> Result<(), String> {
         let Self::Checked {
             conditions, mode, ..
@@ -196,7 +184,7 @@ mod tests {
 
         for encoded in [hex.clone(), format!("0x{hex}")] {
             let check = PostConditionCheck::from_hex(
-                &[encoded.clone()],
+                std::slice::from_ref(&encoded),
                 TransactionPostConditionMode::Deny,
                 principal(SENDER),
             )

--- a/components/clarity-repl/src/repl/post_conditions.rs
+++ b/components/clarity-repl/src/repl/post_conditions.rs
@@ -24,8 +24,8 @@ pub fn parse_post_condition_mode(mode: &str) -> Result<TransactionPostConditionM
 /// database transaction.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum PostConditionCheck {
-    /// Asset movement is unconstrained, as it is for a read-only call or for a
-    /// transaction that carries no post-conditions.
+    /// Asset movement is unconstrained, which is what a transaction carrying no
+    /// post-conditions gets.
     #[default]
     Unchecked,
     /// Constrain asset movement. A violation aborts the payload but still
@@ -54,8 +54,22 @@ impl PostConditionCheck {
             .map(|hex| {
                 let bytes = hex_bytes(hex.strip_prefix("0x").unwrap_or(hex))
                     .map_err(|e| format!("invalid post-condition hex: {e}"))?;
-                TransactionPostCondition::consensus_deserialize(&mut bytes.as_slice())
-                    .map_err(|e| format!("invalid post-condition: {e}"))
+
+                let mut remaining = bytes.as_slice();
+                let condition = TransactionPostCondition::consensus_deserialize(&mut remaining)
+                    .map_err(|e| format!("invalid post-condition: {e}"))?;
+
+                // On the wire a transaction's post-conditions are length-
+                // prefixed, so trailing bytes cannot occur. Here each one
+                // arrives on its own, and ignoring the remainder would accept
+                // input no node would.
+                if !remaining.is_empty() {
+                    return Err(format!(
+                        "invalid post-condition: {} trailing byte(s)",
+                        remaining.len()
+                    ));
+                }
+                Ok(condition)
             })
             .collect::<Result<_, _>>()?;
 
@@ -208,6 +222,19 @@ mod tests {
             principal(SENDER),
         );
         assert!(bad_condition.is_err_and(|e| e.contains("invalid post-condition")));
+    }
+
+    #[test]
+    fn rejects_a_condition_with_trailing_bytes() {
+        let trailing = format!("{}00", hex_of(&sends_exactly(SENDER, 100)));
+
+        let check = PostConditionCheck::from_hex(
+            &[trailing],
+            TransactionPostConditionMode::Deny,
+            principal(SENDER),
+        );
+
+        assert!(check.is_err_and(|e| e.contains("1 trailing byte(s)")));
     }
 
     #[test]

--- a/components/clarity-repl/src/repl/post_conditions.rs
+++ b/components/clarity-repl/src/repl/post_conditions.rs
@@ -34,6 +34,11 @@ pub enum PostConditionCheck {
 }
 
 impl PostConditionCheck {
+    /// Whether this check contains any declared post-conditions.
+    pub fn has_conditions(&self) -> bool {
+        matches!(self, Self::Checked { conditions, .. } if !conditions.is_empty())
+    }
+
     /// Decode consensus-serialized post-conditions.
     ///
     /// The SDK sends the same encoding used on the transaction wire.

--- a/components/clarity-repl/src/repl/post_conditions.rs
+++ b/components/clarity-repl/src/repl/post_conditions.rs
@@ -113,7 +113,9 @@ impl PostConditionCheck {
 #[cfg(test)]
 mod tests {
     use clarity::util::hash::to_hex;
-    use stacks_codec::transaction::{FungibleConditionCode, PostConditionPrincipal};
+    use stacks_codec::transaction::{
+        FungibleConditionCode, PostConditionPrincipal, PoxConditionCode,
+    };
 
     use super::*;
 
@@ -293,5 +295,33 @@ mod tests {
             check.evaluate(&stx_sent(SENDER, 1), StacksEpochId::Epoch33),
             Ok(None)
         );
+    }
+
+    #[test]
+    fn decodes_and_epoch_gates_staking_and_pox_conditions() {
+        let conditions = vec![
+            TransactionPostCondition::Staking(
+                PostConditionPrincipal::Origin,
+                FungibleConditionCode::SentLe,
+                100,
+            ),
+            TransactionPostCondition::Pox(
+                PostConditionPrincipal::Origin,
+                PoxConditionCode::MaybePerformed,
+            ),
+        ];
+        let encoded = conditions.iter().map(hex_of).collect::<Vec<_>>();
+        let check = PostConditionCheck::from_hex(
+            &encoded,
+            TransactionPostConditionMode::Deny,
+            principal(SENDER),
+        )
+        .expect("staking and PoX conditions should decode");
+
+        assert_eq!(check, checked(conditions));
+        assert!(check
+            .validate_for_epoch(StacksEpochId::Epoch34)
+            .is_err_and(|e| e.contains("Staking/Pox post-condition is not supported")));
+        assert_eq!(check.validate_for_epoch(StacksEpochId::Epoch40), Ok(()));
     }
 }

--- a/components/clarity-repl/src/repl/post_conditions.rs
+++ b/components/clarity-repl/src/repl/post_conditions.rs
@@ -1,0 +1,282 @@
+use clarity::types::StacksEpochId;
+use clarity::util::hash::hex_bytes;
+use clarity_types::effects::AssetMap;
+use clarity_types::types::PrincipalData;
+use stacks_codec::transaction::{TransactionPostCondition, TransactionPostConditionMode};
+use stacks_codec::StacksMessageCodec;
+
+/// Parse a post-condition mode as the SDK spells it.
+pub fn parse_post_condition_mode(mode: &str) -> Result<TransactionPostConditionMode, String> {
+    match mode {
+        "allow" => Ok(TransactionPostConditionMode::Allow),
+        "deny" => Ok(TransactionPostConditionMode::Deny),
+        "originator" => Ok(TransactionPostConditionMode::Originator),
+        other => Err(format!(
+            "invalid post-condition mode '{other}': expected 'allow', 'deny' or 'originator'"
+        )),
+    }
+}
+
+/// The post-condition check to apply to a transaction's asset movement.
+///
+/// Mirrors [`super::interpreter::NonceCharge`]: the caller names what the
+/// execution owes, and the interpreter applies it inside the execution's own
+/// database transaction.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum PostConditionCheck {
+    /// Asset movement is unconstrained, as it is for a read-only call or for a
+    /// transaction that carries no post-conditions.
+    #[default]
+    Unchecked,
+    /// Constrain asset movement. A violation aborts the payload but still
+    /// consumes a nonce, the way mainnet treats an `AbortedByCallback`.
+    Checked {
+        conditions: Vec<TransactionPostCondition>,
+        mode: TransactionPostConditionMode,
+        /// The principal whose *unlisted* asset movement `Deny` and
+        /// `Originator` modes constrain.
+        origin: PrincipalData,
+    },
+}
+
+impl PostConditionCheck {
+    /// Decode consensus-serialized post-conditions.
+    ///
+    /// The SDK sends the same bytes a wallet would put on the wire, so simnet
+    /// accepts exactly the input mainnet does.
+    pub fn from_hex(
+        conditions: &[String],
+        mode: TransactionPostConditionMode,
+        origin: PrincipalData,
+    ) -> Result<Self, String> {
+        let conditions = conditions
+            .iter()
+            .map(|hex| {
+                let bytes = hex_bytes(hex.strip_prefix("0x").unwrap_or(hex))
+                    .map_err(|e| format!("invalid post-condition hex: {e}"))?;
+                TransactionPostCondition::consensus_deserialize(&mut bytes.as_slice())
+                    .map_err(|e| format!("invalid post-condition: {e}"))
+            })
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self::Checked {
+            conditions,
+            mode,
+            origin,
+        })
+    }
+
+    /// Reject a transaction whose post-conditions this epoch does not support.
+    ///
+    /// Mainnet does this in `process_transaction_precheck`, before any of the
+    /// transaction runs, and treats a failure as `InvalidStacksTransaction` —
+    /// so the caller must reject rather than abort, consuming no nonce.
+    pub fn validate_for_epoch(&self, epoch: StacksEpochId) -> Result<(), String> {
+        let Self::Checked {
+            conditions, mode, ..
+        } = self
+        else {
+            return Ok(());
+        };
+
+        stacks_transactions::check_post_conditions_supported_in_epoch(conditions, mode, epoch)
+            .map_err(|reason| format!("Invalid Stacks transaction: {reason}"))
+    }
+
+    /// Why `asset_map` violates this check, if it does.
+    ///
+    /// `Ok(None)` means the transaction may commit. `Err` means the check
+    /// itself could not run, which mainnet treats as fatal.
+    pub fn evaluate(
+        &self,
+        asset_map: &AssetMap,
+        epoch: StacksEpochId,
+    ) -> Result<Option<String>, String> {
+        let Self::Checked {
+            conditions,
+            mode,
+            origin,
+        } = self
+        else {
+            return Ok(None);
+        };
+
+        stacks_transactions::check_transaction_postconditions(
+            conditions, mode, origin, asset_map, epoch,
+        )
+        .map_err(|e| format!("failed to evaluate post-conditions: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clarity::util::hash::to_hex;
+    use stacks_codec::transaction::{FungibleConditionCode, PostConditionPrincipal};
+
+    use super::*;
+
+    const SENDER: &str = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+
+    fn principal(address: &str) -> PrincipalData {
+        PrincipalData::parse(address).expect("BUG: not a principal")
+    }
+
+    /// A condition requiring `address` to send exactly `amount` uSTX.
+    fn sends_exactly(address: &str, amount: u64) -> TransactionPostCondition {
+        TransactionPostCondition::STX(
+            PostConditionPrincipal::Standard(match principal(address) {
+                PrincipalData::Standard(standard) => standard.into(),
+                PrincipalData::Contract(_) => unreachable!("BUG: not a standard principal"),
+            }),
+            FungibleConditionCode::SentEq,
+            amount,
+        )
+    }
+
+    fn hex_of(condition: &TransactionPostCondition) -> String {
+        let mut bytes = vec![];
+        condition
+            .consensus_serialize(&mut bytes)
+            .expect("BUG: failed to serialize to a vec");
+        to_hex(&bytes)
+    }
+
+    fn stx_sent(address: &str, amount: u128) -> AssetMap {
+        let mut asset_map = AssetMap::new();
+        asset_map
+            .add_stx_transfer(&principal(address), amount)
+            .expect("BUG: failed to record an STX transfer");
+        asset_map
+    }
+
+    fn checked(conditions: Vec<TransactionPostCondition>) -> PostConditionCheck {
+        PostConditionCheck::Checked {
+            conditions,
+            mode: TransactionPostConditionMode::Deny,
+            origin: principal(SENDER),
+        }
+    }
+
+    #[test]
+    fn parses_every_mode_the_sdk_can_send() {
+        assert_eq!(
+            parse_post_condition_mode("allow"),
+            Ok(TransactionPostConditionMode::Allow)
+        );
+        assert_eq!(
+            parse_post_condition_mode("deny"),
+            Ok(TransactionPostConditionMode::Deny)
+        );
+        assert_eq!(
+            parse_post_condition_mode("originator"),
+            Ok(TransactionPostConditionMode::Originator)
+        );
+        assert!(parse_post_condition_mode("Deny").is_err());
+        assert!(parse_post_condition_mode("").is_err());
+    }
+
+    #[test]
+    fn decodes_conditions_with_or_without_the_hex_prefix() {
+        let expected = sends_exactly(SENDER, 100);
+        let hex = hex_of(&expected);
+
+        for encoded in [hex.clone(), format!("0x{hex}")] {
+            let check = PostConditionCheck::from_hex(
+                &[encoded.clone()],
+                TransactionPostConditionMode::Deny,
+                principal(SENDER),
+            )
+            .unwrap_or_else(|e| panic!("{encoded} should decode: {e}"));
+
+            assert_eq!(check, checked(vec![expected.clone()]));
+        }
+    }
+
+    #[test]
+    fn rejects_input_that_is_not_a_post_condition() {
+        let bad_hex = PostConditionCheck::from_hex(
+            &["nothex".to_string()],
+            TransactionPostConditionMode::Deny,
+            principal(SENDER),
+        );
+        assert!(bad_hex.is_err_and(|e| e.contains("invalid post-condition hex")));
+
+        // Well-formed hex, but 0xff is not a post-condition type byte.
+        let bad_condition = PostConditionCheck::from_hex(
+            &["ff".to_string()],
+            TransactionPostConditionMode::Deny,
+            principal(SENDER),
+        );
+        assert!(bad_condition.is_err_and(|e| e.contains("invalid post-condition")));
+    }
+
+    #[test]
+    fn an_unchecked_transaction_never_fails() {
+        let check = PostConditionCheck::Unchecked;
+
+        assert_eq!(check.validate_for_epoch(StacksEpochId::Epoch21), Ok(()));
+        assert_eq!(
+            check.evaluate(&stx_sent(SENDER, 100), StacksEpochId::Epoch21),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn originator_mode_is_rejected_before_the_epoch_supports_it() {
+        let check = PostConditionCheck::Checked {
+            conditions: vec![],
+            mode: TransactionPostConditionMode::Originator,
+            origin: principal(SENDER),
+        };
+
+        assert!(check
+            .validate_for_epoch(StacksEpochId::Epoch33)
+            .is_err_and(|e| e.contains("Originator post-condition mode is not supported")));
+        assert_eq!(check.validate_for_epoch(StacksEpochId::Epoch34), Ok(()));
+    }
+
+    #[test]
+    fn a_satisfied_condition_passes_and_a_violated_one_reports_why() {
+        let check = checked(vec![sends_exactly(SENDER, 100)]);
+
+        assert_eq!(
+            check.evaluate(&stx_sent(SENDER, 100), StacksEpochId::Epoch33),
+            Ok(None)
+        );
+
+        let violation = check
+            .evaluate(&stx_sent(SENDER, 99), StacksEpochId::Epoch33)
+            .expect("the check should run");
+        assert!(violation.is_some_and(|reason| reason.contains("Post-condition check failure")));
+    }
+
+    #[test]
+    fn deny_mode_rejects_movement_no_condition_covers() {
+        let check = checked(vec![]);
+
+        // Nothing moved, so there is nothing to leave unchecked.
+        assert_eq!(
+            check.evaluate(&AssetMap::new(), StacksEpochId::Epoch33),
+            Ok(None)
+        );
+
+        let violation = check
+            .evaluate(&stx_sent(SENDER, 1), StacksEpochId::Epoch33)
+            .expect("the check should run");
+        assert!(violation.is_some(), "unlisted movement should be denied");
+    }
+
+    #[test]
+    fn allow_mode_permits_movement_no_condition_covers() {
+        let check = PostConditionCheck::Checked {
+            conditions: vec![],
+            mode: TransactionPostConditionMode::Allow,
+            origin: principal(SENDER),
+        };
+
+        assert_eq!(
+            check.evaluate(&stx_sent(SENDER, 1), StacksEpochId::Epoch33),
+            Ok(None)
+        );
+    }
+}

--- a/components/clarity-repl/src/repl/post_conditions.rs
+++ b/components/clarity-repl/src/repl/post_conditions.rs
@@ -5,6 +5,10 @@ use clarity_types::types::PrincipalData;
 use stacks_codec::transaction::{TransactionPostCondition, TransactionPostConditionMode};
 use stacks_codec::StacksMessageCodec;
 
+/// Default to rejecting asset movement that no condition covers.
+pub const DEFAULT_POST_CONDITION_MODE: TransactionPostConditionMode =
+    TransactionPostConditionMode::Deny;
+
 /// Parse a post-condition mode as the SDK spells it.
 pub fn parse_post_condition_mode(mode: &str) -> Result<TransactionPostConditionMode, String> {
     match mode {

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -726,6 +726,19 @@ impl Session {
             }]);
         }
 
+        // TokenTransfer payloads do not run the post-condition checker. The
+        // mode is still part of the transaction wire and must be valid for the
+        // current epoch, but it has no effect when the condition list is empty.
+        let current_epoch = self.interpreter.datastore.get_current_epoch();
+        if let Err(message) = post_conditions.validate_for_epoch(current_epoch) {
+            return Err(vec![Diagnostic {
+                level: Level::Error,
+                message,
+                spans: vec![],
+                suggestion: None,
+            }]);
+        }
+
         let sender = self.interpreter.get_tx_sender();
         let snippet = format!("(stx-transfer? u{amount} tx-sender '{recipient})");
 
@@ -734,7 +747,7 @@ impl Session {
         // which is one, so the terms are named here.
         let terms = TransactionTerms {
             charge: NonceCharge::Sender(sender.into()),
-            post_conditions,
+            post_conditions: PostConditionCheck::Unchecked,
         };
         self.eval_with_inclusion(snippet, false, terms)
             .map_err(Vec::from)

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -21,7 +21,8 @@ use serde::Serialize;
 use super::diagnostic::output_diagnostic;
 use super::hooks::logger::LoggerHook;
 use super::hooks::perf::{CostField, PerfHook};
-use super::interpreter::{ContractCallError, ExecutionError, NonceCharge};
+use super::interpreter::{ContractCallError, ExecutionError, NonceCharge, TransactionTerms};
+use super::post_conditions::PostConditionCheck;
 use super::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Epoch,
     SessionSettings,
@@ -712,14 +713,19 @@ impl Session {
         &mut self,
         amount: u64,
         recipient: &str,
+        post_conditions: PostConditionCheck,
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
         let sender = self.interpreter.get_tx_sender();
         let snippet = format!("(stx-transfer? u{amount} tx-sender '{recipient})");
 
         // An STX transfer is a transaction and consumes a nonce. `eval` also
         // backs bare snippets and function-argument evaluation, neither of
-        // which is one, so the charge is named here.
-        self.eval_with_inclusion(snippet, false, NonceCharge::Sender(sender.into()))
+        // which is one, so the terms are named here.
+        let terms = TransactionTerms {
+            charge: NonceCharge::Sender(sender.into()),
+            post_conditions,
+        };
+        self.eval_with_inclusion(snippet, false, terms)
             .map_err(Vec::from)
     }
 
@@ -728,6 +734,7 @@ impl Session {
         contract: &ClarityContract,
         cost_track: bool,
         ast: Option<&ContractAST>,
+        post_conditions: PostConditionCheck,
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
         let current_epoch = self.interpreter.datastore.get_current_epoch();
         if contract.epoch.resolve() != current_epoch {
@@ -772,13 +779,13 @@ impl Session {
 
         // Boot contracts bypass this transaction path because they are genesis
         // state and consume no nonce.
-        let result = self.interpreter.run_transaction(
-            contract,
-            ast,
-            cost_track,
-            Some(hooks),
-            contract_id.issuer.clone().into(),
-        );
+        let terms = TransactionTerms {
+            charge: NonceCharge::Sender(contract_id.issuer.clone().into()),
+            post_conditions,
+        };
+        let result =
+            self.interpreter
+                .run_with_terms(contract, ast, cost_track, Some(hooks), &terms);
 
         result
             .inspect(|result| {
@@ -804,6 +811,7 @@ impl Session {
         allow_private: bool,
         track_costs: bool,
         kind: CallKind,
+        post_conditions: PostConditionCheck,
     ) -> Result<ExecutionResult, ExecutionError> {
         let initial_tx_sender = self.get_tx_sender();
 
@@ -833,9 +841,14 @@ impl Session {
 
         // Taken from the interpreter rather than re-parsed, so the principal
         // charged is exactly the one the call runs as.
-        let charge = match kind {
-            CallKind::Transaction => NonceCharge::Sender(self.interpreter.get_tx_sender().into()),
-            CallKind::NonceFree => NonceCharge::Free,
+        let terms = TransactionTerms {
+            charge: match kind {
+                CallKind::Transaction => {
+                    NonceCharge::Sender(self.interpreter.get_tx_sender().into())
+                }
+                CallKind::NonceFree => NonceCharge::Free,
+            },
+            post_conditions,
         };
 
         let current_epoch = self.interpreter.datastore.get_current_epoch();
@@ -848,7 +861,7 @@ impl Session {
             track_costs,
             allow_private,
             hooks,
-            &charge,
+            &terms,
         );
         self.set_tx_sender(&initial_tx_sender);
         self.last_contract_call_trace = Some(tracer_hook.output.join("\n"));
@@ -866,6 +879,8 @@ impl Session {
                 ContractCallError::NoSuchFunction(_) => {
                     format!("Method '{method}' does not exist on contract '{contract_id_str}'")
                 }
+                // Already phrased for the user by the post-condition checker.
+                ContractCallError::PostConditionAborted(reason) => reason,
                 ContractCallError::Uncategorized(message) => {
                     format!("Error calling contract function '{method}': {message}")
                 }
@@ -888,16 +903,16 @@ impl Session {
         snippet: String,
         cost_track: bool,
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
-        self.eval_with_inclusion(snippet, cost_track, NonceCharge::Free)
+        self.eval_with_inclusion(snippet, cost_track, TransactionTerms::default())
             .map_err(Vec::from)
     }
 
-    /// Evaluate a snippet while preserving failure inclusion and nonce policy.
+    /// Evaluate a snippet while preserving failure inclusion and transaction terms.
     fn eval_with_inclusion(
         &mut self,
         snippet: String,
         cost_track: bool,
-        charge: NonceCharge,
+        terms: TransactionTerms,
     ) -> Result<AnnotatedExecutionResult, ExecutionError> {
         let current_epoch = self.interpreter.datastore.get_current_epoch();
         let contract = ClarityContract {
@@ -924,7 +939,7 @@ impl Session {
 
         let result =
             self.interpreter
-                .run_with_charge(&contract, None, cost_track, Some(hooks), &charge);
+                .run_with_terms(&contract, None, cost_track, Some(hooks), &terms);
 
         result.inspect(|result| {
             if let EvaluationResult::Contract(contract_result) = &result.result {
@@ -1660,6 +1675,10 @@ mod tests {
     use clarity::util::hash::hex_bytes;
     use clarity_types::types::TupleData;
     use indoc::{formatdoc, indoc};
+    use stacks_codec::transaction::{
+        FungibleConditionCode, PostConditionPrincipal, TransactionPostCondition,
+        TransactionPostConditionMode,
+    };
 
     use super::*;
     use crate::repl::boot::{BOOT_MAINNET_ADDRESS, BOOT_TESTNET_ADDRESS};
@@ -1943,7 +1962,7 @@ mod tests {
             skip_analysis: false,
         };
 
-        let result = session.deploy_contract(&contract, false, None);
+        let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         assert!(result.is_err(), "Expected error for clarity mismatch");
     }
 
@@ -1961,7 +1980,7 @@ mod tests {
             .clarity_version(ClarityVersion::Clarity2)
             .build();
 
-        let result = session.deploy_contract(&contract, false, None);
+        let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.len() == 1);
@@ -1995,7 +2014,7 @@ mod tests {
             .deployer(deployer)
             .code_source(source.to_string())
             .build();
-        let result = session.deploy_contract(&contract, false, None);
+        let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         let after = session.get_nonce(&addr).unwrap();
         (before, after, result)
     }
@@ -2016,7 +2035,9 @@ mod tests {
                 .name(&format!("counter-{expected_nonce}"))
                 .deployer(deployer)
                 .build();
-            session.deploy_contract(&contract, false, None).unwrap();
+            session
+                .deploy_contract(&contract, false, None, PostConditionCheck::Unchecked)
+                .unwrap();
 
             assert_eq!(session.get_nonce(&addr).unwrap(), expected_nonce);
         }
@@ -2037,7 +2058,9 @@ mod tests {
             .epoch(StacksEpochId::Epoch25)
             .clarity_version(ClarityVersion::Clarity2)
             .build();
-        assert!(session.deploy_contract(&contract, false, None).is_err());
+        assert!(session
+            .deploy_contract(&contract, false, None, PostConditionCheck::Unchecked)
+            .is_err());
 
         assert_eq!(session.get_nonce(&addr).unwrap(), 0);
     }
@@ -2063,7 +2086,9 @@ mod tests {
         session.update_epoch(DEFAULT_EPOCH);
 
         let contract = ClarityContractBuilder::new().deployer(sender).build();
-        session.deploy_contract(&contract, false, None).unwrap();
+        session
+            .deploy_contract(&contract, false, None, PostConditionCheck::Unchecked)
+            .unwrap();
         let after_deploy = session.get_nonce(&addr).unwrap();
         assert_eq!(after_deploy, 1, "the deploy itself is a transaction");
 
@@ -2081,6 +2106,7 @@ mod tests {
                     false,
                     false,
                     CallKind::NonceFree,
+                    PostConditionCheck::Unchecked,
                 )
                 .unwrap_or_else(|e| panic!("{method} should execute: {e:?}"));
 
@@ -2108,6 +2134,110 @@ mod tests {
         assert_eq!(session.get_nonce(&sender).unwrap(), before);
     }
 
+    /// Constrain `address` to sending exactly `amount` uSTX, denying anything
+    /// else it might move.
+    fn sends_exactly(address: &str, amount: u64) -> PostConditionCheck {
+        let PrincipalData::Standard(standard) = principal(address) else {
+            unreachable!("BUG: not a standard principal");
+        };
+
+        PostConditionCheck::Checked {
+            conditions: vec![TransactionPostCondition::STX(
+                PostConditionPrincipal::Standard(standard.into()),
+                FungibleConditionCode::SentEq,
+                amount,
+            )],
+            mode: TransactionPostConditionMode::Deny,
+            origin: principal(address),
+        }
+    }
+
+    /// A funded session whose tx-sender is `sender`, at an epoch that supports
+    /// every post-condition mode.
+    fn funded_session(sender: &str) -> Session {
+        let mut session = Session::new(SessionSettings::default());
+        session.update_epoch(StacksEpochId::Epoch34);
+        session
+            .interpreter
+            .mint_stx_balance(principal(sender), 1_000_000)
+            .unwrap();
+        session.set_tx_sender(sender);
+        session
+    }
+
+    #[test]
+    fn a_satisfied_post_condition_commits_the_transfer() {
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
+        let mut session = funded_session(sender);
+
+        session
+            .stx_transfer(1000, recipient, sends_exactly(sender, 1000))
+            .expect("the transfer should commit");
+
+        assert_eq!(
+            session.interpreter.get_balance_for_account(sender, "STX"),
+            999_000
+        );
+        assert_eq!(session.get_nonce(&principal(sender)).unwrap(), 1);
+    }
+
+    #[test]
+    fn a_violated_post_condition_rolls_back_the_transfer_but_charges_the_nonce() {
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
+        let mut session = funded_session(sender);
+
+        let diagnostics = session
+            .stx_transfer(1000, recipient, sends_exactly(sender, 999))
+            .expect_err("the transfer should abort");
+        assert!(diagnostics
+            .last()
+            .is_some_and(|d| d.message.contains("Post-condition check failure")));
+
+        // Mainnet aborts the payload but still includes the transaction, so the
+        // STX stays put and the nonce moves.
+        assert_eq!(
+            session.interpreter.get_balance_for_account(sender, "STX"),
+            1_000_000
+        );
+        assert_eq!(
+            session
+                .interpreter
+                .get_balance_for_account(recipient, "STX"),
+            0
+        );
+        assert_eq!(session.get_nonce(&principal(sender)).unwrap(), 1);
+    }
+
+    #[test]
+    fn an_epoch_unsupported_post_condition_is_rejected_before_execution() {
+        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
+        let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
+        let mut session = funded_session(sender);
+        session.update_epoch(StacksEpochId::Epoch33);
+
+        let originator_mode = PostConditionCheck::Checked {
+            conditions: vec![],
+            mode: TransactionPostConditionMode::Originator,
+            origin: principal(sender),
+        };
+
+        let diagnostics = session
+            .stx_transfer(1000, recipient, originator_mode)
+            .expect_err("the transfer should be rejected");
+        assert!(diagnostics
+            .last()
+            .is_some_and(|d| d.message.contains("Invalid Stacks transaction")));
+
+        // Rejected rather than aborted: nothing ran, so no nonce was consumed.
+        assert_eq!(
+            session.interpreter.get_balance_for_account(sender, "STX"),
+            1_000_000
+        );
+        assert_eq!(session.get_nonce(&principal(sender)).unwrap(), 0);
+    }
+
     #[test]
     fn stx_transfer_bumps_the_sender_nonce() {
         let mut session = Session::new(SessionSettings::default());
@@ -2123,7 +2253,9 @@ mod tests {
 
         assert_eq!(session.get_nonce(&addr).unwrap(), 0);
 
-        session.stx_transfer(1000, recipient).unwrap();
+        session
+            .stx_transfer(1000, recipient, PostConditionCheck::Unchecked)
+            .unwrap();
 
         assert_eq!(session.get_nonce(&addr).unwrap(), 1);
         // The recipient sent nothing, so it owes no nonce.
@@ -2143,7 +2275,11 @@ mod tests {
         assert_eq!(session.get_nonce(&addr).unwrap(), 0);
 
         let result = session
-            .stx_transfer(1000, "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG")
+            .stx_transfer(
+                1000,
+                "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG",
+                PostConditionCheck::Unchecked,
+            )
             .expect("an underfunded transfer still executes");
         match result.execution_result.result {
             EvaluationResult::Snippet(res) => {
@@ -2177,6 +2313,7 @@ mod tests {
                 false,
                 false,
                 CallKind::NonceFree,
+                PostConditionCheck::Unchecked,
             )
             .expect_err("a call to a missing contract must fail");
 
@@ -2205,7 +2342,7 @@ mod tests {
         let sender_before = session.interpreter.get_balance_for_account(sender, "STX");
 
         let diagnostics = session
-            .stx_transfer(1000, recipient)
+            .stx_transfer(1000, recipient, PostConditionCheck::Unchecked)
             .expect_err("a transfer whose nonce cannot be recorded is not a success");
 
         let message = &diagnostics.last().expect("a diagnostic").message;
@@ -2242,7 +2379,9 @@ mod tests {
         session.update_epoch(DEFAULT_EPOCH);
 
         let contract = ClarityContractBuilder::new().deployer(sender).build();
-        session.deploy_contract(&contract, false, None).unwrap();
+        session
+            .deploy_contract(&contract, false, None, PostConditionCheck::Unchecked)
+            .unwrap();
         let contract_id = format!("{sender}.contract");
 
         // Only now, so the deploy above is unaffected.
@@ -2257,6 +2396,7 @@ mod tests {
                 false,
                 false,
                 CallKind::Transaction,
+                PostConditionCheck::Unchecked,
             )
             .expect_err("a call whose nonce cannot be recorded is not a success");
 
@@ -2270,6 +2410,7 @@ mod tests {
                 false,
                 false,
                 CallKind::NonceFree,
+                PostConditionCheck::Unchecked,
             )
             .expect("a read-only call charges nothing and still works");
         match result.result {
@@ -2360,7 +2501,8 @@ mod tests {
                 .clarity_version(ClarityVersion::default_for_epoch(epoch))
                 .code_source(source.to_string())
                 .build();
-            let result = session.deploy_contract(&contract, false, None);
+            let result =
+                session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
             let after = session.get_nonce(&addr).unwrap();
             assert!(
                 result.is_err(),
@@ -2465,7 +2607,7 @@ mod tests {
             skip_analysis: false,
         };
 
-        let _ = session.deploy_contract(&contract, false, None);
+        let _ = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
 
         // assert data-var is set to 0
         assert_eq!(
@@ -2532,7 +2674,7 @@ mod tests {
 
         // deploy default contract
         let contract = ClarityContractBuilder::default().build();
-        let result = session.deploy_contract(&contract, false, None);
+        let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         assert!(result.is_ok());
     }
 
@@ -2551,6 +2693,7 @@ mod tests {
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
         assert_execution_result_value(
             &result,
@@ -2615,6 +2758,7 @@ mod tests {
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
         assert_execution_result_value(&result, Value::okay(Value::Bool(true)).unwrap());
 
@@ -2627,6 +2771,7 @@ mod tests {
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
         assert_execution_result_value(&result, Value::UInt(1));
 
@@ -2639,6 +2784,7 @@ mod tests {
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
         assert!(result.is_ok());
     }
@@ -2651,7 +2797,7 @@ mod tests {
 
         // deploy default contract
         let contract = ClarityContractBuilder::default().build();
-        let _ = session.deploy_contract(&contract, false, None);
+        let _ = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
 
         let result = session.call_contract_fn(
             "contract",
@@ -2661,6 +2807,7 @@ mod tests {
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
         assert_execution_result_value(&result, Value::okay(Value::UInt(1)).unwrap());
 
@@ -2672,6 +2819,7 @@ mod tests {
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
         assert_execution_result_value(&result, Value::UInt(1));
     }
@@ -2725,7 +2873,9 @@ mod tests {
             .epoch(StacksEpochId::Epoch25)
             .build();
 
-        session.deploy_contract(&contract, false, None).unwrap();
+        session
+            .deploy_contract(&contract, false, None, PostConditionCheck::Unchecked)
+            .unwrap();
         session.advance_burn_chain_tip(10);
 
         let result = run_session_snippet(&mut session, "block-height");
@@ -2783,7 +2933,9 @@ mod tests {
             .epoch(StacksEpochId::Epoch30)
             .build();
 
-        session.deploy_contract(&contract, false, None).unwrap();
+        session
+            .deploy_contract(&contract, false, None, PostConditionCheck::Unchecked)
+            .unwrap();
         session.advance_burn_chain_tip(10);
 
         let result = run_session_snippet(&mut session, "stacks-block-height");
@@ -2816,7 +2968,9 @@ mod tests {
             .epoch(StacksEpochId::Epoch25)
             .build();
 
-        session.deploy_contract(&contract, false, None).unwrap();
+        session
+            .deploy_contract(&contract, false, None, PostConditionCheck::Unchecked)
+            .unwrap();
         session.advance_burn_chain_tip(10);
 
         session.update_epoch(StacksEpochId::Epoch30);
@@ -2861,7 +3015,7 @@ mod tests {
 
         // deploy a simple contract
         let contract = ClarityContractBuilder::default().build();
-        let _ = session.deploy_contract(&contract, false, None);
+        let _ = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
 
         // try to call a non-existent function
         let result = session.call_contract_fn(
@@ -2872,6 +3026,7 @@ mod tests {
             false,
             false,
             CallKind::NonceFree,
+            PostConditionCheck::Unchecked,
         );
 
         assert!(result.is_err());
@@ -2957,7 +3112,8 @@ mod tests {
             (test-mint)"#
         );
         let contract = ClarityContractBuilder::default().code_source(src).build();
-        let deploy_result = session.deploy_contract(&contract, false, None);
+        let deploy_result =
+            session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         assert!(deploy_result.is_ok());
         let ExecutionResult { result, .. } = deploy_result.unwrap().into_inner();
 

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1879,8 +1879,8 @@ mod tests {
         // 4.1 exists upstream but is not adopted here. If this fails, upstream
         // has moved again — adopt the pending epoch, or re-pin this and say why.
         assert_eq!(
-            StacksEpochId::latest(),
-            StacksEpochId::Epoch41,
+            StacksEpochId::ALL.last(),
+            Some(&StacksEpochId::Epoch41),
             "upstream added an epoch past the one clarinet knows is pending"
         );
 

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -750,17 +750,6 @@ impl Session {
             return Err(vec![diagnostic]);
         }
 
-        let mut hooks: Vec<&mut dyn EvalHook> = vec![];
-        if let Some(ref mut coverage_hook) = self.coverage_hook {
-            hooks.push(coverage_hook);
-        }
-        if let Some(ref mut logger_hook) = self.logger_hook {
-            hooks.push(logger_hook);
-        }
-        if let Some(ref mut perf_hook) = self.perf_hook {
-            hooks.push(perf_hook);
-        }
-
         if contract.clarity_version > ClarityVersion::default_for_epoch(contract.epoch.resolve()) {
             let diagnostic = Diagnostic {
                 level: Level::Error,
@@ -777,6 +766,20 @@ impl Session {
         let contract_id =
             contract.expect_resolved_contract_identifier(Some(&self.interpreter.get_tx_sender()));
 
+        let initial_tx_sender = self.get_tx_sender();
+        self.set_tx_sender(&contract_id.issuer.to_string());
+
+        let mut hooks: Vec<&mut dyn EvalHook> = vec![];
+        if let Some(ref mut coverage_hook) = self.coverage_hook {
+            hooks.push(coverage_hook);
+        }
+        if let Some(ref mut logger_hook) = self.logger_hook {
+            hooks.push(logger_hook);
+        }
+        if let Some(ref mut perf_hook) = self.perf_hook {
+            hooks.push(perf_hook);
+        }
+
         // Boot contracts bypass this transaction path because they are genesis
         // state and consume no nonce.
         let terms = TransactionTerms {
@@ -786,6 +789,7 @@ impl Session {
         let result =
             self.interpreter
                 .run_with_terms(contract, ast, cost_track, Some(hooks), &terms);
+        self.set_tx_sender(&initial_tx_sender);
 
         result
             .inspect(|result| {

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -715,6 +715,17 @@ impl Session {
         recipient: &str,
         post_conditions: PostConditionCheck,
     ) -> Result<AnnotatedExecutionResult, Vec<Diagnostic>> {
+        // stacks-core rejects TokenTransfer payloads with post-conditions
+        // before execution. Keep simnet aligned with mainnet/testnet here.
+        if post_conditions.has_conditions() {
+            return Err(vec![Diagnostic {
+                level: Level::Error,
+                message: "Invalid Stacks transaction: TokenTransfer transactions do not support post-conditions".into(),
+                spans: vec![],
+                suggestion: None,
+            }]);
+        }
+
         let sender = self.interpreter.get_tx_sender();
         let snippet = format!("(stx-transfer? u{amount} tx-sender '{recipient})");
 
@@ -2170,37 +2181,18 @@ mod tests {
     }
 
     #[test]
-    fn a_satisfied_post_condition_commits_the_transfer() {
-        let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
-        let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
-        let mut session = funded_session(sender);
-
-        session
-            .stx_transfer(1000, recipient, sends_exactly(sender, 1000))
-            .expect("the transfer should commit");
-
-        assert_eq!(
-            session.interpreter.get_balance_for_account(sender, "STX"),
-            999_000
-        );
-        assert_eq!(session.get_nonce(&principal(sender)).unwrap(), 1);
-    }
-
-    #[test]
-    fn a_violated_post_condition_rolls_back_the_transfer_but_charges_the_nonce() {
+    fn a_stx_transfer_with_post_conditions_is_rejected_before_execution() {
         let sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";
         let recipient = "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG";
         let mut session = funded_session(sender);
 
         let diagnostics = session
-            .stx_transfer(1000, recipient, sends_exactly(sender, 999))
-            .expect_err("the transfer should abort");
-        assert!(diagnostics
-            .last()
-            .is_some_and(|d| d.message.contains("Post-condition check failure")));
+            .stx_transfer(1000, recipient, sends_exactly(sender, 1000))
+            .expect_err("the transfer should be rejected");
 
-        // Mainnet aborts the payload but still includes the transaction, so the
-        // STX stays put and the nonce moves.
+        assert!(diagnostics.last().is_some_and(|d| d.message
+            == "Invalid Stacks transaction: TokenTransfer transactions do not support post-conditions"));
+
         assert_eq!(
             session.interpreter.get_balance_for_account(sender, "STX"),
             1_000_000
@@ -2211,7 +2203,7 @@ mod tests {
                 .get_balance_for_account(recipient, "STX"),
             0
         );
-        assert_eq!(session.get_nonce(&principal(sender)).unwrap(), 1);
+        assert_eq!(session.get_nonce(&principal(sender)).unwrap(), 0);
     }
 
     #[test]

--- a/components/clarity-repl/tests/empty_session.rs
+++ b/components/clarity-repl/tests/empty_session.rs
@@ -1,6 +1,7 @@
 use clarity::types::StacksEpochId;
 use clarity::util::hash::hex_bytes;
 use clarity::vm::{ClarityVersion, EvaluationResult, Value};
+use clarity_repl::repl::post_conditions::PostConditionCheck;
 use clarity_repl::repl::{self, ClarityContract, Session, SessionSettings};
 use indoc::indoc;
 
@@ -84,7 +85,7 @@ fn it_handles_clarity2_block_height_in_epoch3() {
         epoch: repl::Epoch::Specific(StacksEpochId::Epoch32),
         skip_analysis: false,
     };
-    let result = session.deploy_contract(&contract, false, None);
+    let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
     assert!(result.is_ok());
 
     let snippet = format!("(contract-call? '{deployer}.gbh get-block-height)");
@@ -124,7 +125,7 @@ fn it_handles_clarity2_get_block_info_in_epoch2() {
         epoch: repl::Epoch::Specific(StacksEpochId::Epoch24),
         skip_analysis: false,
     };
-    let result = session.deploy_contract(&contract, false, None);
+    let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
     assert!(result.is_ok());
 
     let snippet = format!("(contract-call? '{deployer}.gbh get-block-hash u9)");
@@ -172,7 +173,7 @@ fn it_handles_clarity2_get_block_info_in_epoch3() {
         epoch: repl::Epoch::Specific(StacksEpochId::Epoch32),
         skip_analysis: false,
     };
-    let result = session.deploy_contract(&contract, false, None);
+    let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
     assert!(result.is_ok());
 
     let snippet = format!("(contract-call? '{deployer}.gbh get-block-hash u41)");

--- a/components/clarity-repl/tests/empty_session_with_mxs.rs
+++ b/components/clarity-repl/tests/empty_session_with_mxs.rs
@@ -215,6 +215,7 @@ mod test_mxs_session_test {
     use clarity::types::StacksEpochId;
     use clarity::util::hash::hex_bytes;
     use clarity::vm::{ClarityVersion, Value};
+    use clarity_repl::repl::post_conditions::PostConditionCheck;
     use clarity_repl::repl::{self, ClarityContract};
 
     use crate::{eval_snippet, init_mainnet_session, init_testnet_session};
@@ -427,7 +428,7 @@ mod test_mxs_session_test {
             epoch: repl::Epoch::Specific(StacksEpochId::Epoch32),
             skip_analysis: false,
         };
-        let result = session.deploy_contract(&contract, false, None);
+        let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         assert!(result.is_ok());
 
         let snippet = format!("(contract-call? '{deployer}.gbh get-block-height)");
@@ -464,7 +465,7 @@ mod test_mxs_session_test {
             epoch: repl::Epoch::Specific(StacksEpochId::Epoch24),
             skip_analysis: false,
         };
-        let result = session.deploy_contract(&contract, false, None);
+        let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         assert!(result.is_ok());
 
         // 107107 is a block in epoch 2.4
@@ -513,7 +514,7 @@ mod test_mxs_session_test {
             epoch: repl::Epoch::Specific(StacksEpochId::Epoch32),
             skip_analysis: false,
         };
-        let result = session.deploy_contract(&contract, false, None);
+        let result = session.deploy_contract(&contract, false, None, PostConditionCheck::Unchecked);
         assert!(result.is_ok());
 
         // 107_107 is a block in epoch 2.4

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
         # Hash for clarity git dependency - update this when Cargo.lock changes
         # Run `nix run .#check-git-dependencies-hash` to verify or get the new hash
-        clarityHash = "sha256-4pk+Iq706MOkJqW6L88l0Z7kqEkCv8xLhuyFOnnGYkU=";
+        clarityHash = "sha256-d/NdmutjMM7Da4qmEGeetg9mrcC3PvHQuqLzFhi/jZw=";
 
         clarinet = rustPlatform.buildRustPackage {
           inherit pname version;


### PR DESCRIPTION
### Description

Add optional post-conditions in simnet

The following Clarinet SDK methods can now accept the optional parameter `postConditions`:

  - `callPublicFn()`
  - `callPrivateFn()`
  - `deployContract()`
  - `transferSTX()`

where `postConditions` is an array of objects or hex strings, defined in as `@stacks/transactions` as:

```typescript
postConditions?: (PostCondition | PostConditionWire | string)[];
```

To preserve backwards compatibility, using post-conditions in Clarinet SDK methods is completely optional and never required

#### Breaking change?

No

### Example

#### Using Structured Objects

```typescript
  import { Cl, Pc } from "@stacks/transactions";
  import { initSimnet } from "@stacks/clarinet-sdk";

  const simnet = await initSimnet();
  const sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";

  const receipt = simnet.callPublicFn(
    "counter",
    "increment",
    [],
    sender,
    {
      postConditions: [
        Pc.principal(sender)
          .willSendEq(1_000_000)
          .ustx(),
      ],
    },
  );

  console.log(Cl.prettyPrint(receipt.result));
```

#### Using Hex Strings

```typescript
  import {
    Cl,
    Pc,
    postConditionToHex,
  } from "@stacks/transactions";
  import { initSimnet } from "@stacks/clarinet-sdk";

  const simnet = await initSimnet();
  const sender = "ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5";

  const postConditionHex = postConditionToHex(
    Pc.principal(sender)
      .willSendEq(1_000_000)
      .ustx(),
  );

  const receipt = simnet.callPublicFn(
    "counter",
    "increment",
    [],
    sender,
    {
      postConditions: [postConditionHex],
    },
  );

  console.log(Cl.prettyPrint(receipt.result));
```

### Checklist

- [x] Tests added in this PR (if applicable)