### PR TITLE
perf: credit genesis sBTC balances directly instead of replaying a deposit per wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,6 @@ dependencies = [
  "libsecp256k1",
  "mockito",
  "pretty_assertions",
- "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",

--- a/components/clarinet-deployments/Cargo.toml
+++ b/components/clarinet-deployments/Cargo.toml
@@ -10,7 +10,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 yaml_serde = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
-rand = { workspace = true }
 reqwest = { workspace = true }
 stacks-common = { workspace = true, default-features = false }
 

--- a/components/clarinet-deployments/src/lib.rs
+++ b/components/clarinet-deployments/src/lib.rs
@@ -16,14 +16,14 @@ use clarity::vm::ast::ContractAST;
 use clarity::vm::diagnostic::Diagnostic;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier};
 use clarity::vm::{
-    ClarityVersion, ContractName, EvaluationResult, ExecutionResult, SymbolicExpression, Value,
+    ClarityVersion, ContractName, EvaluationResult, ExecutionResult, SymbolicExpression,
 };
 use clarity_repl::analysis::ast_dependency_detector::{ASTDependencyDetector, DependencySet};
 use clarity_repl::repl::boot::{
     get_boot_contract_epoch_and_clarity_version, BOOT_CONTRACTS_DATA, SBTC_BOOT_CONTRACTS,
-    SBTC_DEPOSIT_MAINNET_ADDRESS, SBTC_MAINNET_ADDRESS, SBTC_TESTNET_ADDRESS_PRINCIPAL,
+    SBTC_MAINNET_ADDRESS, SBTC_TESTNET_ADDRESS_PRINCIPAL, SBTC_TOKEN_ASSET_IDENTIFIER,
+    SBTC_TOKEN_MAINNET_ADDRESS,
 };
-use clarity_repl::repl::clarity_values::value_to_string;
 use clarity_repl::repl::post_conditions::PostConditionCheck;
 use clarity_repl::repl::session::{AnnotatedExecutionResult, CallKind, ExecutionResultMap};
 use clarity_repl::repl::{
@@ -155,44 +155,18 @@ fn update_session_with_genesis_accounts(
     }
 }
 
