### PR TITLE
feat: add keyed events to event observer config

### DIFF
--- a/components/clarinet-cli/examples/simple-nft/settings/Devnet.toml
+++ b/components/clarinet-cli/examples/simple-nft/settings/Devnet.toml
@@ -77,7 +77,10 @@ disable_bitcoin_explorer = true
 # disable_stacks_api = true
 # disable_postgres = false
 # working_dir = "tmp/devnet"
-# stacks_node_events_observers = ["host.docker.internal:8002"]
+# stacks_node_events_observers = ["host.docker.internal:8002"] # Defaults to events_keys = ["*"]
+# stacks_node_events_observers = [
+#   { endpoint = "host.docker.internal:8787", events_keys = ["burn_blocks", "memtx"] },
+# ]
 # miner_mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
 # miner_derivation_path = "m/44'/5757'/0'/0/0"
 # orchestrator_port = 20445

--- a/components/clarinet-cli/examples/swappool/settings/Devnet.toml
+++ b/components/clarinet-cli/examples/swappool/settings/Devnet.toml
@@ -77,7 +77,10 @@ disable_stacks_explorer = false
 disable_stacks_api = false
 # disable_bitcoin_explorer = true
 # working_dir = "tmp/devnet"
-# stacks_node_events_observers = ["host.docker.internal:8002"]
+# stacks_node_events_observers = ["host.docker.internal:8002"] # Defaults to events_keys = ["*"]
+# stacks_node_events_observers = [
+#   { endpoint = "host.docker.internal:8787", events_keys = ["burn_blocks", "memtx"] },
+# ]
 # miner_mnemonic = "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce"
 # miner_derivation_path = "m/44'/5757'/0'/0/0"
 # faucet_mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -339,7 +339,10 @@ impl GetChangesForNewProject {
             # disable_postgres = false
             # disable_bitcoin_explorer = true
             # working_dir = "tmp/devnet"
-            # stacks_node_events_observers = ["host.docker.internal:8002"]
+            # stacks_node_events_observers = ["host.docker.internal:8002"] # Defaults to events_keys = ["*"]
+            # stacks_node_events_observers = [
+            #   {{ endpoint = "host.docker.internal:8787", events_keys = ["burn_blocks", "memtx"] }},
+            # ]
             # miner_mnemonic = "{DEFAULT_STACKS_MINER_MNEMONIC}"
             # miner_derivation_path = "{DEFAULT_DERIVATION_PATH}"
             # faucet_mnemonic = "{DEFAULT_FAUCET_MNEMONIC}"

