### PR TITLE
chore: release 3.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+# [3.24.0](https://github.com/stx-labs/clarinet/compare/v3.23.2...v3.24.0) (2026-09-10)
+
+##### New Features
+
+* **simnet:**
+  *  Post-conditions in simnet (#2517) (1f102919)
+  *  Track account nonces in simnet (#2498) (e054f82c)
+* **clarity-vscode:**  
+  *  SDK debug adapter (#2483) (50ee217c)
+  *  Log LSP notification timings (#2532) (08f1a6c7)
+*  Add keyed events to event observer config (#2523) (4bb1877d)
+
+##### Bug Fixes
+
+* **devnet:**  
+  *  Deploy contracts and fund sBTC when booting from a snapshot (#2529) (0f65c856)
+  *  Epoch 4 snapshotting  (#2507) (f26cc288)
+  *  sBTC funding (#2513) (45340efd)
+  *  Update pox-5 Clarity contract (#2510) (30cdeb66)
+* **clarity-vscode:**
+  *  Load the browser LSP Wasm from extensionUri (#2522) (fb76bb55, 58f4c6da)
+  *  Package browser Wasm, stop emitting async chunks (#2520) (d357dba6)
+
+##### Refactors
+
+*  Better universal print macros (#2512) (60edfd44)
+
+##### Chores
+
+* **deps:**
+  *  Bump vscode-languageclient to 10.1.1 (#2533) (2277f9b2)
+  *  Drop node-fetch (#2524) (fe0a7d3f)
+  *  Remove a couple unused dependencies (#2526) (11e41e01)
+  *  Upgrade sdk dependencies (#2519) (70d91f5a)
+  *  Upgrade npm dependencies (#2521) (9a30e3d4)
+
+
 # [3.23.2](https://github.com/stx-labs/clarinet/compare/v3.23.1...v3.23.2) (2026-08-26)
 
 ##### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clarinet-cli"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "chrono",
  "clap",
@@ -688,14 +688,14 @@ dependencies = [
 
 [[package]]
 name = "clarinet-defaults"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "clarity",
 ]
 
 [[package]]
 name = "clarinet-deployments"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "base58",
  "base64 0.22.1",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-files"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "bitcoin",
  "clarinet-defaults",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "clarinet-sdk-wasm"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-events"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "clap",
  "clarinet-files",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-lsp"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "clarinet-defaults",
  "clarinet-deployments",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-repl"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "clarity-static-cost"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "clarity",
  "clarity-types",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "observer"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "axum",
  "base58",
@@ -4283,7 +4283,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-network"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "base58",
  "bitcoincore-rpc",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "stacks-rpc-client"
-version = "3.23.2"
+version = "3.24.0"
 dependencies = [
  "clarinet-utils",
  "clarity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-members = ["components/clarinet-cli"]
 opt-level = 3
 
 [workspace.package]
-version = "3.23.2"
+version = "3.24.0"
 
 # Keep dependencies sorted alphabetically
 [workspace.dependencies]

--- a/components/clarinet-sdk/browser/package.json
+++ b/components/clarinet-sdk/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk-browser",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in the browser",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarinet-sdk/node/package.json
+++ b/components/clarinet-sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stacks/clarinet-sdk",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "author": "Stacks Labs",
   "description": "A SDK to interact with Clarity Smart Contracts in node.js",
   "homepage": "https://stackslabs.com/clarinet",

--- a/components/clarity-vscode/package.json
+++ b/components/clarity-vscode/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/stx-labs/clarinet"
   },
   "license": "GPL-3.0-only",
-  "version": "3.23.2",
+  "version": "3.24.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .vscode-test-web ./debug/dist ./client/dist ./server/dist ./server/src/clarity-lsp-*",


### PR DESCRIPTION
### New Features

*  Post-conditions in simnet (#2517) (1f102919)
*  Add keyed events to event observer config (#2523) (4bb1877d)
*  Track account nonces in simnet (#2498) (e054f82c)
* **clarity-vscode:**  
  *  SDK debug adapter (#2483) (50ee217c)
  *  Log LSP notification timings (#2532) (08f1a6c7)

### Bug Fixes

* **devnet:**  
  *  Deploy contracts and fund sBTC when booting from a snapshot (#2529) (0f65c856)
  *  Epoch 4 snapshotting  (#2507) (f26cc288)
  *  sBTC funding (#2513) (45340efd)
  *  Update pox-5 (#2510) (30cdeb66)
* **clarity-vscode:**
  *  Load the browser LSP wasm from extensionUri (#2522) (fb76bb55, 58f4c6da)
  *  Package browser wasm, stop emitting async chunks (#2520) (d357dba6)

### Refactors

*  Better universal print macros (#2512) (60edfd44)

### Chores

* **deps:**
  *  Bump vscode-languageclient to 10.1.1 (#2533) (2277f9b2)
  *  Drop node-fetch (#2524) (fe0a7d3f)
  *  Remove a couple unused dependencies (#2526) (11e41e01)
  *  Upgrade sdk dependencies (#2519) (70d91f5a)
  *  Upgrade npm dependencies (#2521) (9a30e3d4)