-/// `sbtc-deposit` is deployed as an sBTC boot contract from the epoch sBTC
-/// activates at. It is missing from sessions that never reach that epoch, and
-/// from remote-data sessions, whose sBTC state comes from the network instead.
-/// A hand-authored plan can also publish it before the boot set is installed,
-/// which is what the second lookup covers.
-fn is_sbtc_deposit_deployed(session: &Session) -> bool {
+/// `sbtc-token` is a boot contract from the sBTC activation epoch onward, so it
+/// is absent below that epoch and in remote-data sessions. The second lookup
+/// covers a plan that publishes it at the sBTC address itself.
+fn is_sbtc_token_deployed(session: &Session) -> bool {
     session
         .boot_contracts
-        .contains_key(&SBTC_DEPOSIT_MAINNET_ADDRESS)
-        || session
-            .contracts
-            .contains_key(&SBTC_DEPOSIT_MAINNET_ADDRESS)
+        .contains_key(&SBTC_TOKEN_MAINNET_ADDRESS)
+        || session.contracts.contains_key(&SBTC_TOKEN_MAINNET_ADDRESS)
 }
 
-/// A random 32-byte buffer, standing in for the Bitcoin txid of a deposit.
-fn random_txid() -> SymbolicExpression {
-    let bytes: [u8; 32] = std::array::from_fn(|_| rand::random());
-    SymbolicExpression::atom_value(
-        Value::buff_from(bytes.to_vec()).expect("32 bytes is a valid buffer"),
-    )
-}
-
-/// The `(err ...)` a contract call returned, rendered as Clarity source, or
-/// `None` if the call committed.
-fn err_response(result: &ExecutionResult) -> Option<String> {
-    match &result.result {
-        EvaluationResult::Snippet(snippet) => match &snippet.result {
-            Value::Response(response) if !response.committed => {
-                Some(value_to_string(&snippet.result))
-            }
-            _ => None,
-        },
-        EvaluationResult::Contract(_) => None,
-    }
-}
-
-/// Mint the `sbtc_balance` configured for each genesis wallet, by calling
-/// `sbtc-deposit` the way the sBTC signers would.
+/// Credit the `sbtc_balance` configured for each genesis wallet, writing the
+/// balance and total supply straight into the datastore like genesis STX.
 fn fund_genesis_accounts_with_sbtc(session: &mut Session, deployment: &DeploymentSpecification) {
     let Some(spec) = deployment.genesis.as_ref() else {
         return;
@@ -207,63 +181,22 @@ fn fund_genesis_accounts_with_sbtc(session: &mut Session, deployment: &Deploymen
         return;
     }
 
-    if !is_sbtc_deposit_deployed(session) {
-        let (sbtc_epoch, _) = get_boot_contract_epoch_and_clarity_version("sbtc-deposit");
+    if !is_sbtc_token_deployed(session) {
+        let (sbtc_epoch, _) = get_boot_contract_epoch_and_clarity_version("sbtc-token");
         ueprint!(
             "Warning: unable to mint the configured sbtc_balance: {} is not deployed in this \
              session. The sBTC contracts require epoch {sbtc_epoch} or later.",
-            *SBTC_DEPOSIT_MAINNET_ADDRESS
+            *SBTC_TOKEN_MAINNET_ADDRESS
         );
         return;
     }
 
-    // The deposit is credited against the burn block below the current tip,
-    // whose header hash `complete-deposit-wrapper` checks for a Bitcoin fork.
-    let block_height = session.interpreter.get_burn_block_height() - 1;
-    let burn_hash = session.eval_clarity_string(&format!(
-        "(unwrap-panic (get-burn-block-info? header-hash u{block_height}))"
-    ));
-    let burn_height = SymbolicExpression::atom_value(Value::UInt(block_height.into()));
-    let vout_index = SymbolicExpression::atom_value(Value::UInt(1));
-    let deposit_contract = SBTC_DEPOSIT_MAINNET_ADDRESS.to_string();
-
     for wallet in funded_wallets {
-        let args = vec![
-            random_txid(),
-            vout_index.clone(),
-            SymbolicExpression::atom_value(Value::UInt(wallet.sbtc_balance)),
-            SymbolicExpression::atom_value(Value::Principal(wallet.address.clone().into())),
-            burn_hash.clone(),
-            burn_height.clone(),
-            random_txid(),
-        ];
-        // Session setup, not something the sbtc address sent: like the
-        // boot contracts, it stays at nonce 0.
-        let result = session.call_contract_fn(
-            &deposit_contract,
-            "complete-deposit-wrapper",
-            &args,
-            SBTC_MAINNET_ADDRESS,
-            false,
-            false,
-            CallKind::NonceFree,
-            PostConditionCheck::Unchecked,
-        );
-
-        // A silent failure here is indistinguishable from a mint that never
-        // ran, so report both the runtime errors and an `(err ...)` response.
-        let reasons: Vec<String> = match &result {
-            Ok(execution_result) => err_response(execution_result)
-                .map(|err| format!("complete-deposit-wrapper returned {err}"))
-                .into_iter()
-                .collect(),
-            Err(error) => error
-                .diagnostics
-                .iter()
-                .map(|diagnostic| diagnostic.message.clone())
-                .collect(),
-        };
-        for reason in reasons {
+        if let Err(reason) = session.interpreter.mint_ft_balance(
+            &SBTC_TOKEN_ASSET_IDENTIFIER,
+            &wallet.address.clone().into(),
+            wallet.sbtc_balance,
+        ) {
             ueprint!(
                 "Warning: unable to mint {} sBTC to {}: {reason}",
                 wallet.sbtc_balance,

--- a/components/clarinet-deployments/tests/genesis_accounts_funding.rs
+++ b/components/clarinet-deployments/tests/genesis_accounts_funding.rs
@@ -6,17 +6,14 @@ use clarinet_deployments::types::*;
 use clarinet_deployments::update_session_with_deployment_plan;
 use clarinet_files::StacksNetwork;
 use clarity::types::chainstate::StacksAddress;
-use clarity::types::Address;
+use clarity::types::{Address, StacksEpochId};
 use clarity::vm::types::StandardPrincipalData;
-use clarity::vm::{ClarityVersion, ContractName};
-use clarity_repl::repl::boot::SBTC_CONTRACTS_NAMES;
+use clarity::vm::{ClarityVersion, ContractName, Value};
+use clarity_repl::repl::boot::{
+    SBTC_CONTRACTS_NAMES, SBTC_MAINNET_ADDRESS_PRINCIPAL, SBTC_TOKEN_MAINNET_ADDRESS,
+};
 use clarity_repl::repl::{Session, SessionSettings};
 
-static SBTC_DEPLOYER: LazyLock<StandardPrincipalData> = LazyLock::new(|| {
-    StandardPrincipalData::from(
-        StacksAddress::from_string("SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4").unwrap(),
-    )
-});
 static WALLET_1: LazyLock<StandardPrincipalData> = LazyLock::new(|| {
     StandardPrincipalData::from(
         StacksAddress::from_string("ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5").unwrap(),
@@ -64,6 +61,15 @@ fn epoch_3_0_batch() -> TransactionsBatchSpecification {
     }
 }
 
+/// A session at epoch 3.0, funded from a one-wallet genesis spec.
+fn funded_session(sbtc_balance: u128) -> Session {
+    let mut session = Session::new(SessionSettings::default());
+    let genesis = genesis_with_sbtc_balance(sbtc_balance);
+    let deployment = build_test_deployement_plan(vec![epoch_3_0_batch()], Some(genesis));
+    update_session_with_deployment_plan(&mut session, &deployment, None);
+    session
+}
+
 #[test]
 fn fund_genesis_account_with_stx() {
     let mut session = Session::new(SessionSettings::default());
@@ -101,10 +107,7 @@ fn does_not_fund_sbtc_before_epoch_3_0() {
 /// A wallet with `sbtc_balance = 0` must not show up in the sBTC asset map.
 #[test]
 fn does_not_fund_sbtc_when_the_balance_is_zero() {
-    let mut session = Session::new(SessionSettings::default());
-    let genesis = genesis_with_sbtc_balance(0);
-    let deployment = build_test_deployement_plan(vec![epoch_3_0_batch()], Some(genesis));
-    update_session_with_deployment_plan(&mut session, &deployment, None);
+    let session = funded_session(0);
 
     let assets_maps = session.get_assets_maps();
     assert!(assets_maps.len() == 1);
@@ -113,14 +116,10 @@ fn does_not_fund_sbtc_when_the_balance_is_zero() {
 
 /// The property that matters: a plan carrying *no* sBTC transaction — what a
 /// stock `clarinet new` project generates — still funds the genesis wallets,
-/// because `sbtc-deposit` is a boot contract.
+/// because `sbtc-token` is a boot contract.
 #[test]
 fn can_fund_initial_sbtc_balance_without_any_sbtc_transaction() {
-    let mut session = Session::new(SessionSettings::default());
-
-    let genesis = genesis_with_sbtc_balance(10_000_000_000);
-    let deployment = build_test_deployement_plan(vec![epoch_3_0_batch()], Some(genesis));
-    update_session_with_deployment_plan(&mut session, &deployment, None);
+    let session = funded_session(10_000_000_000);
 
     let assets_maps = session.get_assets_maps();
     assert!(assets_maps.len() == 2);
@@ -148,7 +147,7 @@ fn can_fund_initial_sbtc_balance_with_explicit_sbtc_requirements() {
                     source: "(define-read-only (unused) u1)".to_string(),
                     clarity_version: ClarityVersion::Clarity3,
                     location: PathBuf::from(format!("./requirements/{contract_name}.clar")),
-                    emulated_sender: SBTC_DEPLOYER.clone(),
+                    emulated_sender: SBTC_MAINNET_ADDRESS_PRINCIPAL.clone(),
                     skip_analysis: true,
                 },
             )
@@ -170,4 +169,39 @@ fn can_fund_initial_sbtc_balance_with_explicit_sbtc_requirements() {
         .get(".sbtc-token.sbtc-token")
         .expect("sBTC should be minted");
     assert_eq!(sbtcs.get(&WALLET_1.to_string()), Some(&10_000_000_000));
+}
+
+/// The balance is written to the datastore, so it has to be visible to Clarity
+/// itself and not just to the session's asset map.
+#[test]
+fn can_read_the_funded_sbtc_balance_and_supply_from_clarity() {
+    let mut session = funded_session(10_000_000_000);
+
+    let token = format!("'{}", *SBTC_TOKEN_MAINNET_ADDRESS);
+    let balance = session.eval_clarity_string(&format!(
+        "(contract-call? {token} get-balance '{})",
+        *WALLET_1
+    ));
+    let supply = session.eval_clarity_string(&format!("(contract-call? {token} get-total-supply)"));
+
+    let expected = Value::okay(Value::UInt(10_000_000_000)).unwrap();
+    assert_eq!(balance.match_atom_value(), Some(&expected));
+    assert_eq!(supply.match_atom_value(), Some(&expected));
+}
+
+/// Funding writes through the Clarity database, which owns the epoch key the
+/// session also tracks. Minting must not leave the two disagreeing.
+#[test]
+fn funding_sbtc_leaves_the_session_epoch_alone() {
+    use clarity::vm::database::ClarityBackingStore;
+
+    let mut session = funded_session(10_000_000_000);
+    let epoch = session.interpreter.datastore.get_current_epoch();
+    let clarity_db_epoch = session
+        .interpreter
+        .clarity_datastore
+        .get_data("vm-epoch::epoch-version");
+
+    assert_eq!(epoch, StacksEpochId::Epoch30);
+    assert_eq!(clarity_db_epoch, Ok(Some(format!("{:08x}", epoch as u32))));
 }

--- a/components/clarinet-deployments/tests/genesis_accounts_funding.rs
+++ b/components/clarinet-deployments/tests/genesis_accounts_funding.rs
@@ -189,10 +189,10 @@ fn can_read_the_funded_sbtc_balance_and_supply_from_clarity() {
     assert_eq!(supply.match_atom_value(), Some(&expected));
 }
 
-/// Funding writes through the Clarity database, which owns the epoch key the
-/// session also tracks. Minting must not leave the two disagreeing.
+/// sBTC funding is the last thing the plan does, so the epoch it ran at is
+/// still recorded when it returns. It has to be the session's own epoch.
 #[test]
-fn funding_sbtc_leaves_the_session_epoch_alone() {
+fn funding_sbtc_runs_at_the_session_epoch() {
     use clarity::vm::database::ClarityBackingStore;
 
     let mut session = funded_session(10_000_000_000);

--- a/components/clarinet-deployments/tests/genesis_accounts_funding.rs
+++ b/components/clarinet-deployments/tests/genesis_accounts_funding.rs
@@ -189,6 +189,29 @@ fn can_read_the_funded_sbtc_balance_and_supply_from_clarity() {
     assert_eq!(supply.match_atom_value(), Some(&expected));
 }
 
+/// A deliberate difference from devnet, which still submits a real deposit and
+/// so still rejects anything under the 546 sat Bitcoin dust limit. On simnet a
+/// balance is just a starting balance, so it is credited as configured.
+#[test]
+fn funds_an_sbtc_balance_below_the_bitcoin_dust_limit() {
+    let mut session = funded_session(500);
+
+    let sbtcs = session.get_assets_maps();
+    let sbtcs = sbtcs
+        .get(".sbtc-token.sbtc-token")
+        .expect("sBTC should be minted");
+    assert_eq!(sbtcs.get(&WALLET_1.to_string()), Some(&500));
+
+    let supply = session.eval_clarity_string(&format!(
+        "(contract-call? '{} get-total-supply)",
+        *SBTC_TOKEN_MAINNET_ADDRESS
+    ));
+    assert_eq!(
+        supply.match_atom_value(),
+        Some(&Value::okay(Value::UInt(500)).unwrap())
+    );
+}
+
 /// sBTC funding is the last thing the plan does, so the epoch it ran at is
 /// still recorded when it returns. It has to be the session's own epoch.
 #[test]

--- a/components/clarinet-sdk-wasm/src/core.rs
+++ b/components/clarinet-sdk-wasm/src/core.rs
@@ -1358,7 +1358,7 @@ impl SDK {
             &PrincipalData::Standard(StandardPrincipalData::from(
                 StacksAddress::from_string(&recipient).unwrap(),
             )),
-            amount,
+            amount.into(),
         )
     }
 

--- a/components/clarity-repl/src/repl/boot/mod.rs
+++ b/components/clarity-repl/src/repl/boot/mod.rs
@@ -42,7 +42,7 @@ const BOOT_CODE_SIGNERS_VOTING: &str = std::include_str!("signers-voting.clar");
 /// (from SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4).
 /// Deployed as boot dependencies so pox-5 can resolve its `contract-call?`
 /// and `with-ft` references to sbtc-token, and so genesis `sbtc_balance`
-/// can be minted through sbtc-deposit.
+/// can be credited to sbtc-token.
 const SBTC_REGISTRY_SOURCE: &str = std::include_str!("sbtc-registry.clar");
 const SBTC_TOKEN_SOURCE: &str = std::include_str!("sbtc-token.clar");
 const SBTC_DEPOSIT_SOURCE: &str = std::include_str!("sbtc-deposit.clar");
@@ -59,14 +59,16 @@ pub static SBTC_TESTNET_ADDRESS_PRINCIPAL: LazyLock<StandardPrincipalData> =
 pub static SBTC_MAINNET_ADDRESS_PRINCIPAL: LazyLock<StandardPrincipalData> =
     LazyLock::new(|| PrincipalData::parse_standard_principal(SBTC_MAINNET_ADDRESS).unwrap());
 
-pub static SBTC_DEPOSIT_MAINNET_ADDRESS: LazyLock<QualifiedContractIdentifier> =
-    LazyLock::new(|| {
-        QualifiedContractIdentifier::parse(&format!("{SBTC_MAINNET_ADDRESS}.sbtc-deposit")).unwrap()
-    });
-
 pub static SBTC_TOKEN_MAINNET_ADDRESS: LazyLock<QualifiedContractIdentifier> =
     LazyLock::new(|| {
         QualifiedContractIdentifier::parse(&format!("{SBTC_MAINNET_ADDRESS}.sbtc-token")).unwrap()
+    });
+
+/// The `sbtc-token` fungible token defined by [`SBTC_TOKEN_MAINNET_ADDRESS`].
+pub static SBTC_TOKEN_ASSET_IDENTIFIER: LazyLock<AssetIdentifier> =
+    LazyLock::new(|| AssetIdentifier {
+        contract_identifier: SBTC_TOKEN_MAINNET_ADDRESS.clone(),
+        asset_name: ClarityName::try_from("sbtc-token").unwrap(),
     });
 
 use std::collections::BTreeMap;
@@ -74,8 +76,10 @@ use std::sync::LazyLock;
 
 use clarity::types::StacksEpochId;
 use clarity::vm::ast::ContractAST;
-use clarity::vm::ClarityVersion;
-use clarity_types::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
+use clarity::vm::{ClarityName, ClarityVersion};
+use clarity_types::types::{
+    AssetIdentifier, PrincipalData, QualifiedContractIdentifier, StandardPrincipalData,
+};
 
 use crate::repl::{
     ClarityCodeSource, ClarityContract, ClarityInterpreter, ContractDeployer, Epoch, Settings,
@@ -267,7 +271,7 @@ pub fn get_boot_contracts_data_with_overrides(
 /// Pre-parsed sBTC contracts deployed at the mainnet sBTC address (SM3VDXK3...).
 /// - sbtc-registry deployed first (required by sbtc-token and sbtc-deposit)
 /// - sbtc-token next before the regular boot contracts (required by pox-5)
-/// - sbtc-deposit last (calls into both, and mints the genesis sBTC balances)
+/// - sbtc-deposit last (calls into both)
 ///
 /// The Vec preserves that deployment order.
 pub static SBTC_BOOT_CONTRACTS: LazyLock<

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -1644,6 +1644,59 @@ mod tests {
         )
     }
 
+    /// `mint_ft_balance` takes the full `u128` range, so a second mint can
+    /// exceed what the balance can hold. It must fail without writing.
+    #[test]
+    fn minting_ft_past_u128_leaves_the_balance_untouched() {
+        let mut interpreter = get_interpreter(None);
+        let recipient = PrincipalData::Standard(StandardPrincipalData::transient());
+        let token_name = "ctb";
+
+        let contract = ClarityContractBuilder::default()
+            .code_source(format!("(define-fungible-token {token_name})"))
+            .build();
+        deploy_contract(&mut interpreter, &contract).expect("the fixture deploys");
+        let asset_identifier = AssetIdentifier {
+            contract_identifier: contract
+                .expect_resolved_contract_identifier(Some(&interpreter.get_tx_sender())),
+            asset_name: ClarityName::try_from(token_name).unwrap(),
+        };
+
+        interpreter
+            .mint_ft_balance(&asset_identifier, &recipient, u128::MAX)
+            .expect("the first mint fits");
+
+        let error = interpreter
+            .mint_ft_balance(&asset_identifier, &recipient, 1)
+            .expect_err("the second mint overflows");
+        assert!(error.contains("balance overflow"), "{error}");
+
+        // Neither the datastore nor the tracked asset map moved.
+        assert_eq!(
+            interpreter
+                .get_balance_for_account(&recipient.to_string(), &asset_identifier.sugared()),
+            u128::MAX
+        );
+        let mut global_context = interpreter
+            .get_global_context(DEFAULT_EPOCH, false)
+            .unwrap();
+        global_context.begin();
+        let metadata = global_context
+            .database
+            .load_ft(&asset_identifier.contract_identifier, token_name)
+            .unwrap();
+        let balance = global_context
+            .database
+            .get_ft_balance(
+                &asset_identifier.contract_identifier,
+                token_name,
+                &recipient,
+                Some(&metadata),
+            )
+            .unwrap();
+        assert_eq!(balance, u128::MAX);
+    }
+
     /// `credit` consolidates locked STX against the v2/v3/v4 unlock heights,
     /// and those are gated on the epoch the mint runs at. Pinning a fixed
     /// epoch would apply the wrong unlock rules to a session below it.

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -2,7 +2,6 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
-use clarinet_defaults::DEFAULT_EPOCH;
 use clarity::consts::{CHAIN_ID_MAINNET, CHAIN_ID_TESTNET};
 use clarity::types::StacksEpochId;
 use clarity::vm::analysis::errors::RuntimeCheckErrorKind;
@@ -1375,7 +1374,8 @@ impl ClarityInterpreter {
         amount: u64,
     ) -> Result<String, String> {
         let final_balance = {
-            let mut global_context = self.get_global_context(DEFAULT_EPOCH, false)?;
+            let epoch = self.datastore.get_current_epoch();
+            let mut global_context = self.get_global_context(epoch, false)?;
 
             global_context.begin();
             let mut cur_balance = global_context
@@ -1622,6 +1622,7 @@ impl ClarityInterpreter {
 
 #[cfg(test)]
 mod tests {
+    use clarinet_defaults::DEFAULT_EPOCH;
     use clarity::types::chainstate::StacksAddress;
     use clarity::types::Address;
     use clarity::util::hash::hex_bytes;
@@ -1641,6 +1642,31 @@ mod tests {
             settings.unwrap_or_default(),
             None,
         )
+    }
+
+    /// `credit` consolidates locked STX against the v2/v3/v4 unlock heights,
+    /// and those are gated on the epoch the mint runs at. Pinning a fixed
+    /// epoch would apply the wrong unlock rules to a session below it.
+    #[test]
+    fn minting_stx_runs_at_the_session_epoch() {
+        use clarity::vm::database::ClarityBackingStore;
+
+        let mut interpreter = get_interpreter(None);
+        let epoch = StacksEpochId::Epoch25;
+        assert_ne!(epoch, DEFAULT_EPOCH, "epoch must differ to be meaningful");
+        interpreter
+            .datastore
+            .set_current_epoch(&mut interpreter.clarity_datastore, epoch);
+
+        let recipient = PrincipalData::Standard(StandardPrincipalData::transient());
+        interpreter.mint_stx_balance(recipient, 1_000).unwrap();
+
+        assert_eq!(
+            interpreter
+                .clarity_datastore
+                .get_data("vm-epoch::epoch-version"),
+            Ok(Some(format!("{:08x}", epoch as u32)))
+        );
     }
 
     #[test]

--- a/components/clarity-repl/src/repl/interpreter.rs
+++ b/components/clarity-repl/src/repl/interpreter.rs
@@ -1404,47 +1404,42 @@ impl ClarityInterpreter {
         &mut self,
         asset_identifier: &AssetIdentifier,
         recipient: &PrincipalData,
-        amount: u64,
+        amount: u128,
     ) -> Result<String, String> {
-        let contract_identifier = asset_identifier.contract_identifier.clone();
-        let token_name = asset_identifier.asset_name.to_string();
+        let contract_identifier = &asset_identifier.contract_identifier;
+        let token_name: &str = &asset_identifier.asset_name;
         let final_balance = {
-            let mut global_context = self.get_global_context(DEFAULT_EPOCH, false)?;
+            let epoch = self.datastore.get_current_epoch();
+            let mut global_context = self.get_global_context(epoch, false)?;
 
             global_context.begin();
 
             let metadata = global_context
                 .database
-                .load_ft(&contract_identifier, &token_name)
+                .load_ft(contract_identifier, token_name)
                 .map_err(|e| {
                     format!("failed to load_ft for {contract_identifier}.{token_name}: {e:?}")
                 })?;
 
             let cur_balance = global_context
                 .database
-                .get_ft_balance(&contract_identifier, &token_name, recipient, Some(&metadata))
+                .get_ft_balance(contract_identifier, token_name, recipient, Some(&metadata))
                 .map_err(|e| format!("failed to get_ft_balance for {contract_identifier}.{token_name} {recipient}: {e:?}"))?;
+
+            let final_balance = cur_balance.checked_add(amount).ok_or_else(|| {
+                format!("balance overflow for {contract_identifier}.{token_name} {recipient}")
+            })?;
 
             global_context.database.set_ft_balance(
-                &contract_identifier,
-                &token_name,
+                contract_identifier,
+                token_name,
                 recipient,
-                cur_balance + amount as u128,
+                final_balance,
             ).map_err(|e| format!("failed to set_ft_balance for {contract_identifier}.{token_name} {recipient}: {e:?}"))?;
-
-            let final_balance = global_context
-                .database
-                .get_ft_balance(&contract_identifier, &token_name, recipient, Some(&metadata))
-                .map_err(|e| format!("failed to get_ft_balance for {contract_identifier}.{token_name} {recipient}: {e:?}"))?;
 
             global_context
                 .database
-                .checked_increase_token_supply(
-                    &contract_identifier,
-                    &token_name,
-                    amount as u128,
-                    &metadata,
-                )
+                .checked_increase_token_supply(contract_identifier, token_name, amount, &metadata)
                 .map_err(|e| format!("failed to increase token supply for {contract_identifier}.{token_name}: {e:?}"))?;
 
             global_context
@@ -1452,11 +1447,7 @@ impl ClarityInterpreter {
                 .map_err(|e| format!("failed to commit ctx: {e:?}"))?;
             final_balance
         };
-        self.credit_token(
-            recipient.to_string(),
-            asset_identifier.sugared(),
-            amount.into(),
-        );
+        self.credit_token(recipient.to_string(), asset_identifier.sugared(), amount);
         Ok(format!("→ {recipient}: {final_balance} {token_name}"))
     }
 

--- a/components/clarity-repl/src/repl/session.rs
+++ b/components/clarity-repl/src/repl/session.rs
@@ -1588,7 +1588,7 @@ impl Session {
             return "Unable to parse the recipient address".red().to_string();
         };
 
-        let Ok(amount) = args[3].parse::<u64>() else {
+        let Ok(amount) = args[3].parse::<u128>() else {
             return "Unable to parse the amount".red().to_string();
         };
 


### PR DESCRIPTION
Genesis `sbtc_balance` was minted by calling `sbtc-deposit.complete-deposit-wrapper` once per wallet, on every simnet session start and every LSP rebuild. That cost ~0.75 ms per wallet (7.7 ms for a default 10-wallet project), and it is on by default even for projects that never touch sBTC.

Credit the balance with `mint_ft_balance` instead, the same direct datastore write genesis STX already uses. It moves the total supply too, so `get-balance` and `get-total-supply` are unchanged. The only state no longer written is the registry deposit record, keyed by a txid that was random per session and so unreachable. Funding 10 wallets is now indistinguishable from funding none.


### Epoch fix

Both `mint_ft_balance` and `mint_stx_balance` forced `DEFAULT_EPOCH` instead of running at the session's epoch. This matters for STX: `credit` consolidates locked balances against the v2/v3/v4 unlock heights, and those are epoch-gated, so a mint into an account with locked STX could release tokens that should still be locked. Both now use the session epoch, covered by `minting_stx_runs_at_the_session_epoch`.

Also here: the balance addition is `checked_add`, and `amount` widened to `u128` so `sbtc_balance` needs no narrowing.