--- a/components/clarinet-files/src/lib.rs
+++ b/components/clarinet-files/src/lib.rs
@@ -21,7 +21,7 @@ use std::pin::Pin;
 
 pub use network_manifest::{
     compute_addresses, AccountConfig, DevnetConfig, DevnetConfigFile, NetworkManifest,
-    NetworkManifestFile, PoxStackingOrder, DEFAULT_BITCOIN_EXPLORER_IMAGE,
+    NetworkManifestFile, PoxStackingOrder, StacksNodeEventObserver, DEFAULT_BITCOIN_EXPLORER_IMAGE,
     DEFAULT_BITCOIN_NODE_IMAGE, DEFAULT_DERIVATION_PATH, DEFAULT_DOCKER_PLATFORM,
     DEFAULT_EPOCH_2_0, DEFAULT_EPOCH_2_05, DEFAULT_EPOCH_2_1, DEFAULT_EPOCH_2_2, DEFAULT_EPOCH_2_3,
     DEFAULT_EPOCH_2_4, DEFAULT_EPOCH_2_5, DEFAULT_EPOCH_3_0, DEFAULT_EPOCH_3_1, DEFAULT_EPOCH_3_2,

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -146,7 +146,7 @@ pub struct DevnetConfigFile {
     pub bitcoin_node_rpc_port: Option<u16>,
     pub stacks_node_p2p_port: Option<u16>,
     pub stacks_node_rpc_port: Option<u16>,
-    pub stacks_node_events_observers: Option<Vec<String>>,
+    pub stacks_node_events_observers: Option<Vec<StacksNodeEventObserver>>,
     pub stacks_node_wait_time_for_microblocks: Option<u32>,
     pub stacks_node_first_attempt_time_ms: Option<u32>,
     pub stacks_node_env_vars: Option<Vec<String>>,
@@ -208,6 +208,41 @@ pub struct DevnetConfigFile {
     pub epoch_4_0: Option<u64>,
     pub use_docker_gateway_routing: Option<bool>,
     pub docker_platform: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(from = "StacksNodeEventObserverFile")]
+pub struct StacksNodeEventObserver {
+    pub endpoint: String,
+    pub events_keys: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StacksNodeEventObserverFile {
+    Endpoint(String),
+    Config {
+        endpoint: String,
+        events_keys: Vec<String>,
+    },
+}
+
+impl From<StacksNodeEventObserverFile> for StacksNodeEventObserver {
+    fn from(observer: StacksNodeEventObserverFile) -> Self {
+        match observer {
+            StacksNodeEventObserverFile::Endpoint(endpoint) => Self {
+                endpoint,
+                events_keys: vec!["*".into()],
+            },
+            StacksNodeEventObserverFile::Config {
+                endpoint,
+                events_keys,
+            } => Self {
+                endpoint,
+                events_keys,
+            },
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -284,7 +319,7 @@ pub struct DevnetConfig {
     pub stacks_node_rpc_port: u16,
     pub stacks_node_wait_time_for_microblocks: u32,
     pub stacks_node_first_attempt_time_ms: u32,
-    pub stacks_node_events_observers: Vec<String>,
+    pub stacks_node_events_observers: Vec<StacksNodeEventObserver>,
     pub stacks_node_env_vars: Vec<String>,
     pub stacks_node_next_initiative_delay: u16,
     pub stacks_api_port: u16,
@@ -1262,7 +1297,52 @@ fn compute_btc_address(_public_key: &PublicKey, _network: &BitcoinNetwork) -> St
 mod tests {
     use clarinet_defaults::DEFAULT_EPOCH;
 
-    use crate::{DEFAULT_STACKS_NODE_IMAGE, DEFAULT_STACKS_SIGNER_IMAGE};
+    use crate::{
+        DevnetConfigFile, StacksNodeEventObserver, DEFAULT_STACKS_NODE_IMAGE,
+        DEFAULT_STACKS_SIGNER_IMAGE,
+    };
+
+    #[test]
+    fn parses_legacy_stacks_node_event_observer() {
+        let config: DevnetConfigFile =
+            toml::from_str(r#"stacks_node_events_observers = ["host.docker.internal:8002"]"#)
+                .unwrap();
+
+        assert_eq!(
+            config.stacks_node_events_observers.unwrap(),
+            vec![StacksNodeEventObserver {
+                endpoint: "host.docker.internal:8002".into(),
+                events_keys: vec!["*".into()],
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_selective_stacks_node_event_observers() {
+        let config: DevnetConfigFile = toml::from_str(
+            r#"
+            stacks_node_events_observers = [
+                { endpoint = "host.docker.internal:8787", events_keys = ["burn_blocks", "memtx"] },
+                { endpoint = "host.docker.internal:8788", events_keys = [] },
+            ]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.stacks_node_events_observers.unwrap(),
+            vec![
+                StacksNodeEventObserver {
+                    endpoint: "host.docker.internal:8787".into(),
+                    events_keys: vec!["burn_blocks".into(), "memtx".into()],
+                },
+                StacksNodeEventObserver {
+                    endpoint: "host.docker.internal:8788".into(),
+                    events_keys: vec![],
+                },
+            ]
+        );
+    }
 
     #[test]
     fn test_default_stacks_docker_images_version() {

--- a/components/clarity-vscode/test-data/test-cases/settings/Devnet.toml
+++ b/components/clarity-vscode/test-data/test-cases/settings/Devnet.toml
@@ -36,7 +36,10 @@ disable_stacks_api = false
 # disable_postgres = false
 # disable_bitcoin_explorer = true
 # working_dir = "tmp/devnet"
-# stacks_node_events_observers = ["host.docker.internal:8002"]
+# stacks_node_events_observers = ["host.docker.internal:8002"] # Defaults to events_keys = ["*"]
+# stacks_node_events_observers = [
+#   { endpoint = "host.docker.internal:8787", events_keys = ["burn_blocks", "memtx"] },
+# ]
 # miner_mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
 # miner_derivation_path = "m/44'/5757'/0'/0/0"
 # faucet_mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"

--- a/components/stacks-network/src/orchestrator.rs
+++ b/components/stacks-network/src/orchestrator.rs
@@ -22,7 +22,8 @@ use bollard::Docker;
 use clarinet_deployments::types::BurnchainEpochConfig;
 use clarinet_files::{
     DevnetConfig, DevnetConfigFile, NetworkManifest, ProjectManifest, StacksNetwork,
-    DEFAULT_DOCKER_PLATFORM, DEFAULT_POX_PREPARE_LENGTH, DEFAULT_POX_REWARD_LENGTH,
+    StacksNodeEventObserver, DEFAULT_DOCKER_PLATFORM, DEFAULT_POX_PREPARE_LENGTH,
+    DEFAULT_POX_REWARD_LENGTH,
 };
 use clarity::types::chainstate::StacksPrivateKey;
 use clarity::types::PrivateKey;
@@ -30,6 +31,7 @@ use futures::stream::TryStreamExt;
 use hiro_system_kit::slog;
 use indoc::formatdoc;
 use observer::utils::Context;
+use serde::Serialize;
 
 use crate::bitcoin_rpc_client::BitcoinRpcClient;
 use crate::command::run_docker_command;
@@ -38,6 +40,64 @@ use crate::event::{send_status_update, DevnetEvent, Status};
 const BITCOIND_DATA_DIR: &str = "/home/bitcoin/.bitcoin";
 
 const DOCKER_ERR_MSG: &str = "unable to get docker client";
+
+#[derive(Serialize)]
+struct StacksNodeEventObserversConfig<'a> {
+    events_observer: &'a [StacksNodeEventObserver],
+}
+
+fn serialize_stacks_node_event_observers(
+    observers: &[StacksNodeEventObserver],
+) -> Result<String, String> {
+    if observers.is_empty() {
+        return Ok(String::new());
+    }
+
+    toml::to_string(&StacksNodeEventObserversConfig {
+        events_observer: observers,
+    })
+    .map_err(|e| format!("unable to serialize Stacks node event observers: {e:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_selective_stacks_node_event_observers() {
+        let observers = vec![
+            StacksNodeEventObserver {
+                endpoint: "host.docker.internal:8787".into(),
+                events_keys: vec!["burn_blocks".into(), "memtx".into()],
+            },
+            StacksNodeEventObserver {
+                endpoint: "host.docker.internal:8788".into(),
+                events_keys: vec![
+                    "ST000000000000000000002AMW42H.token::mint".into(),
+                    "ST000000000000000000002AMW42H.token.asset".into(),
+                ],
+            },
+        ];
+
+        let serialized = serialize_stacks_node_event_observers(&observers).unwrap();
+        let config = stackslib::config::ConfigFile::from_str(&serialized).unwrap();
+        let parsed = config.events_observer.unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        for observer in observers {
+            let parsed_observer = parsed
+                .iter()
+                .find(|candidate| candidate.endpoint == observer.endpoint)
+                .unwrap();
+            assert_eq!(parsed_observer.events_keys, observer.events_keys);
+        }
+    }
+
+    #[test]
+    fn omits_empty_stacks_node_event_observer_config() {
+        assert_eq!(serialize_stacks_node_event_observers(&[]).unwrap(), "");
+    }
+}
 
 #[derive(Debug)]
 pub struct DevnetOrchestrator {
@@ -953,15 +1013,9 @@ impl DevnetOrchestrator {
             ));
         }
 
-        for chains_coordinator in devnet_config.stacks_node_events_observers.iter() {
-            stacks_conf.push_str(&formatdoc!(
-                r#"
-                [[events_observer]]
-                endpoint = "{chains_coordinator}"
-                events_keys = ["*"]
-                "#,
-            ));
-        }
+        stacks_conf.push_str(&serialize_stacks_node_event_observers(
+            &devnet_config.stacks_node_events_observers,
+        )?);
 
         stacks_conf.push_str(&formatdoc!(
             r#"


### PR DESCRIPTION
- closes #2204 

backwards compat remains defaulted to ["*"]:

 ```toml
stacks_node_events_observers = ["host.docker.internal:8002"]
 ```

specific event keys:

 ```toml
stacks_node_events_observers = [
  { endpoint = "host.docker.internal:8787", events_keys = ["burn_blocks", "memtx"] },
]
 ```