### PR TITLE
perf: cache wallet key derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "bip32",
  "bip39",
  "bs58",
+ "divan",
  "libsecp256k1",
  "rand 0.9.4",
 ]

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -559,3 +559,61 @@ impl GetChangesForNewProject {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clarinet_files::DEFAULT_DERIVATION_PATH;
+
+    use super::*;
+
+    fn generated_devnet_toml() -> String {
+        let changes =
+            GetChangesForNewProject::new("/tmp".into(), "bench-guard".into(), false, false)
+                .run()
+                .expect("project generation failed");
+
+        changes
+            .into_iter()
+            .find_map(|change| match change {
+                Changes::AddFile(file) if file.path.ends_with("settings/Devnet.toml") => {
+                    Some(file.content)
+                }
+                _ => None,
+            })
+            .expect("generated project has no settings/Devnet.toml")
+    }
+
+    /// A default project derives 10 wallets on every session start, and the
+    /// LSP re-derives them on every file save. `clarinet-utils` bakes their
+    /// keys in so the PBKDF2 rounds are skipped — but only for these exact
+    /// phrases. Editing the template below without updating that table would
+    /// quietly hand ~10 ms back to every session.
+    #[test]
+    fn generated_wallets_are_precomputed() {
+        let manifest: toml::Value =
+            toml::from_str(&generated_devnet_toml()).expect("generated Devnet.toml is not valid");
+
+        let Some(toml::Value::Table(accounts)) = manifest.get("accounts") else {
+            panic!("generated Devnet.toml has no [accounts] table");
+        };
+        assert_eq!(accounts.len(), 10, "unexpected number of default accounts");
+
+        for (label, settings) in accounts {
+            let toml::Value::Table(settings) = settings else {
+                panic!("[accounts.{label}] is not a table");
+            };
+            let Some(toml::Value::String(mnemonic)) = settings.get("mnemonic") else {
+                panic!("[accounts.{label}] has no mnemonic");
+            };
+            let derivation = match settings.get("derivation") {
+                Some(toml::Value::String(path)) => path.as_str(),
+                _ => DEFAULT_DERIVATION_PATH,
+            };
+            assert!(
+                clarinet_utils::is_precomputed(mnemonic, derivation),
+                "the generated {label} mnemonic is missing from the \
+                 clarinet-utils precomputed table"
+            );
+        }
+    }
+}

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -1302,6 +1302,30 @@ mod tests {
         DEFAULT_STACKS_SIGNER_IMAGE,
     };
 
