### PR TITLE
fix(clarity-vscode): load the browser LSP wasm from extensionUri

### DIFF
--- a/components/clarity-vscode/client/src/clientBrowser.ts
+++ b/components/clarity-vscode/client/src/clientBrowser.ts
@@ -1,6 +1,8 @@
 import { ExtensionContext, Uri } from "vscode";
 import { LanguageClient } from "vscode-languageclient/browser";
 
+import { INIT_WASM_METHOD } from "../../shared/lspWorkerProtocol";
+import type { InitWasmMessage } from "../../shared/lspWorkerProtocol";
 import { clientOpts, initClient } from "./common";
 
 let client: LanguageClient;
@@ -12,6 +14,19 @@ export async function activate(context: ExtensionContext) {
   );
 
   const worker = new Worker(serverMain.toString(true));
+
+  // VS Code starts this worker from a blob URL on an isolated origin, so it
+  // can't resolve the wasm module relatively to itself. `extensionUri` is the
+  // only reliable source for it: it points at whichever registry served the
+  // extension (Marketplace, Open VSX, or the local dev server).
+  const initWasm: InitWasmMessage = {
+    method: INIT_WASM_METHOD,
+    wasmURL: Uri.joinPath(
+      context.extensionUri,
+      "server/dist/lsp-browser_bg.wasm",
+    ).toString(true),
+  };
+  worker.postMessage(initWasm);
 
   let serverWorkerReady: ((value: unknown) => void) | null = null;
   let workerTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/components/clarity-vscode/client/tsconfig.json
+++ b/components/clarity-vscode/client/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "preserve",
     "moduleResolution": "bundler",
     "types": ["node"],
-    "rootDir": "src",
     "sourceMap": true,
     "noImplicitAny": true,
     "strict": true

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",
     "pretest": "NODE_ENV=test concurrently \"rspack build -c ./rspack.config.dev.js\" \"swc --config-file .runTests.swcrc ./client/tests/runTests.ts -o ./client/dist/tests/runTests.js\"",
     "test": "node client/dist/tests/runTests.js",
-    "lint": "eslint ./client/src ./server/src",
+    "lint": "eslint ./client/src ./server/src ./shared",
     "dev:watch": "rspack build -c ./rspack.config.dev.js -w",
     "dev:browser": "vscode-test-web --extensionDevelopmentPath=. ./test-data --open-devtools",
     "dev": "rspack build -c ./rspack.config.dev.js && concurrently \"pnpm:dev:*\"",

--- a/components/clarity-vscode/rspack.config.js
+++ b/components/clarity-vscode/rspack.config.js
@@ -6,20 +6,12 @@ const path = require("path");
 const rspack = require("@rspack/core");
 const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 
-const { name, publisher, version } = require("./package.json");
-
 const PRODUCTION = process.env.NODE_ENV === "production";
 
 /** @type RspackConfig["mode"] */
 const mode = PRODUCTION ? "production" : "none";
 /** @type RspackConfig["devtool"] */
 const devtool = PRODUCTION ? false : "source-map";