+    /// Every devnet wallet is derived on each `NetworkManifest` load, which the
+    /// LSP does on every file save. `clarinet-utils` bakes their keys in so the
+    /// PBKDF2 rounds are skipped; if a default mnemonic or the derivation path
+    /// changes here, that table goes stale and the cost comes back silently.
+    #[test]
+    fn devnet_default_mnemonics_are_precomputed() {
+        use crate::{
+            DEFAULT_DERIVATION_PATH, DEFAULT_FAUCET_MNEMONIC, DEFAULT_STACKER_MNEMONIC,
+            DEFAULT_STACKS_MINER_MNEMONIC,
+        };
+
+        for (label, mnemonic) in [
+            ("miner", DEFAULT_STACKS_MINER_MNEMONIC),
+            ("faucet", DEFAULT_FAUCET_MNEMONIC),
+            ("stacker", DEFAULT_STACKER_MNEMONIC),
+        ] {
+            assert!(
+                clarinet_utils::is_precomputed(mnemonic, DEFAULT_DERIVATION_PATH),
+                "the default devnet {label} mnemonic is missing from the \
+                 clarinet-utils precomputed table"
+            );
+        }
+    }
+
     #[test]
     fn parses_legacy_stacks_node_event_observer() {
         let config: DevnetConfigFile =

--- a/components/clarinet-utils/Cargo.toml
+++ b/components/clarinet-utils/Cargo.toml
@@ -17,3 +17,10 @@ rand.workspace = true
 [lib]
 name = "clarinet_utils"
 path = "src/lib.rs"
+
+[dev-dependencies]
+divan = { workspace = true }
+
+[[bench]]
+name = "bip32"
+harness = false

--- a/components/clarinet-utils/benches/bip32.rs
+++ b/components/clarinet-utils/benches/bip32.rs
@@ -1,0 +1,69 @@
+//! Where the time inside `get_bip32_keys_from_mnemonic` actually goes.
+//!
+//! Three stages, run back to back for every wallet in `settings/Devnet.toml`:
+//!   1. `Mnemonic::to_seed` — PBKDF2-HMAC-SHA512, 2048 rounds
+//!   2. `XPrv::derive_from_path` — one HMAC-SHA512 + one secp256k1 point
+//!      multiplication per level (5 levels for `m/44'/5757'/0'/0/0`)
+//!   3. `PublicKey::from_secret_key` — one more point multiplication
+
+use std::hint::black_box;
+use std::str::FromStr;
+
+use bip32::{DerivationPath, XPrv};
+use bip39::{Language, Mnemonic};
+use clarinet_utils::{get_bip32_keys_from_mnemonic, random_mnemonic};
+use libsecp256k1::{PublicKey, SecretKey};
+
+const PHRASE: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
+const DERIVATION: &str = "m/44'/5757'/0'/0/0";
+
+fn main() {
+    divan::main();
+}
+
+/// The three stages together, for a mnemonic no cache has seen.
+#[divan::bench]
+fn total_uncached(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| random_mnemonic().to_string())
+        .bench_values(|phrase| get_bip32_keys_from_mnemonic(&phrase, "", DERIVATION).unwrap());
+}
+
+/// The same call for a mnemonic Clarinet ships, which resolves from the
+/// compile-time table instead.
+#[divan::bench]
+fn total_precomputed() -> (Vec<u8>, PublicKey) {
+    get_bip32_keys_from_mnemonic(black_box(PHRASE), "", black_box(DERIVATION)).unwrap()
+}
+
+#[divan::bench]
+fn stage1_to_seed(bencher: divan::Bencher) {
+    let mnemonic = Mnemonic::parse_in(Language::English, PHRASE).unwrap();
+    bencher.bench(|| black_box(&mnemonic).to_seed(""));
+}
+
+#[divan::bench]
+fn stage2_derive_path(bencher: divan::Bencher) {
+    let mnemonic = Mnemonic::parse_in(Language::English, PHRASE).unwrap();
+    let mut seed = [0u8; 64];
+    seed.copy_from_slice(&mnemonic.to_seed(""));
+    let path = DerivationPath::from_str(DERIVATION).unwrap();
+    bencher.bench(|| XPrv::derive_from_path(black_box(seed), black_box(&path)).unwrap());
+}
+
+#[divan::bench]
+fn stage3_public_key(bencher: divan::Bencher) {
+    let mnemonic = Mnemonic::parse_in(Language::English, PHRASE).unwrap();
+    let mut seed = [0u8; 64];
+    seed.copy_from_slice(&mnemonic.to_seed(""));
+    let path = DerivationPath::from_str(DERIVATION).unwrap();
+    let xprv = XPrv::derive_from_path(seed, &path).unwrap();
+    let secret = SecretKey::parse_slice(&xprv.private_key().to_bytes()).unwrap();
+    bencher.bench(|| PublicKey::from_secret_key(black_box(&secret)));
+}
+
+/// Parsing the derivation path string itself — should be noise.
+#[divan::bench]
+fn derivation_path_parse() -> DerivationPath {
+    DerivationPath::from_str(black_box(DERIVATION)).unwrap()
+}

--- a/components/clarinet-utils/src/lib.rs
+++ b/components/clarinet-utils/src/lib.rs
@@ -1,5 +1,9 @@
+mod precomputed;
+
+use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::{LazyLock, Mutex};
 
 use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, Error as AesGcmError, KeyInit, Nonce};
@@ -7,6 +11,7 @@ use argon2::{Argon2, Error as Argon2Error};
 use bip32::{DerivationPath, XPrv};
 use bip39::{Error as MnemonicError, Language, Mnemonic};
 use libsecp256k1::{PublicKey, SecretKey};
+pub use precomputed::is_precomputed;
 use rand::RngCore;
 
 /// Size of the AES-GCM nonce
@@ -61,11 +66,67 @@ pub fn random_mnemonic() -> Mnemonic {
     Mnemonic::from_entropy_in(Language::English, &entropy).unwrap()
 }
 
+type DerivedKeys = (Vec<u8>, PublicKey);
+
+/// Keys already derived in this process, keyed by `(phrase, password, path)`.
+///
+/// The same handful of wallets get derived over and over: the LSP rebuilds the
+/// whole `NetworkManifest` on every file save, and `clarinet deployments apply`
+/// re-derives the signing key for every transaction in the plan. The table in
+/// [`precomputed`] only covers the mnemonics Clarinet ships; this covers
+/// everything else, including custom wallets in a project's `Devnet.toml`.
+///
+/// Entries are bounded by the number of distinct wallets a process ever sees —
+/// a dozen or so — so there is nothing to evict.
+///
+/// This does keep derived secrets alive for the lifetime of the process. That
+/// is already true of the plaintext mnemonics held in `NetworkManifest`, which
+/// outlive every caller here.
+static DERIVED_KEYS: LazyLock<Mutex<HashMap<(String, String, String), DerivedKeys>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 pub fn get_bip32_keys_from_mnemonic(
     phrase: &str,
     password: &str,
     derivation: &str,
-) -> Result<(Vec<u8>, PublicKey), String> {
+) -> Result<DerivedKeys, String> {
+    // A BIP39 passphrase changes the seed, so the table only applies without one.
+    if password.is_empty() {
+        if let Some(keys) = precomputed::lookup(phrase, derivation) {
+            return Ok(keys);
+        }
+    }
+
+    let cache_key = (
+        phrase.to_string(),
+        password.to_string(),
+        derivation.to_string(),
+    );
+
+    // A poisoned lock only means some other thread panicked mid-lookup. This
+    // is a cache: fall back to deriving rather than propagating the failure.
+    if let Ok(cache) = DERIVED_KEYS.lock() {
+        if let Some(keys) = cache.get(&cache_key) {
+            return Ok(keys.clone());
+        }
+    }
+
+    let keys = derive_bip32_keys(phrase, password, derivation)?;
+
+    if let Ok(mut cache) = DERIVED_KEYS.lock() {
+        cache.insert(cache_key, keys.clone());
+    }
+
+    Ok(keys)
+}
+
+/// The derivation itself, with no caching. ~0.8 ms native / ~1.4 ms in the
+/// wasm build, dominated by the 2048 PBKDF2-HMAC-SHA512 rounds of `to_seed`.
+fn derive_bip32_keys(
+    phrase: &str,
+    password: &str,
+    derivation: &str,
+) -> Result<DerivedKeys, String> {
     let mnemonic = Mnemonic::parse_in(Language::English, phrase).map_err(|e| e.to_string())?;
     let seed_vec = mnemonic.to_seed(password);
     if seed_vec.len() != 64 {
@@ -329,6 +390,63 @@ mod tests {
         let (secret, pubkey) = result.unwrap();
         assert_eq!(secret.len(), 32);
         assert_eq!(pubkey.serialize_compressed().len(), 33);
+    }
+
+    /// A precomputed phrase must come back byte-identical to a live derivation.
+    #[test]
+    fn test_get_bip32_keys_uses_precomputed_table() {
+        const PHRASE: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
+        const DERIVATION: &str = "m/44'/5757'/0'/0/0";
+        assert!(is_precomputed(PHRASE, DERIVATION));
+
+        let (cached_secret, cached_public) =
+            get_bip32_keys_from_mnemonic(PHRASE, "", DERIVATION).unwrap();
+        let (derived_secret, derived_public) = derive_bip32_keys(PHRASE, "", DERIVATION).unwrap();
+
+        assert_eq!(cached_secret, derived_secret);
+        assert_eq!(cached_public, derived_public);
+    }
+
+    /// A BIP39 passphrase produces a different seed, so the table must not
+    /// answer for it.
+    #[test]
+    fn test_get_bip32_keys_bypasses_table_when_password_is_set() {
+        const PHRASE: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
+        const DERIVATION: &str = "m/44'/5757'/0'/0/0";
+
+        let (no_password, _) = get_bip32_keys_from_mnemonic(PHRASE, "", DERIVATION).unwrap();
+        let (with_password, _) =
+            get_bip32_keys_from_mnemonic(PHRASE, "hunter2", DERIVATION).unwrap();
+
+        assert_ne!(no_password, with_password);
+        assert_eq!(
+            with_password,
+            derive_bip32_keys(PHRASE, "hunter2", DERIVATION).unwrap().0
+        );
+    }
+
+    /// A mnemonic outside the table must be memoized, and the memoized value
+    /// must match a fresh derivation.
+    #[test]
+    fn test_get_bip32_keys_memoizes_unknown_mnemonics() {
+        const PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        const DERIVATION: &str = "m/44'/5757'/0'/0/3";
+        assert!(!is_precomputed(PHRASE, DERIVATION));
+
+        let first = get_bip32_keys_from_mnemonic(PHRASE, "", DERIVATION).unwrap();
+        let second = get_bip32_keys_from_mnemonic(PHRASE, "", DERIVATION).unwrap();
+        let fresh = derive_bip32_keys(PHRASE, "", DERIVATION).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first, fresh);
+    }
+
+    /// Neither cache may swallow the errors the callers rely on.
+    #[test]
+    fn test_get_bip32_keys_still_rejects_invalid_input() {
+        const PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        assert!(get_bip32_keys_from_mnemonic("not a mnemonic", "", "m/44'/5757'/0'/0/0").is_err());
+        assert!(get_bip32_keys_from_mnemonic(PHRASE, "", "not a path").is_err());
     }
 
     #[test]

--- a/components/clarinet-utils/src/precomputed.rs
+++ b/components/clarinet-utils/src/precomputed.rs
@@ -1,0 +1,192 @@
+//! Compile-time table of derived keys for the mnemonics Clarinet ships.
+//!
+//! Deriving a wallet costs ~0.8 ms native / ~1.4 ms in the wasm build, almost
+//! all of it the 2048 PBKDF2-HMAC-SHA512 rounds of `Mnemonic::to_seed`. A
+//! default project has 10 accounts in `settings/Devnet.toml` and devnet adds
+//! a miner and a stacker, so every session — and, in the LSP, every file save
+//! — spends ~10 ms recomputing the same answer.
+//!
+//! These phrases are already public: `clarinet new` writes them into
+//! `settings/Devnet.toml` along with the resulting secret keys, so baking the
+//! derived keys in exposes nothing new.
+//!
+//! The table is kept honest by tests rather than by discipline:
+//!   - [`tests::entries_match_live_derivation`] re-derives every entry
+//!   - `clarinet-files` asserts the devnet miner/faucet/stacker defaults hit it
+//!   - `clarinet-cli` asserts every account in a generated `Devnet.toml` hits it
+//!
+//! To add an entry, put the phrase in with placeholder keys and run the
+//! clarinet-utils tests; the failure prints what the values should be.
+
+use libsecp256k1::PublicKey;
+
+/// Every mnemonic Clarinet ships is used at the default Stacks derivation
+/// path. A custom `derivation` in a manifest misses the table and is derived
+/// normally.
+const DERIVATION_PATH: &str = "m/44'/5757'/0'/0/0";
+
+struct Entry {
+    phrase: &'static str,
+    secret_key: [u8; 32],
+    /// Uncompressed SEC1. `PublicKey::parse` only has to check that the point
+    /// is on the curve, where `parse_compressed` would have to recover `y`
+    /// with a modular square root.
+    public_key: [u8; 65],
+}
+
+const fn hex_nibble(c: u8) -> u8 {
+    match c {
+        b'0'..=b'9' => c - b'0',
+        b'a'..=b'f' => c - b'a' + 10,
+        _ => panic!("hex literal must be lowercase [0-9a-f]"),
+    }
+}
+
+/// Decodes a hex literal at compile time, so the table stays readable (and
+/// diffable against the `# secret_key:` comments in generated manifests)
+/// without paying for decoding at runtime.
+const fn hex<const N: usize>(s: &str) -> [u8; N] {
+    let bytes = s.as_bytes();
+    assert!(bytes.len() == 2 * N, "hex literal has the wrong length");
+    let mut out = [0u8; N];
+    let mut i = 0;
+    while i < N {
+        out[i] = (hex_nibble(bytes[2 * i]) << 4) | hex_nibble(bytes[2 * i + 1]);
+        i += 1;
+    }
+    out
+}
+
+static ENTRIES: &[Entry] = &[
+    // deployer
+    Entry {
+        phrase: "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw",
+        secret_key: hex("753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a6"),
+        public_key: hex("0490a5cac7c33fda49f70bc1b0866fa0ba7a9440d9de647fecb8132ceb76a94dfa80c44836f7a07cf96a13d3c2c7833a833ff59a3533b8369daa4949da39b09901"),
+    },
+    // wallet_1
+    Entry {
+        phrase: "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild",
+        secret_key: hex("7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c178"),
+        public_key: hex("04cd2cfdbd2ad9332828a7a13ef62cb999e063421c708e863a7ffed71fb61c88c94df6c2a9ebb183ffe28dcb6d43f36e926041fa56df1237ffa648cc0d22ea3737"),
+    },
+    // wallet_2
+    Entry {
+        phrase: "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital",
+        secret_key: hex("530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc2091"),
+        public_key: hex("041843d01fa0bb9a3495fd2caf92505a81055dbe1fd545880fd40c3a1c7fd9c40a89f441cf6ce7ed7e234e67d97613226993415af5aa0dd42f55807e7b128df9d8"),
+    },
+    // wallet_3
+    Entry {
+        phrase: "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high",
+        secret_key: hex("d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b39"),
+        public_key: hex("04c4b5eacb71a27be633ed970dcbc41c00440364bc04ba38ae4683ac24e708bf334891b9ad5c5e9ee021e796102e40f7345e1b402ff69fb4f52e221b1dabad1968"),
+    },
+    // wallet_4
+    Entry {
+        phrase: "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin",
+        secret_key: hex("f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c7"),
+        public_key: hex("04b3e0a76b292b2c83fc0ac14ae6160d0438ebe94e14bbb5b7755153628886e08ea5b60ea54a7fa77b069f5bc87f281b92ff2583d5e865312043b995115ef64727"),
+    },
+    // wallet_5
+    Entry {
+        phrase: "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase",
+        secret_key: hex("3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe8"),
+        public_key: hex("049fa3c9b2c98acc46563707702ee633141b2c125b85649e11548a30233f97ed9f9a3153eb9bb1eda3a9931ea12216cf3c94ba54ffa426edbcd52e057f036f97dd"),
+    },
+    // wallet_6
+    Entry {
+        phrase: "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy",
+        secret_key: hex("7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb"),
+        public_key: hex("048efa20fa5706567008ebaf48f7ae891342eeb944d96392f719c505c89f84ed8d36c32d5d9f728bbae80a35c7acb50a7b038d0e5d45c2e4669c15469db53eca08"),
+    },
+    // wallet_7
+    Entry {
+        phrase: "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow",
+        secret_key: hex("b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f14"),
+        public_key: hex("043f19d77c842b675bd8c858e9ac8b0ca2efa566f17accf8ef9ceb5a992dc67836b95faf7956d718512b37bf67c0a6ee107206a2c980900142ce8b016110f90ffc"),
+    },
+    // wallet_8
+    Entry {
+        phrase: "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune",
+        secret_key: hex("6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e"),
+        public_key: hex("049fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc79bd248ed760f07f0aa0719b4601950c95e4e1a35ddd855a398b12d3ae31dbd34"),
+    },
+    // faucet — also `DEFAULT_FAUCET_MNEMONIC`
+    Entry {
+        phrase: "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform",
+        secret_key: hex("de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b8"),
+        public_key: hex("04add319140c528a8955d76d4afe32c4d3143fea57ea353a31ce793cffb77ef8615cc09053489331377e2c637385f00cd5a1cafa54e4a083908d08dfae4f088d72"),
+    },
+    // `DEFAULT_STACKS_MINER_MNEMONIC`
+    Entry {
+        phrase: "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce",
+        secret_key: hex("3b68e410cc7f9b8bae76f2f2991b69ecd0627c95da22a904065dfb2a73d0585f"),
+        public_key: hex("0439810ebf35e6f6c26062c99f3e183708d377720617c90a986859ec9c95d00be9e16af4fe2d857755f0dd691cecb3489a5c6e04889f0015ed0d39e8262fe36608"),
+    },
+    // `DEFAULT_STACKER_MNEMONIC`
+    Entry {
+        phrase: "empty lens any direct brother then drop fury rule pole win claim scissors list rescue horn rent inform relief jump sword weekend half legend",
+        secret_key: hex("e93b8341c35983ae5b8f93b9530bd90281fd5e5e00a5094c2b7863ace78eac62"),
+        public_key: hex("044b9b194720f870d99c4f629b84626e0cdf1198b10b4dca7c4851771d72d07f8578333fcbdeec9de504890796e32741f397bed30fa4bb7451cf0d4a457cdcb8c7"),
+    },
+];
+
+fn find(phrase: &str, derivation: &str) -> Option<&'static Entry> {
+    if derivation != DERIVATION_PATH {
+        return None;
+    }
+    ENTRIES.iter().find(|entry| entry.phrase == phrase)
+}
+
+/// The derived keys for a shipped mnemonic, or `None` if it isn't one.
+pub(crate) fn lookup(phrase: &str, derivation: &str) -> Option<(Vec<u8>, PublicKey)> {
+    let entry = find(phrase, derivation)?;
+    let public_key = PublicKey::parse(&entry.public_key)
+        .expect("precomputed public key is not a valid secp256k1 point");
+    Some((entry.secret_key.to_vec(), public_key))
+}
+
+/// Whether this mnemonic and path resolve from the table instead of being
+/// derived. Exposed so crates that own the shipped mnemonics can assert their
+/// defaults are covered.
+pub fn is_precomputed(phrase: &str, derivation: &str) -> bool {
+    find(phrase, derivation).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::derive_bip32_keys;
+
+    /// The table is only as good as its agreement with the real derivation.
+    #[test]
+    fn entries_match_live_derivation() {
+        for entry in ENTRIES {
+            let (secret_key, public_key) = derive_bip32_keys(entry.phrase, "", DERIVATION_PATH)
+                .unwrap_or_else(|e| panic!("failed to derive {}: {e}", entry.phrase));
+
+            let hex = |bytes: &[u8]| bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
+            assert_eq!(
+                hex(&secret_key),
+                hex(&entry.secret_key),
+                "stale secret_key for \"{}\"",
+                entry.phrase
+            );
+            assert_eq!(
+                hex(&public_key.serialize()),
+                hex(&entry.public_key),
+                "stale public_key for \"{}\"",
+                entry.phrase
+            );
+        }
+    }
+
+    #[test]
+    fn lookup_is_scoped_to_the_default_derivation_path() {
+        let phrase = ENTRIES[0].phrase;
+        assert!(is_precomputed(phrase, DERIVATION_PATH));
+        assert!(!is_precomputed(phrase, "m/44'/5757'/0'/0/1"));
+        assert!(!is_precomputed("not a mnemonic", DERIVATION_PATH));
+    }
+}