-
-// Where the browser server fetches its Wasm from at runtime. Non-production
-// builds are served by `@vscode/test-web` (`pnpm dev`, `pnpm test`).
-const extensionURL = PRODUCTION
-  ? `https://${publisher}.vscode-unpkg.net/${publisher}/${name}/${version}/extension/`
-  : "http://localhost:3000/static/devextensions/";
 
 const swcLoader = {
   test: /\.ts$/,
@@ -110,9 +102,6 @@ const serverBrowserConfig = {
   output: serverOutput,
   resolve: { extensions: [".ts", ".js"] },
   plugins: [
-    new rspack.DefinePlugin({
-      __EXTENSION_URL__: JSON.stringify(extensionURL),
-    }),
     new WasmPackPlugin({
       crateDirectory: path.resolve(__dirname, "../clarity-lsp"),
       extraArgs: "--release --target=web",
@@ -128,10 +117,16 @@ const serverBrowserConfig = {
     }),
   ],
   module: {
-    rules: [swcLoader],
-    // Don't turn that same `new URL()` into a second, hashed copy of the Wasm
-    // in non-production builds, where the glue survives.
-    parser: { javascript: { url: false } },
+    rules: [
+      swcLoader,
+      {
+        // Don't turn that same `new URL()` into a second, hashed copy of the
+        // Wasm in non-production builds, where the glue survives. Scoped to the
+        // glue so the rest of the bundle keeps normal `new URL()` assets.
+        test: /clarity-lsp-browser[\\/]lsp-browser\.js$/,
+        parser: { url: false },
+      },
+    ],
   },
 };
 

--- a/components/clarity-vscode/server/src/serverBrowser.ts
+++ b/components/clarity-vscode/server/src/serverBrowser.ts
@@ -4,13 +4,42 @@ import {
   BrowserMessageWriter,
 } from "vscode-languageserver/browser";
 
+import { isInitWasmMessage } from "../../shared/lspWorkerProtocol";
 import { initSync, LspVscodeBridge } from "./clarity-lsp-browser/lsp-browser";
 import { initConnection } from "./common";
 
-declare const __EXTENSION_URL__: string;
+const INIT_WASM_TIMEOUT = 10_000;
 
-(async function startServer() {
-  const wasmURL = new URL("server/dist/lsp-browser_bg.wasm", __EXTENSION_URL__);
+// This worker runs from a blob URL on an isolated origin, so neither
+// `self.location` nor a build-time constant can locate the extension assets:
+// the host differs between the VS Code Marketplace, Open VSX and local
+// development. Only the client knows the real URL, and it hands it over here.
+function waitForWasmURL(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    function onInitWasm({ data }: MessageEvent) {
+      if (!isInitWasmMessage(data)) return;
+      self.removeEventListener("message", onInitWasm);
+      clearTimeout(timeout);
+      resolve(data.wasmURL);
+    }
+
+    const timeout = setTimeout(() => {
+      self.removeEventListener("message", onInitWasm);
+      reject(new Error("timed out waiting for the wasm url from the client"));
+    }, INIT_WASM_TIMEOUT);
+
+    // registered synchronously, before the worker yields for the first time,
+    // so that the client message can not be missed
+    self.addEventListener("message", onInitWasm);
+  });
+}
+
+async function startServer() {
+  // the connection can only be opened once the init message has been consumed:
+  // `BrowserMessageReader` would otherwise forward it to the language server as
+  // an unknown notification. The client doesn't send any LSP message before it
+  // receives `serverWorkerReady`, so nothing can be lost in the meantime.
+  const wasmURL = await waitForWasmURL();
 
   const wasmModule = fetch(wasmURL, {
     headers: {
@@ -33,4 +62,10 @@ declare const __EXTENSION_URL__: string;
 
   initConnection(connection, bridge);
   connection.sendNotification("serverWorkerReady");
-})();
+}
+
+startServer().catch((err) => {
+  // the client can only report its own generic worker timeout, so make the
+  // actual cause visible instead of leaving an unhandled rejection behind
+  console.error("failed to start the clarity language server", err);
+});

--- a/components/clarity-vscode/shared/lspWorkerProtocol.ts
+++ b/components/clarity-vscode/shared/lspWorkerProtocol.ts
@@ -1,0 +1,19 @@
+// Contract between the web extension client and the LSP server worker, shared
+// so that a rename can't silently desynchronise the two bundles.
+//
+// The worker is started from a blob URL on an isolated origin and can't resolve
+// the extension assets by itself, so the client sends it the wasm URL derived
+// from `extensionUri` as the very first message.
+
+export const INIT_WASM_METHOD = "clarity-lsp/initWasm";
+
+export interface InitWasmMessage {
+  method: typeof INIT_WASM_METHOD;
+  wasmURL: string;
+}
+
+export function isInitWasmMessage(data: unknown): data is InitWasmMessage {
+  if (typeof data !== "object" || data === null) return false;
+  const { method, wasmURL } = data as Partial<InitWasmMessage>;
+  return method === INIT_WASM_METHOD && typeof wasmURL === "string";
+}


### PR DESCRIPTION
### Description

The browser language server fetched its wasm from a build-time URL hardcoded to `stackslabs.vscode-unpkg.net`, which is the wrong host on Open VSX (VSCodium web, Gitpod, Theia) and since the release workflow ships the same vsix to both registries, the web LSP could never start there.

`clientBrowser.ts` now derives the URL from `context.extensionUri` and posts it to the worker, which consumes it before opening the LSP connection; relative resolution isn't an option because VS Code starts that worker from a blob URL on an isolated origin. Also scopes #2520's `parser.url` to the wasm-bindgen glue rather than the whole server bundle.