### PR DESCRIPTION
### Description

Wallet key derivation was being redone constantly for inputs that never change. Each problem and what it does now:

- **Every session re-derived the same 10 wallets.** A default project's `settings/Devnet.toml` ships hardcoded mnemonics, so the answer is always identical — ~8 ms native, ~14 ms in the wasm build, per session. → A compile-time table of derived keys for the 12 mnemonics Clarinet ships (~1.2 KB of binary).
- **Custom wallets got no help from a table.** → A process-wide memo keyed by `(phrase, password, path)`, so anything not in the table is derived once per process.
- **`sign_transaction_payload` re-derived the signing key for every transaction** in a deployment plan, and `build_state` reloads the whole `NetworkManifest` on every file save. → Both caches sit behind `clarinet_utils::get_bip32_keys_from_mnemonic`, so every caller benefits without changing a signature.
**Known limitations of this branch, all fixed in #2540** (stacked on this PR — merge them together):

- The memo is an unbounded `HashMap`. An `[accounts.x]` table with no `mnemonic` gets a fresh `random_mnemonic()` on every load, so it can never be hit again and accumulates for the life of an LSP session (~300 bytes per save, and only for a hand-written manifest — no shipped fixture has such an account). #2540 caps it and evicts rather than refusing inserts.
- The cache key includes the BIP39 passphrase, so a non-empty one would be retained in plaintext. Nothing in the workspace passes one. #2540 excludes passphrase-bearing derivations from the cache entirely.
- `DerivedKeys` is private while appearing in a `pub fn` signature. #2540 makes it public.

#2540 also consolidates the shipped mnemonics into a single home, which is why these ride along with it rather than being separate.

#### Breaking change?

No.

### Benchmarks

`cargo bench -p clarinet-utils --bench bip32`; wasm via `wasm-pack --target nodejs` on Node 24, built as the SDK ships (`wasm-opt -Oz`).

|                           | native      | wasm        |
|---------------------------|-------------|-------------|
| uncached                  | 827 µs      | 1.34 ms     |
| compile-time table hit    | **66 ns**   | **149 ns**  |
| process memo hit          | **78 ns**   | **134 ns**  |

Multiplied across the 10 wallets a default project declares, that is ~8 ms native and ~14 ms wasm per session, reduced to well under 0.1 ms.

- 645 µs of the uncached 827 µs is `Mnemonic::to_seed`'s 2048 PBKDF2 rounds, 144 µs the BIP32 path walk and 19 µs the public key — so no faster backend helps, only skipping the work does.
- End to end, `initSimnet` on a fresh SDK with a 1-contract project: **105.0 ms → 93.8 ms** (min of 60 interleaved runs).

**Run on 2026-09-10, Apple silicon.**

### About the CodeQL alerts

- All 18 are one false positive: the flagged value is the **empty BIP39 passphrase** `""`, not a key. Two of the hits are on `random_mnemonic()` calls, which is by definition not hardcoded — the `""` is the only literal there. Clarinet uses no passphrase.
- **This PR introduces zero new mnemonics.** All 12 phrases were already literals on `main`; the change reduces the number of copies.
- They're public local-devnet test wallets: `clarinet new` writes all ten into `settings/Devnet.toml` in plaintext next to their `# secret_key:` values, and `clarinet-files` has hardcoded wallet_1's key as `DEFAULT_PRIVATE_KEYS` for years. Anyone who funded these on mainnet was compromised long before this PR.
- Dismissed as false positives with the reasoning recorded on each alert.
- One thing the alerts *don't* cover: the memo keeps derived secrets alive for the process lifetime. `NetworkManifest` already retains the plaintext mnemonics for longer, and the long-lived processes (LSP, SDK) only read `Devnet.toml`. The narrower case of a BIP39 passphrase — which the manifest does *not* hold — is fixed in #2540.

---

### Checklist

- [x] Tests added in this PR (if applicable)

A baked table is only as good as its agreement with reality, so tests guard it rather than discipline: `clarinet-utils` re-derives every entry against the live derivation; `clarinet-files` asserts the devnet miner/faucet/stacker defaults hit the table; `clarinet-cli` asserts every account in a generated `Devnet.toml` does. Plus coverage that a BIP39 passphrase bypasses the table, that a full memo still caches, and that neither cache swallows invalid-input errors.

`cargo tst` 1072/1072, clippy clean on native and `wasm32-unknown-unknown`, SDK suite 160 tests pass — those assert exact `stx_address` strings for the default wallets, which is the real confirmation the baked keys are right.




---

<sub>A second benchmark (`clarinet-files/benches/wallet_addresses.rs`) was dropped from this PR on review: its manifest-level numbers were useful while developing but duplicated `bip32.rs`, which carries every figure above. That also retires the two review threads on that file.</sub>
