### PR TITLE
refactor: give the shipped mnemonics a single home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "clarinet-deployments",
  "clarinet-files",
  "clarinet-format",
+ "clarinet-utils",
  "clarity",
  "clarity-repl",
  "clarity-static-cost",

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -570,6 +570,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use clarinet_files::{compute_addresses, StacksNetwork};
+    use clarinet_utils::DEFAULT_DEVNET_ACCOUNTS;
 
     use super::*;
 
@@ -584,34 +585,10 @@ mod tests {
         derivation: Option<String>,
     }
 
-    /// Accounts the template is expected to emit, and the constant each one
-    /// interpolates.
-    const EXPECTED_ACCOUNTS: [(&str, &str); 10] = [
-        ("deployer", DEFAULT_DEPLOYER_MNEMONIC),
-        ("wallet_1", DEFAULT_WALLET_1_MNEMONIC),
-        ("wallet_2", DEFAULT_WALLET_2_MNEMONIC),
-        ("wallet_3", DEFAULT_WALLET_3_MNEMONIC),
-        ("wallet_4", DEFAULT_WALLET_4_MNEMONIC),
-        ("wallet_5", DEFAULT_WALLET_5_MNEMONIC),
-        ("wallet_6", DEFAULT_WALLET_6_MNEMONIC),
-        ("wallet_7", DEFAULT_WALLET_7_MNEMONIC),
-        ("wallet_8", DEFAULT_WALLET_8_MNEMONIC),
-        ("faucet", DEFAULT_FAUCET_MNEMONIC),
-    ];
-
-    /// The generated wallets interpolate `clarinet-utils` constants, and
-    /// `clarinet-utils` asserts every one of those has precomputed keys — so
-    /// content cannot drift. What this guards is the *set*: a wallet added with
-    /// a fresh literal phrase, or a custom derivation path, would quietly miss
-    /// the table and cost a ~1.4 ms PBKDF2 derivation per session.
-    #[test]
-    fn generated_wallets_use_the_shared_mnemonics() {
-        let changes =
-            GetChangesForNewProject::new("/tmp".into(), "drift-guard".into(), false, false)
-                .run()
-                .expect("project generation failed");
-
-        let devnet_toml = changes
+    fn generated_devnet_toml() -> String {
+        GetChangesForNewProject::new("/tmp".into(), "drift-guard".into(), false, false)
+            .run()
+            .expect("project generation failed")
             .into_iter()
             .find_map(|change| match change {
                 Changes::AddFile(file) if file.path.ends_with("settings/Devnet.toml") => {
@@ -619,12 +596,23 @@ mod tests {
                 }
                 _ => None,
             })
-            .expect("generated project has no settings/Devnet.toml");
+            .expect("generated project has no settings/Devnet.toml")
+    }
 
+    /// The template interpolates `clarinet-utils` constants, so a phrase cannot
+    /// drift. What this guards is the *set* of accounts: comparing against
+    /// `DEFAULT_DEVNET_ACCOUNTS` rather than a local copy means an account
+    /// added with an off-table phrase cannot be satisfied by editing this test
+    /// — it has to join the shared list, where `clarinet-utils` asserts it has
+    /// precomputed keys. Otherwise it would silently cost a PBKDF2 derivation
+    /// per session, on every LSP file save.
+    #[test]
+    fn generated_wallets_use_the_shared_mnemonics() {
+        let devnet_toml = generated_devnet_toml();
         let generated: GeneratedDevnet =
             toml::from_str(&devnet_toml).expect("generated Devnet.toml is not valid");
 
-        let expected: BTreeMap<&str, &str> = EXPECTED_ACCOUNTS.into_iter().collect();
+        let expected: BTreeMap<&str, &str> = DEFAULT_DEVNET_ACCOUNTS.into_iter().collect();
         let actual: BTreeMap<&str, &str> = generated
             .accounts
             .iter()
@@ -633,45 +621,74 @@ mod tests {
         assert_eq!(actual, expected);
 
         for (label, account) in &generated.accounts {
-            let derivation = account.derivation.as_deref();
             assert!(
-                derivation.is_none() || derivation == Some(DEFAULT_DERIVATION_PATH),
+                matches!(
+                    account.derivation.as_deref(),
+                    None | Some(DEFAULT_DERIVATION_PATH)
+                ),
                 "account {label} overrides the derivation path, which misses the \
                  precomputed table"
             );
         }
-
-        verify_documented_addresses(&devnet_toml);
     }
 
     /// Each account block documents its derived key and addresses in comments
-    /// that developers copy into tests. The mnemonics now live in
-    /// `clarinet-utils`, so nothing else would notice if one were rotated and
-    /// these literals left behind.
-    fn verify_documented_addresses(devnet_toml: &str) {
+    /// that developers copy into tests. The mnemonics live in `clarinet-utils`
+    /// now, so nothing else would notice if one were rotated and these literals
+    /// left behind.
+    ///
+    /// The comments are stripped by TOML parsing, so this scans the raw text —
+    /// but it takes the mnemonic from the parsed document rather than
+    /// re-extracting it, so a template quoting change cannot silently turn this
+    /// into a no-op.
+    #[test]
+    fn generated_devnet_documents_correct_addresses() {
+        let devnet_toml = generated_devnet_toml();
+        let generated: GeneratedDevnet =
+            toml::from_str(&devnet_toml).expect("generated Devnet.toml is not valid");
         let networks = StacksNetwork::Devnet.get_networks();
-        let mut checked = 0;
 
+        let mut checked = BTreeMap::new();
         for block in devnet_toml.split("[accounts.").skip(1) {
-            let field = |prefix: &str| {
+            let label = block
+                .lines()
+                .next()
+                .and_then(|l| l.split(']').next())
+                .expect("account block has no label");
+            let mnemonic = &generated
+                .accounts
+                .get(label)
+                .unwrap_or_else(|| panic!("block {label} is not in the parsed document"))
+                .mnemonic;
+
+            let documented = |prefix: &str| {
                 block
                     .lines()
                     .find_map(|line| line.trim().strip_prefix(prefix))
                     .map(str::trim)
-                    .unwrap_or_else(|| panic!("account block is missing {prefix}"))
+                    .unwrap_or_else(|| panic!("account {label} is missing {prefix}"))
             };
-            let label = block.lines().next().unwrap().trim_end_matches(']');
-            let mnemonic = field("mnemonic = ").trim_matches('"');
-
             let (stx_address, btc_address, secret_key) =
                 compute_addresses(mnemonic, DEFAULT_DERIVATION_PATH, &networks);
 
-            assert_eq!(field("# secret_key: "), secret_key, "{label} secret_key");
-            assert_eq!(field("# stx_address: "), stx_address, "{label} stx_address");
-            assert_eq!(field("# btc_address: "), btc_address, "{label} btc_address");
-            checked += 1;
+            assert_eq!(
+                documented("# secret_key: "),
+                secret_key,
+                "{label} secret_key"
+            );
+            assert_eq!(
+                documented("# stx_address: "),
+                stx_address,
+                "{label} stx_address"
+            );
+            assert_eq!(
+                documented("# btc_address: "),
+                btc_address,
+                "{label} btc_address"
+            );
+            checked.insert(label, ());
         }
 
-        assert_eq!(checked, EXPECTED_ACCOUNTS.len());
+        assert_eq!(checked.len(), generated.accounts.len());
     }
 }

--- a/components/clarinet-cli/src/generate/project.rs
+++ b/components/clarinet-cli/src/generate/project.rs
@@ -1,11 +1,16 @@
 use clarinet_files::{
-    DEFAULT_BITCOIN_EXPLORER_IMAGE, DEFAULT_BITCOIN_NODE_IMAGE, DEFAULT_DERIVATION_PATH,
-    DEFAULT_EPOCH_2_0, DEFAULT_EPOCH_2_05, DEFAULT_EPOCH_2_1, DEFAULT_EPOCH_2_2, DEFAULT_EPOCH_2_3,
-    DEFAULT_EPOCH_2_4, DEFAULT_EPOCH_2_5, DEFAULT_EPOCH_3_0, DEFAULT_EPOCH_3_1, DEFAULT_EPOCH_3_2,
-    DEFAULT_EPOCH_3_3, DEFAULT_EPOCH_3_4, DEFAULT_EPOCH_4_0, DEFAULT_FAUCET_MNEMONIC,
-    DEFAULT_POSTGRES_IMAGE, DEFAULT_STACKER_MNEMONIC, DEFAULT_STACKS_API_IMAGE,
-    DEFAULT_STACKS_EXPLORER_IMAGE, DEFAULT_STACKS_MINER_MNEMONIC, DEFAULT_STACKS_NODE_IMAGE,
-    DEFAULT_STACKS_SIGNER_IMAGE,
+    DEFAULT_BITCOIN_EXPLORER_IMAGE, DEFAULT_BITCOIN_NODE_IMAGE, DEFAULT_EPOCH_2_0,
+    DEFAULT_EPOCH_2_05, DEFAULT_EPOCH_2_1, DEFAULT_EPOCH_2_2, DEFAULT_EPOCH_2_3, DEFAULT_EPOCH_2_4,
+    DEFAULT_EPOCH_2_5, DEFAULT_EPOCH_3_0, DEFAULT_EPOCH_3_1, DEFAULT_EPOCH_3_2, DEFAULT_EPOCH_3_3,
+    DEFAULT_EPOCH_3_4, DEFAULT_EPOCH_4_0, DEFAULT_POSTGRES_IMAGE, DEFAULT_STACKS_API_IMAGE,
+    DEFAULT_STACKS_EXPLORER_IMAGE, DEFAULT_STACKS_NODE_IMAGE, DEFAULT_STACKS_SIGNER_IMAGE,
+};
+use clarinet_utils::{
+    DEFAULT_DEPLOYER_MNEMONIC, DEFAULT_DERIVATION_PATH, DEFAULT_FAUCET_MNEMONIC,
+    DEFAULT_STACKER_MNEMONIC, DEFAULT_STACKS_MINER_MNEMONIC, DEFAULT_WALLET_1_MNEMONIC,
+    DEFAULT_WALLET_2_MNEMONIC, DEFAULT_WALLET_3_MNEMONIC, DEFAULT_WALLET_4_MNEMONIC,
+    DEFAULT_WALLET_5_MNEMONIC, DEFAULT_WALLET_6_MNEMONIC, DEFAULT_WALLET_7_MNEMONIC,
+    DEFAULT_WALLET_8_MNEMONIC,
 };
 use indoc::{formatdoc, indoc};
 
@@ -254,7 +259,7 @@ impl GetChangesForNewProject {
             deployment_fee_rate = 10
 
             [accounts.deployer]
-            mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+            mnemonic = "{DEFAULT_DEPLOYER_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
@@ -262,7 +267,7 @@ impl GetChangesForNewProject {
             # btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
 
             [accounts.wallet_1]
-            mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+            mnemonic = "{DEFAULT_WALLET_1_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
@@ -270,7 +275,7 @@ impl GetChangesForNewProject {
             # btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
 
             [accounts.wallet_2]
-            mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+            mnemonic = "{DEFAULT_WALLET_2_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
@@ -278,7 +283,7 @@ impl GetChangesForNewProject {
             # btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
 
             [accounts.wallet_3]
-            mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+            mnemonic = "{DEFAULT_WALLET_3_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
@@ -286,7 +291,7 @@ impl GetChangesForNewProject {
             # btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
 
             [accounts.wallet_4]
-            mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+            mnemonic = "{DEFAULT_WALLET_4_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
@@ -294,7 +299,7 @@ impl GetChangesForNewProject {
             # btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
 
             [accounts.wallet_5]
-            mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+            mnemonic = "{DEFAULT_WALLET_5_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
@@ -302,7 +307,7 @@ impl GetChangesForNewProject {
             # btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
 
             [accounts.wallet_6]
-            mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+            mnemonic = "{DEFAULT_WALLET_6_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
@@ -310,7 +315,7 @@ impl GetChangesForNewProject {
             # btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
 
             [accounts.wallet_7]
-            mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+            mnemonic = "{DEFAULT_WALLET_7_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
@@ -318,7 +323,7 @@ impl GetChangesForNewProject {
             # btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
 
             [accounts.wallet_8]
-            mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+            mnemonic = "{DEFAULT_WALLET_8_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
@@ -326,7 +331,7 @@ impl GetChangesForNewProject {
             # btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
 
             [accounts.faucet]
-            mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+            mnemonic = "{DEFAULT_FAUCET_MNEMONIC}"
             balance = 100_000_000_000_000
             sbtc_balance = 1_000_000_000
             # secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
@@ -562,17 +567,51 @@ impl GetChangesForNewProject {
 
 #[cfg(test)]
 mod tests {
-    use clarinet_files::DEFAULT_DERIVATION_PATH;
+    use std::collections::BTreeMap;
+
+    use clarinet_files::{compute_addresses, StacksNetwork};
 
     use super::*;
 
-    fn generated_devnet_toml() -> String {
+    #[derive(serde::Deserialize)]
+    struct GeneratedDevnet {
+        accounts: BTreeMap<String, GeneratedAccount>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct GeneratedAccount {
+        mnemonic: String,
+        derivation: Option<String>,
+    }
+
+    /// Accounts the template is expected to emit, and the constant each one
+    /// interpolates.
+    const EXPECTED_ACCOUNTS: [(&str, &str); 10] = [
+        ("deployer", DEFAULT_DEPLOYER_MNEMONIC),
+        ("wallet_1", DEFAULT_WALLET_1_MNEMONIC),
+        ("wallet_2", DEFAULT_WALLET_2_MNEMONIC),
+        ("wallet_3", DEFAULT_WALLET_3_MNEMONIC),
+        ("wallet_4", DEFAULT_WALLET_4_MNEMONIC),
+        ("wallet_5", DEFAULT_WALLET_5_MNEMONIC),
+        ("wallet_6", DEFAULT_WALLET_6_MNEMONIC),
+        ("wallet_7", DEFAULT_WALLET_7_MNEMONIC),
+        ("wallet_8", DEFAULT_WALLET_8_MNEMONIC),
+        ("faucet", DEFAULT_FAUCET_MNEMONIC),
+    ];
+
+    /// The generated wallets interpolate `clarinet-utils` constants, and
+    /// `clarinet-utils` asserts every one of those has precomputed keys — so
+    /// content cannot drift. What this guards is the *set*: a wallet added with
+    /// a fresh literal phrase, or a custom derivation path, would quietly miss
+    /// the table and cost a ~1.4 ms PBKDF2 derivation per session.
+    #[test]
+    fn generated_wallets_use_the_shared_mnemonics() {
         let changes =
-            GetChangesForNewProject::new("/tmp".into(), "bench-guard".into(), false, false)
+            GetChangesForNewProject::new("/tmp".into(), "drift-guard".into(), false, false)
                 .run()
                 .expect("project generation failed");
 
-        changes
+        let devnet_toml = changes
             .into_iter()
             .find_map(|change| match change {
                 Changes::AddFile(file) if file.path.ends_with("settings/Devnet.toml") => {
@@ -580,40 +619,59 @@ mod tests {
                 }
                 _ => None,
             })
-            .expect("generated project has no settings/Devnet.toml")
-    }
+            .expect("generated project has no settings/Devnet.toml");
 
-    /// A default project derives 10 wallets on every session start, and the
-    /// LSP re-derives them on every file save. `clarinet-utils` bakes their
-    /// keys in so the PBKDF2 rounds are skipped — but only for these exact
-    /// phrases. Editing the template below without updating that table would
-    /// quietly hand ~10 ms back to every session.
-    #[test]
-    fn generated_wallets_are_precomputed() {
-        let manifest: toml::Value =
-            toml::from_str(&generated_devnet_toml()).expect("generated Devnet.toml is not valid");
+        let generated: GeneratedDevnet =
+            toml::from_str(&devnet_toml).expect("generated Devnet.toml is not valid");
 
-        let Some(toml::Value::Table(accounts)) = manifest.get("accounts") else {
-            panic!("generated Devnet.toml has no [accounts] table");
-        };
-        assert_eq!(accounts.len(), 10, "unexpected number of default accounts");
+        let expected: BTreeMap<&str, &str> = EXPECTED_ACCOUNTS.into_iter().collect();
+        let actual: BTreeMap<&str, &str> = generated
+            .accounts
+            .iter()
+            .map(|(label, account)| (label.as_str(), account.mnemonic.as_str()))
+            .collect();
+        assert_eq!(actual, expected);
 
-        for (label, settings) in accounts {
-            let toml::Value::Table(settings) = settings else {
-                panic!("[accounts.{label}] is not a table");
-            };
-            let Some(toml::Value::String(mnemonic)) = settings.get("mnemonic") else {
-                panic!("[accounts.{label}] has no mnemonic");
-            };
-            let derivation = match settings.get("derivation") {
-                Some(toml::Value::String(path)) => path.as_str(),
-                _ => DEFAULT_DERIVATION_PATH,
-            };
+        for (label, account) in &generated.accounts {
+            let derivation = account.derivation.as_deref();
             assert!(
-                clarinet_utils::is_precomputed(mnemonic, derivation),
-                "the generated {label} mnemonic is missing from the \
-                 clarinet-utils precomputed table"
+                derivation.is_none() || derivation == Some(DEFAULT_DERIVATION_PATH),
+                "account {label} overrides the derivation path, which misses the \
+                 precomputed table"
             );
         }
+
+        verify_documented_addresses(&devnet_toml);
+    }
+
+    /// Each account block documents its derived key and addresses in comments
+    /// that developers copy into tests. The mnemonics now live in
+    /// `clarinet-utils`, so nothing else would notice if one were rotated and
+    /// these literals left behind.
+    fn verify_documented_addresses(devnet_toml: &str) {
+        let networks = StacksNetwork::Devnet.get_networks();
+        let mut checked = 0;
+
+        for block in devnet_toml.split("[accounts.").skip(1) {
+            let field = |prefix: &str| {
+                block
+                    .lines()
+                    .find_map(|line| line.trim().strip_prefix(prefix))
+                    .map(str::trim)
+                    .unwrap_or_else(|| panic!("account block is missing {prefix}"))
+            };
+            let label = block.lines().next().unwrap().trim_end_matches(']');
+            let mnemonic = field("mnemonic = ").trim_matches('"');
+
+            let (stx_address, btc_address, secret_key) =
+                compute_addresses(mnemonic, DEFAULT_DERIVATION_PATH, &networks);
+
+            assert_eq!(field("# secret_key: "), secret_key, "{label} secret_key");
+            assert_eq!(field("# stx_address: "), stx_address, "{label} stx_address");
+            assert_eq!(field("# btc_address: "), btc_address, "{label} btc_address");
+            checked += 1;
+        }
+
+        assert_eq!(checked, EXPECTED_ACCOUNTS.len());
     }
 }

--- a/components/clarinet-deployments/tests/devnet_sbtc_plan.rs
+++ b/components/clarinet-deployments/tests/devnet_sbtc_plan.rs
@@ -8,13 +8,11 @@ use std::path::Path;
 use clarinet_deployments::generate_default_deployment;
 use clarinet_deployments::types::TransactionSpecification;
 use clarinet_files::{ProjectManifest, StacksNetwork};
+use clarinet_utils::DEFAULT_DEPLOYER_MNEMONIC as TEST_MNEMONIC;
 use clarity_repl::repl::boot::{SBTC_CONTRACTS_NAMES, SBTC_MAINNET_ADDRESS};
 use clarity_repl::utils::Environment;
 use indoc::formatdoc;
 use tempfile::TempDir;
-
-/// Well-known Clarinet test mnemonic, matching the generated settings files.
-const TEST_MNEMONIC: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
 
 /// Write a project with a single contract and no requirements, the way
 /// `clarinet new` followed by `clarinet contract new` would.

--- a/components/clarinet-deployments/tests/devnet_snapshot_deployment.rs
+++ b/components/clarinet-deployments/tests/devnet_snapshot_deployment.rs
@@ -14,6 +14,7 @@ use clarinet_deployments::types::{
     TransactionsBatchSpecification,
 };
 use clarinet_files::{NetworkManifest, NetworkManifestFile, StacksNetwork};
+use clarinet_utils::DEFAULT_DEPLOYER_MNEMONIC as DEPLOYER_MNEMONIC;
 use clarity::codec::StacksMessageCodec;
 use clarity::vm::types::{PrincipalData, QualifiedContractIdentifier, StandardPrincipalData};
 use clarity::vm::{ClarityVersion, ContractName};
@@ -24,7 +25,6 @@ use serde_json::json;
 use stacks_codec::transaction::{StacksTransaction, TransactionPayload};
 use stacks_rpc_client::rpc_client::NodeInfo;
 
-const DEPLOYER_MNEMONIC: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
 const DEPLOYER: &str = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM";
 
 /// Deployer nonce carried by a snapshot that already published two requirements.

--- a/components/clarinet-deployments/tests/sbtc_testnet_remap.rs
+++ b/components/clarinet-deployments/tests/sbtc_testnet_remap.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use clarinet_deployments::generate_default_deployment;
 use clarinet_deployments::types::TransactionSpecification;
 use clarinet_files::{ProjectManifest, StacksNetwork};
+use clarinet_utils::DEFAULT_DEPLOYER_MNEMONIC as TEST_MNEMONIC;
 use clarity_repl::utils::Environment;
 use indoc::formatdoc;
 use mockito::{Server, ServerGuard};
@@ -28,9 +29,6 @@ const SBTC_TESTNET_DEPLOYER: &str = "SN3VMHXEN64ZZF71JQ5VESXDWTR301XTTXGF4J8F1";
 
 /// A contract that is not sBTC, used to check the remap is not over-broad.
 const OTHER_DEPLOYER: &str = "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9";
-
-/// Well-known Clarinet test mnemonic, matching the generated settings files.
-const TEST_MNEMONIC: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
 
 /// Stand-in for the real requirement source. The remap keys off the issuer
 /// address, not the body, so a dependency-free contract keeps the test fast.

--- a/components/clarinet-files/src/network_manifest.rs
+++ b/components/clarinet-files/src/network_manifest.rs
@@ -3,6 +3,10 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use clarinet_utils::{get_bip32_keys_from_mnemonic, mnemonic_from_phrase, random_mnemonic};
+pub use clarinet_utils::{
+    DEFAULT_DERIVATION_PATH, DEFAULT_FAUCET_MNEMONIC, DEFAULT_STACKER_MNEMONIC,
+    DEFAULT_STACKS_MINER_MNEMONIC,
+};
 use clarity::types::chainstate::{StacksAddress, StacksPrivateKey};
 use clarity::util::hash::bytes_to_hex;
 use clarity::util::secp256k1::Secp256k1PublicKey;
@@ -13,8 +17,6 @@ use toml::value::Value;
 
 use super::FileAccessor;
 use crate::paths;
-
-pub const DEFAULT_DERIVATION_PATH: &str = "m/44'/5757'/0'/0/0";
 
 pub const DEFAULT_STACKS_NODE_IMAGE: &str = "ghcr.io/stacks-network/stacks-core:4.0.1-alpine";
 pub const DEFAULT_STACKS_SIGNER_IMAGE: &str = "ghcr.io/stacks-network/stacks-signer:4.0.1-alpine";
@@ -27,9 +29,6 @@ pub const DEFAULT_BITCOIN_EXPLORER_IMAGE: &str = "quay.io/hirosystems/bitcoin-ex
 
 pub const DEFAULT_STACKS_EXPLORER_IMAGE: &str = "ghcr.io/stx-labs/explorer:latest";
 
-pub const DEFAULT_STACKS_MINER_MNEMONIC: &str = "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce";
-pub const DEFAULT_FAUCET_MNEMONIC: &str = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform";
-pub const DEFAULT_STACKER_MNEMONIC: &str = "empty lens any direct brother then drop fury rule pole win claim scissors list rescue horn rent inform relief jump sword weekend half legend";
 pub const DEFAULT_DOCKER_PLATFORM: &str = "linux/amd64";
 
 /// Normalize a user-provided docker_host value to include a scheme prefix.
@@ -1301,30 +1300,6 @@ mod tests {
         DevnetConfigFile, StacksNodeEventObserver, DEFAULT_STACKS_NODE_IMAGE,
         DEFAULT_STACKS_SIGNER_IMAGE,
     };
-
-    /// Every devnet wallet is derived on each `NetworkManifest` load, which the
-    /// LSP does on every file save. `clarinet-utils` bakes their keys in so the
-    /// PBKDF2 rounds are skipped; if a default mnemonic or the derivation path
-    /// changes here, that table goes stale and the cost comes back silently.
-    #[test]
-    fn devnet_default_mnemonics_are_precomputed() {
-        use crate::{
-            DEFAULT_DERIVATION_PATH, DEFAULT_FAUCET_MNEMONIC, DEFAULT_STACKER_MNEMONIC,
-            DEFAULT_STACKS_MINER_MNEMONIC,
-        };
-
-        for (label, mnemonic) in [
-            ("miner", DEFAULT_STACKS_MINER_MNEMONIC),
-            ("faucet", DEFAULT_FAUCET_MNEMONIC),
-            ("stacker", DEFAULT_STACKER_MNEMONIC),
-        ] {
-            assert!(
-                clarinet_utils::is_precomputed(mnemonic, DEFAULT_DERIVATION_PATH),
-                "the default devnet {label} mnemonic is missing from the \
-                 clarinet-utils precomputed table"
-            );
-        }
-    }
 
     #[test]
     fn parses_legacy_stacks_node_event_observer() {

--- a/components/clarinet-utils/benches/bip32.rs
+++ b/components/clarinet-utils/benches/bip32.rs
@@ -1,6 +1,8 @@
-//! Where the time inside `get_bip32_keys_from_mnemonic` actually goes.
+//! What `get_bip32_keys_from_mnemonic` costs in each of its three cache
+//! states, and where the time goes when it has to derive.
 //!
-//! Three stages, run back to back for every wallet in `settings/Devnet.toml`:
+//! The derivation runs three stages back to back, once per wallet in
+//! `settings/Devnet.toml`:
 //!   1. `Mnemonic::to_seed` — PBKDF2-HMAC-SHA512, 2048 rounds
 //!   2. `XPrv::derive_from_path` — one HMAC-SHA512 + one secp256k1 point
 //!      multiplication per level (5 levels for `m/44'/5757'/0'/0/0`)
@@ -11,59 +13,84 @@ use std::str::FromStr;
 
 use bip32::{DerivationPath, XPrv};
 use bip39::{Language, Mnemonic};
-use clarinet_utils::{get_bip32_keys_from_mnemonic, random_mnemonic};
+use clarinet_utils::{
+    get_bip32_keys_from_mnemonic, random_mnemonic, DEFAULT_DEPLOYER_MNEMONIC,
+    DEFAULT_DERIVATION_PATH,
+};
 use libsecp256k1::{PublicKey, SecretKey};
-
-const PHRASE: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
-const DERIVATION: &str = "m/44'/5757'/0'/0/0";
 
 fn main() {
     divan::main();
 }
 
-/// The three stages together, for a mnemonic no cache has seen.
+/// A mnemonic no cache has seen: the full derivation.
 #[divan::bench]
-fn total_uncached(bencher: divan::Bencher) {
+fn uncached(bencher: divan::Bencher) {
     bencher
         .with_inputs(|| random_mnemonic().to_string())
-        .bench_values(|phrase| get_bip32_keys_from_mnemonic(&phrase, "", DERIVATION).unwrap());
+        .bench_values(|phrase| {
+            get_bip32_keys_from_mnemonic(&phrase, "", DEFAULT_DERIVATION_PATH).unwrap()
+        });
 }
 
-/// The same call for a mnemonic Clarinet ships, which resolves from the
-/// compile-time table instead.
+/// A mnemonic Clarinet ships: resolved from the compile-time table.
 #[divan::bench]
-fn total_precomputed() -> (Vec<u8>, PublicKey) {
-    get_bip32_keys_from_mnemonic(black_box(PHRASE), "", black_box(DERIVATION)).unwrap()
+fn precomputed() -> (Vec<u8>, PublicKey) {
+    get_bip32_keys_from_mnemonic(
+        black_box(DEFAULT_DEPLOYER_MNEMONIC),
+        "",
+        black_box(DEFAULT_DERIVATION_PATH),
+    )
+    .unwrap()
 }
 
+/// A custom mnemonic on its second and later use: resolved from the memo.
 #[divan::bench]
-fn stage1_to_seed(bencher: divan::Bencher) {
-    let mnemonic = Mnemonic::parse_in(Language::English, PHRASE).unwrap();
-    bencher.bench(|| black_box(&mnemonic).to_seed(""));
+fn memoized(bencher: divan::Bencher) {
+    let phrase = random_mnemonic().to_string();
+    get_bip32_keys_from_mnemonic(&phrase, "", DEFAULT_DERIVATION_PATH).unwrap();
+    bencher.bench(|| {
+        get_bip32_keys_from_mnemonic(black_box(&phrase), "", black_box(DEFAULT_DERIVATION_PATH))
+            .unwrap()
+    });
 }
 
-#[divan::bench]
-fn stage2_derive_path(bencher: divan::Bencher) {
-    let mnemonic = Mnemonic::parse_in(Language::English, PHRASE).unwrap();
-    let mut seed = [0u8; 64];
-    seed.copy_from_slice(&mnemonic.to_seed(""));
-    let path = DerivationPath::from_str(DERIVATION).unwrap();
-    bencher.bench(|| XPrv::derive_from_path(black_box(seed), black_box(&path)).unwrap());
-}
+mod stages {
+    use super::*;
 
-#[divan::bench]
-fn stage3_public_key(bencher: divan::Bencher) {
-    let mnemonic = Mnemonic::parse_in(Language::English, PHRASE).unwrap();
-    let mut seed = [0u8; 64];
-    seed.copy_from_slice(&mnemonic.to_seed(""));
-    let path = DerivationPath::from_str(DERIVATION).unwrap();
-    let xprv = XPrv::derive_from_path(seed, &path).unwrap();
-    let secret = SecretKey::parse_slice(&xprv.private_key().to_bytes()).unwrap();
-    bencher.bench(|| PublicKey::from_secret_key(black_box(&secret)));
-}
+    /// `to_seed` already returns `[u8; 64]`, so no copy is needed to feed
+    /// `XPrv::derive_from_path`.
+    fn seed_and_path() -> ([u8; 64], DerivationPath) {
+        let mnemonic = Mnemonic::parse_in(Language::English, DEFAULT_DEPLOYER_MNEMONIC).unwrap();
+        (
+            mnemonic.to_seed(""),
+            DerivationPath::from_str(DEFAULT_DERIVATION_PATH).unwrap(),
+        )
+    }
 
-/// Parsing the derivation path string itself — should be noise.
-#[divan::bench]
-fn derivation_path_parse() -> DerivationPath {
-    DerivationPath::from_str(black_box(DERIVATION)).unwrap()
+    #[divan::bench]
+    fn to_seed(bencher: divan::Bencher) {
+        let mnemonic = Mnemonic::parse_in(Language::English, DEFAULT_DEPLOYER_MNEMONIC).unwrap();
+        bencher.bench(|| black_box(&mnemonic).to_seed(""));
+    }
+
+    #[divan::bench]
+    fn derive_path(bencher: divan::Bencher) {
+        let (seed, path) = seed_and_path();
+        bencher.bench(|| XPrv::derive_from_path(black_box(seed), black_box(&path)).unwrap());
+    }
+
+    #[divan::bench]
+    fn public_key(bencher: divan::Bencher) {
+        let (seed, path) = seed_and_path();
+        let xprv = XPrv::derive_from_path(seed, &path).unwrap();
+        let secret = SecretKey::parse_slice(&xprv.private_key().to_bytes()).unwrap();
+        bencher.bench(|| PublicKey::from_secret_key(black_box(&secret)));
+    }
+
+    /// Parsing the derivation path string itself — should be noise.
+    #[divan::bench]
+    fn derivation_path_parse() -> DerivationPath {
+        DerivationPath::from_str(black_box(DEFAULT_DERIVATION_PATH)).unwrap()
+    }
 }

--- a/components/clarinet-utils/benches/bip32.rs
+++ b/components/clarinet-utils/benches/bip32.rs
@@ -12,9 +12,8 @@ use std::hint::black_box;
 use std::str::FromStr;
 
 use bip32::{DerivationPath, XPrv};
-use bip39::{Language, Mnemonic};
 use clarinet_utils::{
-    get_bip32_keys_from_mnemonic, random_mnemonic, DEFAULT_DEPLOYER_MNEMONIC,
+    get_bip32_keys_from_mnemonic, mnemonic_from_phrase, random_mnemonic, DEFAULT_DEPLOYER_MNEMONIC,
     DEFAULT_DERIVATION_PATH,
 };
 use libsecp256k1::{PublicKey, SecretKey};
@@ -45,13 +44,21 @@ fn precomputed() -> (Vec<u8>, PublicKey) {
 }
 
 /// A custom mnemonic on its second and later use: resolved from the memo.
+///
+/// Uses a 24-word phrase at a non-default path — it misses the table and lands
+/// in the memo, and the key length is most of a memo hit, so a 12-word
+/// `random_mnemonic()` would understate it against the `precomputed` row.
 #[divan::bench]
 fn memoized(bencher: divan::Bencher) {
-    let phrase = random_mnemonic().to_string();
-    get_bip32_keys_from_mnemonic(&phrase, "", DEFAULT_DERIVATION_PATH).unwrap();
+    const OFF_TABLE_PATH: &str = "m/44'/5757'/0'/0/9";
+    get_bip32_keys_from_mnemonic(DEFAULT_DEPLOYER_MNEMONIC, "", OFF_TABLE_PATH).unwrap();
     bencher.bench(|| {
-        get_bip32_keys_from_mnemonic(black_box(&phrase), "", black_box(DEFAULT_DERIVATION_PATH))
-            .unwrap()
+        get_bip32_keys_from_mnemonic(
+            black_box(DEFAULT_DEPLOYER_MNEMONIC),
+            "",
+            black_box(OFF_TABLE_PATH),
+        )
+        .unwrap()
     });
 }
 
@@ -61,7 +68,7 @@ mod stages {
     /// `to_seed` already returns `[u8; 64]`, so no copy is needed to feed
     /// `XPrv::derive_from_path`.
     fn seed_and_path() -> ([u8; 64], DerivationPath) {
-        let mnemonic = Mnemonic::parse_in(Language::English, DEFAULT_DEPLOYER_MNEMONIC).unwrap();
+        let mnemonic = mnemonic_from_phrase(DEFAULT_DEPLOYER_MNEMONIC).unwrap();
         (
             mnemonic.to_seed(""),
             DerivationPath::from_str(DEFAULT_DERIVATION_PATH).unwrap(),
@@ -70,7 +77,7 @@ mod stages {
 
     #[divan::bench]
     fn to_seed(bencher: divan::Bencher) {
-        let mnemonic = Mnemonic::parse_in(Language::English, DEFAULT_DEPLOYER_MNEMONIC).unwrap();
+        let mnemonic = mnemonic_from_phrase(DEFAULT_DEPLOYER_MNEMONIC).unwrap();
         bencher.bench(|| black_box(&mnemonic).to_seed(""));
     }
 

--- a/components/clarinet-utils/src/lib.rs
+++ b/components/clarinet-utils/src/lib.rs
@@ -389,6 +389,9 @@ mod tests {
     use super::*;
     use crate::precomputed::is_precomputed;
 
+    /// Serializes the tests that drive `DERIVED_KEYS` to its cap.
+    static CACHE_TESTS: Mutex<()> = Mutex::new(());
+
     #[test]
     fn test_mnemonic_from_phrase_12() {
         let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -454,19 +457,16 @@ mod tests {
     /// must not end up in the process-wide memo.
     #[test]
     fn test_passphrase_bearing_derivations_are_not_memoized() {
+        // Asserting on the map's *length* would race with any other test that
+        // inserts; this phrase is freshly random, so only this test could put
+        // it there.
         let phrase = random_mnemonic().to_string();
-        let before = derived_keys().len();
 
         get_bip32_keys_from_mnemonic(&phrase, "hunter2", DEFAULT_DERIVATION_PATH).unwrap();
 
-        assert_eq!(
-            derived_keys().len(),
-            before,
-            "a passphrase-bearing derivation was memoized"
-        );
         assert!(
             !derived_keys().keys().any(|(cached, _)| cached == &phrase),
-            "the phrase of a passphrase-bearing derivation was retained"
+            "a passphrase-bearing derivation was memoized"
         );
     }
 
@@ -510,6 +510,12 @@ mod tests {
     #[test]
     fn test_memo_still_caches_once_full() {
         const DERIVATION: &str = "m/44'/5757'/0'/0/7";
+        // The default harness runs tests as threads in one process, and this is
+        // the only test that pushes the map to its cap, where inserts start
+        // evicting. Hold the guard so it cannot evict a sibling's entry, or
+        // have its own evicted, mid-assertion. (`cargo tst` uses nextest, which
+        // gives each test its own process; plain `cargo test` does not.)
+        let _serialized = CACHE_TESTS.lock().unwrap_or_else(PoisonError::into_inner);
 
         // Fill past the limit with phrases nothing will ask for again, the way
         // an `[accounts.x]` table with no `mnemonic` does on every load.

--- a/components/clarinet-utils/src/lib.rs
+++ b/components/clarinet-utils/src/lib.rs
@@ -72,10 +72,12 @@ pub fn random_mnemonic() -> Mnemonic {
     Mnemonic::from_entropy_in(Language::English, &entropy).unwrap()
 }
 
-pub(crate) type DerivedKeys = (Vec<u8>, PublicKey);
+/// The 32-byte secret key and its secp256k1 public key.
+pub type DerivedKeys = (Vec<u8>, PublicKey);
 
-/// `(phrase, password, derivation)`.
-type CacheKey = (String, String, String);
+/// `(phrase, derivation)`. Passphrase-bearing derivations are never memoized,
+/// so no passphrase is ever stored here — see [`get_bip32_keys_from_mnemonic`].
+type CacheKey = (String, String);
 
 /// Most callers derive the same handful of wallets over and over: the LSP
 /// rebuilds the whole `NetworkManifest` on every file save, and
@@ -91,7 +93,8 @@ type CacheKey = (String, String, String);
 ///
 /// This does keep derived secrets alive for the lifetime of the process. That
 /// is already true of the plaintext mnemonics held in `NetworkManifest`, which
-/// outlive every caller here.
+/// outlive every caller here — but it is *not* true of a BIP39 passphrase,
+/// which is why those are excluded entirely rather than merely keyed on.
 static DERIVED_KEYS: LazyLock<Mutex<HashMap<CacheKey, DerivedKeys>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
@@ -103,7 +106,10 @@ const CACHE_LIMIT: usize = 64;
 ///
 /// Evicting rather than declining the insert matters: the phrases that fill
 /// the map are the unrepeatable random ones, so refusing new entries would let
-/// them permanently crowd out wallets that *are* looked up again.
+/// them permanently crowd out wallets that *are* looked up again. Which entry
+/// goes is arbitrary — tracking recency would only pay off in a session that
+/// both exceeds the cap and reuses an evicted wallet, and re-deriving one
+/// wallet costs less than the bookkeeping would.
 fn memoize(cache_key: CacheKey, keys: &DerivedKeys) {
     let mut cache = derived_keys();
     while cache.len() >= CACHE_LIMIT {
@@ -126,26 +132,30 @@ pub fn get_bip32_keys_from_mnemonic(
     password: &str,
     derivation: &str,
 ) -> Result<DerivedKeys, String> {
-    // A BIP39 passphrase changes the seed, so the table only applies without
-    // one. Checking it first means a table hit allocates nothing.
-    if password.is_empty() {
-        if let Some(keys) = precomputed::lookup(phrase, derivation) {
-            return Ok(keys);
-        }
+    // A BIP39 passphrase changes the seed, so neither cache can answer for one.
+    // Returning early rather than keying on the passphrase keeps it out of
+    // process memory: unlike the mnemonic, a passphrase is a user secret that
+    // `NetworkManifest` never holds, and nothing in the workspace passes one
+    // today, so there is nothing to trade away.
+    if !password.is_empty() {
+        return derive_bip32_keys(phrase, password, derivation);
     }
 
-    let cache_key = (
-        phrase.to_string(),
-        password.to_string(),
-        derivation.to_string(),
-    );
+    // Checked first, so a table hit allocates nothing.
+    if let Some(keys) = precomputed::lookup(phrase, derivation) {
+        return Ok(keys);
+    }
 
+    let cache_key = (phrase.to_string(), derivation.to_string());
     if let Some(keys) = derived_keys().get(&cache_key) {
         return Ok(keys.clone());
     }
 
     // Deliberately not holding the guard across the derivation — it is ~0.8 ms,
-    // and concurrent derivations of different wallets should not serialize.
+    // and derivations of *different* wallets should not serialize behind each
+    // other. Two threads racing on the same new wallet will therefore both
+    // derive it and the second insert wins; that costs one extra derivation,
+    // once, which is cheaper than the per-key coordination to avoid it.
     let keys = derive_bip32_keys(phrase, password, derivation)?;
     memoize(cache_key, &keys);
 
@@ -440,6 +450,26 @@ mod tests {
         assert_eq!(cached_public, derived_public);
     }
 
+    /// A passphrase is a user secret that `NetworkManifest` never holds, so it
+    /// must not end up in the process-wide memo.
+    #[test]
+    fn test_passphrase_bearing_derivations_are_not_memoized() {
+        let phrase = random_mnemonic().to_string();
+        let before = derived_keys().len();
+
+        get_bip32_keys_from_mnemonic(&phrase, "hunter2", DEFAULT_DERIVATION_PATH).unwrap();
+
+        assert_eq!(
+            derived_keys().len(),
+            before,
+            "a passphrase-bearing derivation was memoized"
+        );
+        assert!(
+            !derived_keys().keys().any(|(cached, _)| cached == &phrase),
+            "the phrase of a passphrase-bearing derivation was retained"
+        );
+    }
+
     /// A BIP39 passphrase produces a different seed, so the table must not
     /// answer for it.
     #[test]
@@ -495,7 +525,7 @@ mod tests {
         // A wallet first seen now must still land in the memo.
         let phrase = random_mnemonic().to_string();
         let first = get_bip32_keys_from_mnemonic(&phrase, "", DERIVATION).unwrap();
-        let key = (phrase.clone(), String::new(), DERIVATION.to_string());
+        let key = (phrase.clone(), DERIVATION.to_string());
         assert_eq!(
             derived_keys().get(&key),
             Some(&first),

--- a/components/clarinet-utils/src/lib.rs
+++ b/components/clarinet-utils/src/lib.rs
@@ -3,7 +3,7 @@ mod precomputed;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, MutexGuard, PoisonError};
 
 use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, Error as AesGcmError, KeyInit, Nonce};
@@ -11,7 +11,13 @@ use argon2::{Argon2, Error as Argon2Error};
 use bip32::{DerivationPath, XPrv};
 use bip39::{Error as MnemonicError, Language, Mnemonic};
 use libsecp256k1::{PublicKey, SecretKey};
-pub use precomputed::is_precomputed;
+pub use precomputed::{
+    DEFAULT_DEPLOYER_MNEMONIC, DEFAULT_DERIVATION_PATH, DEFAULT_FAUCET_MNEMONIC,
+    DEFAULT_STACKER_MNEMONIC, DEFAULT_STACKS_MINER_MNEMONIC, DEFAULT_WALLET_1_MNEMONIC,
+    DEFAULT_WALLET_2_MNEMONIC, DEFAULT_WALLET_3_MNEMONIC, DEFAULT_WALLET_4_MNEMONIC,
+    DEFAULT_WALLET_5_MNEMONIC, DEFAULT_WALLET_6_MNEMONIC, DEFAULT_WALLET_7_MNEMONIC,
+    DEFAULT_WALLET_8_MNEMONIC,
+};
 use rand::RngCore;
 
 /// Size of the AES-GCM nonce
@@ -66,31 +72,62 @@ pub fn random_mnemonic() -> Mnemonic {
     Mnemonic::from_entropy_in(Language::English, &entropy).unwrap()
 }
 
-type DerivedKeys = (Vec<u8>, PublicKey);
+pub(crate) type DerivedKeys = (Vec<u8>, PublicKey);
 
-/// Keys already derived in this process, keyed by `(phrase, password, path)`.
+/// `(phrase, password, derivation)`.
+type CacheKey = (String, String, String);
+
+/// Most callers derive the same handful of wallets over and over: the LSP
+/// rebuilds the whole `NetworkManifest` on every file save, and
+/// `clarinet deployments apply` re-derives the signing key for every
+/// transaction in the plan. The table in [`precomputed`] only covers the
+/// mnemonics Clarinet ships; this covers everything else, including custom
+/// wallets in a project's `Devnet.toml`.
 ///
-/// The same handful of wallets get derived over and over: the LSP rebuilds the
-/// whole `NetworkManifest` on every file save, and `clarinet deployments apply`
-/// re-derives the signing key for every transaction in the plan. The table in
-/// [`precomputed`] only covers the mnemonics Clarinet ships; this covers
-/// everything else, including custom wallets in a project's `Devnet.toml`.
-///
-/// Entries are bounded by the number of distinct wallets a process ever sees —
-/// a dozen or so — so there is nothing to evict.
+/// One path does not benefit and must not be allowed to grow the map without
+/// bound: an `[accounts.x]` table with no `mnemonic` gets a fresh
+/// `random_mnemonic()` on every manifest load, so it can never be hit again.
+/// [`CACHE_LIMIT`] keeps that from accumulating for the life of an LSP session.
 ///
 /// This does keep derived secrets alive for the lifetime of the process. That
 /// is already true of the plaintext mnemonics held in `NetworkManifest`, which
 /// outlive every caller here.
-static DERIVED_KEYS: LazyLock<Mutex<HashMap<(String, String, String), DerivedKeys>>> =
+static DERIVED_KEYS: LazyLock<Mutex<HashMap<CacheKey, DerivedKeys>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Comfortably above the ~13 wallets a devnet manifest declares, low enough
+/// that the randomly generated phrases described above cannot pile up.
+const CACHE_LIMIT: usize = 64;
+
+/// Insert, evicting an arbitrary entry first if the map is full.
+///
+/// Evicting rather than declining the insert matters: the phrases that fill
+/// the map are the unrepeatable random ones, so refusing new entries would let
+/// them permanently crowd out wallets that *are* looked up again.
+fn memoize(cache_key: CacheKey, keys: &DerivedKeys) {
+    let mut cache = derived_keys();
+    while cache.len() >= CACHE_LIMIT {
+        let Some(evict) = cache.keys().next().cloned() else {
+            break;
+        };
+        cache.remove(&evict);
+    }
+    cache.insert(cache_key, keys.clone());
+}
+
+/// A poisoned lock only means another thread panicked mid-lookup. This is a
+/// cache, so recover the map rather than propagating the failure.
+fn derived_keys() -> MutexGuard<'static, HashMap<CacheKey, DerivedKeys>> {
+    DERIVED_KEYS.lock().unwrap_or_else(PoisonError::into_inner)
+}
 
 pub fn get_bip32_keys_from_mnemonic(
     phrase: &str,
     password: &str,
     derivation: &str,
 ) -> Result<DerivedKeys, String> {
-    // A BIP39 passphrase changes the seed, so the table only applies without one.
+    // A BIP39 passphrase changes the seed, so the table only applies without
+    // one. Checking it first means a table hit allocates nothing.
     if password.is_empty() {
         if let Some(keys) = precomputed::lookup(phrase, derivation) {
             return Ok(keys);
@@ -103,19 +140,14 @@ pub fn get_bip32_keys_from_mnemonic(
         derivation.to_string(),
     );
 
-    // A poisoned lock only means some other thread panicked mid-lookup. This
-    // is a cache: fall back to deriving rather than propagating the failure.
-    if let Ok(cache) = DERIVED_KEYS.lock() {
-        if let Some(keys) = cache.get(&cache_key) {
-            return Ok(keys.clone());
-        }
+    if let Some(keys) = derived_keys().get(&cache_key) {
+        return Ok(keys.clone());
     }
 
+    // Deliberately not holding the guard across the derivation — it is ~0.8 ms,
+    // and concurrent derivations of different wallets should not serialize.
     let keys = derive_bip32_keys(phrase, password, derivation)?;
-
-    if let Ok(mut cache) = DERIVED_KEYS.lock() {
-        cache.insert(cache_key, keys.clone());
-    }
+    memoize(cache_key, &keys);
 
     Ok(keys)
 }
@@ -127,7 +159,7 @@ fn derive_bip32_keys(
     password: &str,
     derivation: &str,
 ) -> Result<DerivedKeys, String> {
-    let mnemonic = Mnemonic::parse_in(Language::English, phrase).map_err(|e| e.to_string())?;
+    let mnemonic = mnemonic_from_phrase(phrase)?;
     let seed_vec = mnemonic.to_seed(password);
     if seed_vec.len() != 64 {
         return Err("Seed must be 64 bytes".to_string());
@@ -345,6 +377,7 @@ pub fn decrypt_mnemonic_phrase(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::precomputed::is_precomputed;
 
     #[test]
     fn test_mnemonic_from_phrase_12() {
@@ -395,8 +428,8 @@ mod tests {
     /// A precomputed phrase must come back byte-identical to a live derivation.
     #[test]
     fn test_get_bip32_keys_uses_precomputed_table() {
-        const PHRASE: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
-        const DERIVATION: &str = "m/44'/5757'/0'/0/0";
+        const PHRASE: &str = DEFAULT_DEPLOYER_MNEMONIC;
+        const DERIVATION: &str = DEFAULT_DERIVATION_PATH;
         assert!(is_precomputed(PHRASE, DERIVATION));
 
         let (cached_secret, cached_public) =
@@ -411,8 +444,8 @@ mod tests {
     /// answer for it.
     #[test]
     fn test_get_bip32_keys_bypasses_table_when_password_is_set() {
-        const PHRASE: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
-        const DERIVATION: &str = "m/44'/5757'/0'/0/0";
+        const PHRASE: &str = DEFAULT_DEPLOYER_MNEMONIC;
+        const DERIVATION: &str = DEFAULT_DERIVATION_PATH;
 
         let (no_password, _) = get_bip32_keys_from_mnemonic(PHRASE, "", DERIVATION).unwrap();
         let (with_password, _) =
@@ -441,11 +474,42 @@ mod tests {
         assert_eq!(first, fresh);
     }
 
+    /// A full memo must keep working. The phrases that fill it are the
+    /// unrepeatable random ones, so refusing new entries once full would let
+    /// them crowd out wallets that are actually looked up again.
+    #[test]
+    fn test_memo_still_caches_once_full() {
+        const DERIVATION: &str = "m/44'/5757'/0'/0/7";
+
+        // Fill past the limit with phrases nothing will ask for again, the way
+        // an `[accounts.x]` table with no `mnemonic` does on every load.
+        for _ in 0..CACHE_LIMIT + 4 {
+            let throwaway = random_mnemonic().to_string();
+            get_bip32_keys_from_mnemonic(&throwaway, "", DERIVATION).unwrap();
+        }
+        assert!(
+            derived_keys().len() <= CACHE_LIMIT,
+            "memo grew past its cap"
+        );
+
+        // A wallet first seen now must still land in the memo.
+        let phrase = random_mnemonic().to_string();
+        let first = get_bip32_keys_from_mnemonic(&phrase, "", DERIVATION).unwrap();
+        let key = (phrase.clone(), String::new(), DERIVATION.to_string());
+        assert_eq!(
+            derived_keys().get(&key),
+            Some(&first),
+            "a wallet seen after the memo filled up was not cached"
+        );
+    }
+
     /// Neither cache may swallow the errors the callers rely on.
     #[test]
     fn test_get_bip32_keys_still_rejects_invalid_input() {
         const PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-        assert!(get_bip32_keys_from_mnemonic("not a mnemonic", "", "m/44'/5757'/0'/0/0").is_err());
+        assert!(
+            get_bip32_keys_from_mnemonic("not a mnemonic", "", DEFAULT_DERIVATION_PATH).is_err()
+        );
         assert!(get_bip32_keys_from_mnemonic(PHRASE, "", "not a path").is_err());
     }
 

--- a/components/clarinet-utils/src/lib.rs
+++ b/components/clarinet-utils/src/lib.rs
@@ -12,11 +12,11 @@ use bip32::{DerivationPath, XPrv};
 use bip39::{Error as MnemonicError, Language, Mnemonic};
 use libsecp256k1::{PublicKey, SecretKey};
 pub use precomputed::{
-    DEFAULT_DEPLOYER_MNEMONIC, DEFAULT_DERIVATION_PATH, DEFAULT_FAUCET_MNEMONIC,
-    DEFAULT_STACKER_MNEMONIC, DEFAULT_STACKS_MINER_MNEMONIC, DEFAULT_WALLET_1_MNEMONIC,
-    DEFAULT_WALLET_2_MNEMONIC, DEFAULT_WALLET_3_MNEMONIC, DEFAULT_WALLET_4_MNEMONIC,
-    DEFAULT_WALLET_5_MNEMONIC, DEFAULT_WALLET_6_MNEMONIC, DEFAULT_WALLET_7_MNEMONIC,
-    DEFAULT_WALLET_8_MNEMONIC,
+    DEFAULT_DEPLOYER_MNEMONIC, DEFAULT_DERIVATION_PATH, DEFAULT_DEVNET_ACCOUNTS,
+    DEFAULT_FAUCET_MNEMONIC, DEFAULT_STACKER_MNEMONIC, DEFAULT_STACKS_MINER_MNEMONIC,
+    DEFAULT_WALLET_1_MNEMONIC, DEFAULT_WALLET_2_MNEMONIC, DEFAULT_WALLET_3_MNEMONIC,
+    DEFAULT_WALLET_4_MNEMONIC, DEFAULT_WALLET_5_MNEMONIC, DEFAULT_WALLET_6_MNEMONIC,
+    DEFAULT_WALLET_7_MNEMONIC, DEFAULT_WALLET_8_MNEMONIC,
 };
 use rand::RngCore;
 
@@ -98,25 +98,31 @@ type CacheKey = (String, String);
 static DERIVED_KEYS: LazyLock<Mutex<HashMap<CacheKey, DerivedKeys>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Comfortably above the ~13 wallets a devnet manifest declares, low enough
-/// that the randomly generated phrases described above cannot pile up.
-const CACHE_LIMIT: usize = 64;
+/// Bounds the map without being reachable by a real manifest. Sized well
+/// above any plausible account count on purpose: if the cap were close to it,
+/// a project declaring more wallets than the cap would evict and re-derive the
+/// overflow on *every* load, permanently — trading a bounded ~400 KB for
+/// hundreds of milliseconds. At this size an entry (~380 B) is only ever
+/// evicted by the unrepeatable random phrases the cap exists for.
+const CACHE_LIMIT: usize = 1024;
 
 /// Insert, evicting an arbitrary entry first if the map is full.
 ///
 /// Evicting rather than declining the insert matters: the phrases that fill
 /// the map are the unrepeatable random ones, so refusing new entries would let
 /// them permanently crowd out wallets that *are* looked up again. Which entry
-/// goes is arbitrary — tracking recency would only pay off in a session that
-/// both exceeds the cap and reuses an evicted wallet, and re-deriving one
-/// wallet costs less than the bookkeeping would.
+/// goes is arbitrary, which is only tolerable because [`CACHE_LIMIT`] is far
+/// above any real account count — a useful entry is picked with probability
+/// `real_wallets / CACHE_LIMIT`, and evicting one costs a single re-derivation.
+///
+/// This is the sole insertion point and it evicts first, so the map is never
+/// above the cap on entry and at most one entry is ever removed.
 fn memoize(cache_key: CacheKey, keys: &DerivedKeys) {
     let mut cache = derived_keys();
-    while cache.len() >= CACHE_LIMIT {
-        let Some(evict) = cache.keys().next().cloned() else {
-            break;
-        };
-        cache.remove(&evict);
+    if cache.len() >= CACHE_LIMIT {
+        if let Some(evict) = cache.keys().next().cloned() {
+            cache.remove(&evict);
+        }
     }
     cache.insert(cache_key, keys.clone());
 }
@@ -170,12 +176,7 @@ fn derive_bip32_keys(
     derivation: &str,
 ) -> Result<DerivedKeys, String> {
     let mnemonic = mnemonic_from_phrase(phrase)?;
-    let seed_vec = mnemonic.to_seed(password);
-    if seed_vec.len() != 64 {
-        return Err("Seed must be 64 bytes".to_string());
-    }
-    let mut seed = [0u8; 64];
-    seed.copy_from_slice(&seed_vec);
+    let seed = mnemonic.to_seed(password);
     let derivation_path = DerivationPath::from_str(derivation).map_err(|e| e.to_string())?;
     let xprv = XPrv::derive_from_path(seed, &derivation_path).map_err(|e| e.to_string())?;
     let secret_bytes = xprv.private_key().to_bytes();
@@ -389,9 +390,6 @@ mod tests {
     use super::*;
     use crate::precomputed::is_precomputed;
 
-    /// Serializes the tests that drive `DERIVED_KEYS` to its cap.
-    static CACHE_TESTS: Mutex<()> = Mutex::new(());
-
     #[test]
     fn test_mnemonic_from_phrase_12() {
         let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
@@ -507,21 +505,20 @@ mod tests {
     /// A full memo must keep working. The phrases that fill it are the
     /// unrepeatable random ones, so refusing new entries once full would let
     /// them crowd out wallets that are actually looked up again.
+    ///
+    /// Exercises `memoize` directly rather than deriving `CACHE_LIMIT` keys:
+    /// filling the map through the public entry point would cost over a
+    /// thousand PBKDF2 derivations, and eviction is a property of `memoize`.
     #[test]
     fn test_memo_still_caches_once_full() {
         const DERIVATION: &str = "m/44'/5757'/0'/0/7";
-        // The default harness runs tests as threads in one process, and this is
-        // the only test that pushes the map to its cap, where inserts start
-        // evicting. Hold the guard so it cannot evict a sibling's entry, or
-        // have its own evicted, mid-assertion. (`cargo tst` uses nextest, which
-        // gives each test its own process; plain `cargo test` does not.)
-        let _serialized = CACHE_TESTS.lock().unwrap_or_else(PoisonError::into_inner);
+        let keys = derive_bip32_keys(DEFAULT_DEPLOYER_MNEMONIC, "", DERIVATION).unwrap();
 
-        // Fill past the limit with phrases nothing will ask for again, the way
-        // an `[accounts.x]` table with no `mnemonic` does on every load.
-        for _ in 0..CACHE_LIMIT + 4 {
-            let throwaway = random_mnemonic().to_string();
-            get_bip32_keys_from_mnemonic(&throwaway, "", DERIVATION).unwrap();
+        for i in 0..CACHE_LIMIT + 4 {
+            memoize(
+                (format!("filler phrase {i}"), DERIVATION.to_string()),
+                &keys,
+            );
         }
         assert!(
             derived_keys().len() <= CACHE_LIMIT,
@@ -529,12 +526,14 @@ mod tests {
         );
 
         // A wallet first seen now must still land in the memo.
-        let phrase = random_mnemonic().to_string();
-        let first = get_bip32_keys_from_mnemonic(&phrase, "", DERIVATION).unwrap();
-        let key = (phrase.clone(), DERIVATION.to_string());
+        let key = (
+            "a phrase seen after the cap".to_string(),
+            DERIVATION.to_string(),
+        );
+        memoize(key.clone(), &keys);
         assert_eq!(
             derived_keys().get(&key),
-            Some(&first),
+            Some(&keys),
             "a wallet seen after the memo filled up was not cached"
         );
     }

--- a/components/clarinet-utils/src/precomputed.rs
+++ b/components/clarinet-utils/src/precomputed.rs
@@ -10,20 +10,64 @@
 //! `settings/Devnet.toml` along with the resulting secret keys, so baking the
 //! derived keys in exposes nothing new.
 //!
-//! The table is kept honest by tests rather than by discipline:
-//!   - [`tests::entries_match_live_derivation`] re-derives every entry
-//!   - `clarinet-files` asserts the devnet miner/faucet/stacker defaults hit it
-//!   - `clarinet-cli` asserts every account in a generated `Devnet.toml` hits it
+//! The phrases below are the single source of truth: `clarinet-files`
+//! re-exports the devnet ones and `clarinet-cli` interpolates the account ones
+//! into the `clarinet new` template, so a table entry cannot drift away from
+//! the mnemonic it describes. What tests still have to guard is the *hex* —
+//! see [`tests::entries_match_live_derivation`].
 //!
 //! To add an entry, put the phrase in with placeholder keys and run the
 //! clarinet-utils tests; the failure prints what the values should be.
 
 use libsecp256k1::PublicKey;
 
-/// Every mnemonic Clarinet ships is used at the default Stacks derivation
-/// path. A custom `derivation` in a manifest misses the table and is derived
-/// normally.
-const DERIVATION_PATH: &str = "m/44'/5757'/0'/0/0";
+use crate::DerivedKeys;
+
+/// Every mnemonic Clarinet ships is used at this path. A custom `derivation`
+/// in a manifest misses the table and is derived normally.
+///
+/// Re-exported by `clarinet-files`, which is where the rest of the workspace
+/// reads it from.
+pub const DEFAULT_DERIVATION_PATH: &str = "m/44'/5757'/0'/0/0";
+
+/// The accounts `clarinet new` writes into `settings/Devnet.toml`.
+/// `clarinet-cli` interpolates these into the generated manifest.
+pub const DEFAULT_DEPLOYER_MNEMONIC: &str = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw";
+pub const DEFAULT_WALLET_1_MNEMONIC: &str = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild";
+pub const DEFAULT_WALLET_2_MNEMONIC: &str = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital";
+pub const DEFAULT_WALLET_3_MNEMONIC: &str = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high";
+pub const DEFAULT_WALLET_4_MNEMONIC: &str = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin";
+pub const DEFAULT_WALLET_5_MNEMONIC: &str = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase";
+pub const DEFAULT_WALLET_6_MNEMONIC: &str = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy";
+pub const DEFAULT_WALLET_7_MNEMONIC: &str = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow";
+pub const DEFAULT_WALLET_8_MNEMONIC: &str = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune";
+
+/// Doubles as the `faucet` account of a generated project and as the devnet
+/// faucet the chains coordinator spends from.
+pub const DEFAULT_FAUCET_MNEMONIC: &str = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform";
+
+/// Devnet infrastructure wallets. These never appear in a generated
+/// `settings/Devnet.toml`; `clarinet-files` supplies them as defaults.
+pub const DEFAULT_STACKS_MINER_MNEMONIC: &str = "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce";
+pub const DEFAULT_STACKER_MNEMONIC: &str = "empty lens any direct brother then drop fury rule pole win claim scissors list rescue horn rent inform relief jump sword weekend half legend";
+
+/// Every phrase in the table, so tests can assert the two stay in step
+/// without the table itself being public.
+#[cfg(test)]
+const ALL_MNEMONICS: [&str; 12] = [
+    DEFAULT_DEPLOYER_MNEMONIC,
+    DEFAULT_WALLET_1_MNEMONIC,
+    DEFAULT_WALLET_2_MNEMONIC,
+    DEFAULT_WALLET_3_MNEMONIC,
+    DEFAULT_WALLET_4_MNEMONIC,
+    DEFAULT_WALLET_5_MNEMONIC,
+    DEFAULT_WALLET_6_MNEMONIC,
+    DEFAULT_WALLET_7_MNEMONIC,
+    DEFAULT_WALLET_8_MNEMONIC,
+    DEFAULT_FAUCET_MNEMONIC,
+    DEFAULT_STACKS_MINER_MNEMONIC,
+    DEFAULT_STACKER_MNEMONIC,
+];
 
 struct Entry {
     phrase: &'static str,
@@ -58,89 +102,77 @@ const fn hex<const N: usize>(s: &str) -> [u8; N] {
 }
 
 static ENTRIES: &[Entry] = &[
-    // deployer
     Entry {
-        phrase: "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw",
+        phrase: DEFAULT_DEPLOYER_MNEMONIC,
         secret_key: hex("753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a6"),
         public_key: hex("0490a5cac7c33fda49f70bc1b0866fa0ba7a9440d9de647fecb8132ceb76a94dfa80c44836f7a07cf96a13d3c2c7833a833ff59a3533b8369daa4949da39b09901"),
     },
-    // wallet_1
     Entry {
-        phrase: "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild",
+        phrase: DEFAULT_WALLET_1_MNEMONIC,
         secret_key: hex("7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c178"),
         public_key: hex("04cd2cfdbd2ad9332828a7a13ef62cb999e063421c708e863a7ffed71fb61c88c94df6c2a9ebb183ffe28dcb6d43f36e926041fa56df1237ffa648cc0d22ea3737"),
     },
-    // wallet_2
     Entry {
-        phrase: "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital",
+        phrase: DEFAULT_WALLET_2_MNEMONIC,
         secret_key: hex("530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc2091"),
         public_key: hex("041843d01fa0bb9a3495fd2caf92505a81055dbe1fd545880fd40c3a1c7fd9c40a89f441cf6ce7ed7e234e67d97613226993415af5aa0dd42f55807e7b128df9d8"),
     },
-    // wallet_3
     Entry {
-        phrase: "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high",
+        phrase: DEFAULT_WALLET_3_MNEMONIC,
         secret_key: hex("d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b39"),
         public_key: hex("04c4b5eacb71a27be633ed970dcbc41c00440364bc04ba38ae4683ac24e708bf334891b9ad5c5e9ee021e796102e40f7345e1b402ff69fb4f52e221b1dabad1968"),
     },
-    // wallet_4
     Entry {
-        phrase: "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin",
+        phrase: DEFAULT_WALLET_4_MNEMONIC,
         secret_key: hex("f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c7"),
         public_key: hex("04b3e0a76b292b2c83fc0ac14ae6160d0438ebe94e14bbb5b7755153628886e08ea5b60ea54a7fa77b069f5bc87f281b92ff2583d5e865312043b995115ef64727"),
     },
-    // wallet_5
     Entry {
-        phrase: "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase",
+        phrase: DEFAULT_WALLET_5_MNEMONIC,
         secret_key: hex("3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe8"),
         public_key: hex("049fa3c9b2c98acc46563707702ee633141b2c125b85649e11548a30233f97ed9f9a3153eb9bb1eda3a9931ea12216cf3c94ba54ffa426edbcd52e057f036f97dd"),
     },
-    // wallet_6
     Entry {
-        phrase: "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy",
+        phrase: DEFAULT_WALLET_6_MNEMONIC,
         secret_key: hex("7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb"),
         public_key: hex("048efa20fa5706567008ebaf48f7ae891342eeb944d96392f719c505c89f84ed8d36c32d5d9f728bbae80a35c7acb50a7b038d0e5d45c2e4669c15469db53eca08"),
     },
-    // wallet_7
     Entry {
-        phrase: "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow",
+        phrase: DEFAULT_WALLET_7_MNEMONIC,
         secret_key: hex("b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f14"),
         public_key: hex("043f19d77c842b675bd8c858e9ac8b0ca2efa566f17accf8ef9ceb5a992dc67836b95faf7956d718512b37bf67c0a6ee107206a2c980900142ce8b016110f90ffc"),
     },
-    // wallet_8
     Entry {
-        phrase: "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune",
+        phrase: DEFAULT_WALLET_8_MNEMONIC,
         secret_key: hex("6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e"),
         public_key: hex("049fb154a570a1645af3dd43c3c668a979b59d21a46dd717fd799b13be3b2a0dc79bd248ed760f07f0aa0719b4601950c95e4e1a35ddd855a398b12d3ae31dbd34"),
     },
-    // faucet — also `DEFAULT_FAUCET_MNEMONIC`
     Entry {
-        phrase: "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform",
+        phrase: DEFAULT_FAUCET_MNEMONIC,
         secret_key: hex("de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b8"),
         public_key: hex("04add319140c528a8955d76d4afe32c4d3143fea57ea353a31ce793cffb77ef8615cc09053489331377e2c637385f00cd5a1cafa54e4a083908d08dfae4f088d72"),
     },
-    // `DEFAULT_STACKS_MINER_MNEMONIC`
     Entry {
-        phrase: "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce",
+        phrase: DEFAULT_STACKS_MINER_MNEMONIC,
         secret_key: hex("3b68e410cc7f9b8bae76f2f2991b69ecd0627c95da22a904065dfb2a73d0585f"),
         public_key: hex("0439810ebf35e6f6c26062c99f3e183708d377720617c90a986859ec9c95d00be9e16af4fe2d857755f0dd691cecb3489a5c6e04889f0015ed0d39e8262fe36608"),
     },
-    // `DEFAULT_STACKER_MNEMONIC`
     Entry {
-        phrase: "empty lens any direct brother then drop fury rule pole win claim scissors list rescue horn rent inform relief jump sword weekend half legend",
+        phrase: DEFAULT_STACKER_MNEMONIC,
         secret_key: hex("e93b8341c35983ae5b8f93b9530bd90281fd5e5e00a5094c2b7863ace78eac62"),
         public_key: hex("044b9b194720f870d99c4f629b84626e0cdf1198b10b4dca7c4851771d72d07f8578333fcbdeec9de504890796e32741f397bed30fa4bb7451cf0d4a457cdcb8c7"),
     },
 ];
 
 fn find(phrase: &str, derivation: &str) -> Option<&'static Entry> {
-    if derivation != DERIVATION_PATH {
+    if derivation != DEFAULT_DERIVATION_PATH {
         return None;
     }
     ENTRIES.iter().find(|entry| entry.phrase == phrase)
 }
 
 /// The derived keys for a shipped mnemonic, or `None` if it isn't one.
-pub(crate) fn lookup(phrase: &str, derivation: &str) -> Option<(Vec<u8>, PublicKey)> {
+pub(crate) fn lookup(phrase: &str, derivation: &str) -> Option<DerivedKeys> {
     let entry = find(phrase, derivation)?;
     let public_key = PublicKey::parse(&entry.public_key)
         .expect("precomputed public key is not a valid secp256k1 point");
@@ -148,45 +180,77 @@ pub(crate) fn lookup(phrase: &str, derivation: &str) -> Option<(Vec<u8>, PublicK
 }
 
 /// Whether this mnemonic and path resolve from the table instead of being
-/// derived. Exposed so crates that own the shipped mnemonics can assert their
-/// defaults are covered.
-pub fn is_precomputed(phrase: &str, derivation: &str) -> bool {
+/// derived. Test-only on purpose: table membership exists for speed and may
+/// gain or lose entries for speed, so it must not become product behaviour.
+#[cfg(test)]
+pub(crate) fn is_precomputed(phrase: &str, derivation: &str) -> bool {
     find(phrase, derivation).is_some()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::derive_bip32_keys;
+    use crate::{derive_bip32_keys, mnemonic_from_phrase};
+
+    fn to_hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
 
     /// The table is only as good as its agreement with the real derivation.
     #[test]
     fn entries_match_live_derivation() {
         for entry in ENTRIES {
-            let (secret_key, public_key) = derive_bip32_keys(entry.phrase, "", DERIVATION_PATH)
-                .unwrap_or_else(|e| panic!("failed to derive {}: {e}", entry.phrase));
+            let (secret_key, public_key) =
+                derive_bip32_keys(entry.phrase, "", DEFAULT_DERIVATION_PATH)
+                    .unwrap_or_else(|e| panic!("failed to derive {}: {e}", entry.phrase));
 
-            let hex = |bytes: &[u8]| bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
             assert_eq!(
-                hex(&secret_key),
-                hex(&entry.secret_key),
+                to_hex(&secret_key),
+                to_hex(&entry.secret_key),
                 "stale secret_key for \"{}\"",
                 entry.phrase
             );
             assert_eq!(
-                hex(&public_key.serialize()),
-                hex(&entry.public_key),
+                to_hex(&public_key.serialize()),
+                to_hex(&entry.public_key),
                 "stale public_key for \"{}\"",
                 entry.phrase
             );
         }
     }
 
+    /// Sharing the phrase constants makes drift impossible in one direction
+    /// only: a new constant could still be declared and never added here.
+    #[test]
+    fn every_shipped_mnemonic_is_in_the_table() {
+        assert_eq!(ALL_MNEMONICS.len(), ENTRIES.len());
+        for mnemonic in ALL_MNEMONICS {
+            assert!(
+                is_precomputed(mnemonic, DEFAULT_DERIVATION_PATH),
+                "shipped mnemonic missing from the table: \"{mnemonic}\""
+            );
+        }
+    }
+
+    /// Callers look the table up with the *parsed* phrase — see
+    /// `compute_addresses`, which passes `mnemonic_from_phrase(..).to_string()`.
+    /// If a table phrase were not already in BIP39's canonical spelling, every
+    /// lookup for it would miss and the entry would be dead weight.
+    #[test]
+    fn table_phrases_are_canonically_spelled() {
+        for entry in ENTRIES {
+            let parsed = mnemonic_from_phrase(entry.phrase)
+                .unwrap_or_else(|e| panic!("invalid mnemonic in table: {e}"))
+                .to_string();
+            assert_eq!(parsed, entry.phrase, "table phrase is not canonical");
+        }
+    }
+
     #[test]
     fn lookup_is_scoped_to_the_default_derivation_path() {
         let phrase = ENTRIES[0].phrase;
-        assert!(is_precomputed(phrase, DERIVATION_PATH));
+        assert!(is_precomputed(phrase, DEFAULT_DERIVATION_PATH));
         assert!(!is_precomputed(phrase, "m/44'/5757'/0'/0/1"));
-        assert!(!is_precomputed("not a mnemonic", DERIVATION_PATH));
+        assert!(!is_precomputed("not a mnemonic", DEFAULT_DERIVATION_PATH));
     }
 }

--- a/components/clarinet-utils/src/precomputed.rs
+++ b/components/clarinet-utils/src/precomputed.rs
@@ -26,8 +26,8 @@ use crate::DerivedKeys;
 /// Every mnemonic Clarinet ships is used at this path. A custom `derivation`
 /// in a manifest misses the table and is derived normally.
 ///
-/// Re-exported by `clarinet-files`, which is where the rest of the workspace
-/// reads it from.
+/// Also re-exported by `clarinet-files` for consumers that already depend on
+/// it; both paths resolve to this constant.
 pub const DEFAULT_DERIVATION_PATH: &str = "m/44'/5757'/0'/0/0";
 
 /// The accounts `clarinet new` writes into `settings/Devnet.toml`.
@@ -51,23 +51,34 @@ pub const DEFAULT_FAUCET_MNEMONIC: &str = "shadow private easily thought say log
 pub const DEFAULT_STACKS_MINER_MNEMONIC: &str = "fragile loan twenty basic net assault jazz absorb diet talk art shock innocent float punch travel gadget embrace caught blossom hockey surround initial reduce";
 pub const DEFAULT_STACKER_MNEMONIC: &str = "empty lens any direct brother then drop fury rule pole win claim scissors list rescue horn rent inform relief jump sword weekend half legend";
 
-/// Every phrase in the table, so tests can assert the two stay in step
-/// without the table itself being public.
-#[cfg(test)]
-const ALL_MNEMONICS: [&str; 12] = [
-    DEFAULT_DEPLOYER_MNEMONIC,
-    DEFAULT_WALLET_1_MNEMONIC,
-    DEFAULT_WALLET_2_MNEMONIC,
-    DEFAULT_WALLET_3_MNEMONIC,
-    DEFAULT_WALLET_4_MNEMONIC,
-    DEFAULT_WALLET_5_MNEMONIC,
-    DEFAULT_WALLET_6_MNEMONIC,
-    DEFAULT_WALLET_7_MNEMONIC,
-    DEFAULT_WALLET_8_MNEMONIC,
-    DEFAULT_FAUCET_MNEMONIC,
-    DEFAULT_STACKS_MINER_MNEMONIC,
-    DEFAULT_STACKER_MNEMONIC,
+/// The accounts a generated `settings/Devnet.toml` declares, in order.
+///
+/// `clarinet-cli` interpolates the phrases into its template by name — inline
+/// format args need a plain identifier — and asserts against this list that it
+/// emitted exactly these accounts. Going through the list rather than a local
+/// copy is what makes an account added with an off-table phrase fail.
+pub const DEFAULT_DEVNET_ACCOUNTS: [(&str, &str); 10] = [
+    ("deployer", DEFAULT_DEPLOYER_MNEMONIC),
+    ("wallet_1", DEFAULT_WALLET_1_MNEMONIC),
+    ("wallet_2", DEFAULT_WALLET_2_MNEMONIC),
+    ("wallet_3", DEFAULT_WALLET_3_MNEMONIC),
+    ("wallet_4", DEFAULT_WALLET_4_MNEMONIC),
+    ("wallet_5", DEFAULT_WALLET_5_MNEMONIC),
+    ("wallet_6", DEFAULT_WALLET_6_MNEMONIC),
+    ("wallet_7", DEFAULT_WALLET_7_MNEMONIC),
+    ("wallet_8", DEFAULT_WALLET_8_MNEMONIC),
+    ("faucet", DEFAULT_FAUCET_MNEMONIC),
 ];
+
+/// Every phrase the workspace ships: the generated accounts plus the two
+/// devnet infrastructure wallets, which never appear in a manifest.
+#[cfg(test)]
+fn all_shipped_mnemonics() -> impl Iterator<Item = &'static str> {
+    DEFAULT_DEVNET_ACCOUNTS
+        .iter()
+        .map(|(_, mnemonic)| *mnemonic)
+        .chain([DEFAULT_STACKS_MINER_MNEMONIC, DEFAULT_STACKER_MNEMONIC])
+}
 
 struct Entry {
     phrase: &'static str,
@@ -219,12 +230,13 @@ mod tests {
         }
     }
 
-    /// Sharing the phrase constants makes drift impossible in one direction
-    /// only: a new constant could still be declared and never added here.
+    /// Every phrase the workspace ships must have baked keys, or it silently
+    /// costs a PBKDF2 derivation per session. Sharing the constants makes the
+    /// phrases themselves impossible to drift; this covers the table.
     #[test]
     fn every_shipped_mnemonic_is_in_the_table() {
-        assert_eq!(ALL_MNEMONICS.len(), ENTRIES.len());
-        for mnemonic in ALL_MNEMONICS {
+        assert_eq!(all_shipped_mnemonics().count(), ENTRIES.len());
+        for mnemonic in all_shipped_mnemonics() {
             assert!(
                 is_precomputed(mnemonic, DEFAULT_DERIVATION_PATH),
                 "shipped mnemonic missing from the table: \"{mnemonic}\""

--- a/components/clarity-lsp/Cargo.toml
+++ b/components/clarity-lsp/Cargo.toml
@@ -18,6 +18,7 @@ clarinet-deployments = { path = "../clarinet-deployments" }
 clarity-static-cost = { path = "../clarity-static-cost" }
 
 [dev-dependencies]
+clarinet-utils = { path = "../clarinet-utils" }
 divan = { workspace = true }
 indoc = { workspace = true }
 tokio = { workspace = true }

--- a/components/clarity-lsp/benches/ast_cache.rs
+++ b/components/clarity-lsp/benches/ast_cache.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 
 use clarinet_deployments::{generate_default_deployment_with_cache, CachedContractAST};
 use clarinet_files::{FileAccessor, FileAccessorResult, ProjectManifest, StacksNetwork};
+use clarinet_utils::DEFAULT_DEPLOYER_MNEMONIC;
 use clarity_repl::utils::Environment;
 use divan::Bencher;
 use indoc::{formatdoc, indoc};
@@ -127,16 +128,21 @@ const CONTRACT_FUNCTIONS: &str = indoc! {r#"
 /// lost in per-call fixed overhead.
 const FUNCTIONS_PER_CONTRACT: usize = 6;
 
-const DEVNET_TOML: &str = indoc! {r#"
-    [network]
-    name = "devnet"
-    deployment_fee_rate = 10
+/// The deployer wallet has precomputed keys in `clarinet-utils`; using the
+/// shared constant keeps it that way, so this bench keeps measuring the AST
+/// cache rather than an accidental PBKDF2 derivation.
+fn devnet_toml() -> String {
+    formatdoc! {r#"
+        [network]
+        name = "devnet"
+        deployment_fee_rate = 10
 
-    [accounts.deployer]
-    mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
-    balance = 100_000_000_000_000
-    sbtc_balance = 1_000_000_000
-"#};
+        [accounts.deployer]
+        mnemonic = "{DEFAULT_DEPLOYER_MNEMONIC}"
+        balance = 100_000_000_000_000
+        sbtc_balance = 1_000_000_000
+    "#}
+}
 
 fn build_manifest(n: usize) -> String {
     let mut out = String::from(indoc! {r#"
@@ -185,7 +191,7 @@ impl BenchFileAccessor {
     fn new(n: usize, modified_index: Option<usize>) -> Self {
         let mut files = HashMap::new();
         files.insert(MANIFEST_PATH.to_string(), build_manifest(n));
-        files.insert(DEVNET_PATH.to_string(), DEVNET_TOML.to_string());
+        files.insert(DEVNET_PATH.to_string(), devnet_toml());
         for i in 0..n {
             let salt = if Some(i) == modified_index {
                 "_modified"

--- a/components/clarity-lsp/src/common/backend.rs
+++ b/components/clarity-lsp/src/common/backend.rs
@@ -683,9 +683,10 @@ mod lsp_tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
+    use clarinet_utils::DEFAULT_DEPLOYER_MNEMONIC;
     use clarity::vm::ClarityVersion;
     use clarity_repl::utils::Environment;
-    use indoc::indoc;
+    use indoc::{formatdoc, indoc};
     use ls_types::{
         DocumentRangeFormattingParams, FormattingOptions, Position, Range, TextDocumentIdentifier,
         WorkDoneProgressParams,
@@ -820,17 +821,16 @@ mod lsp_tests {
             "#}
             .to_string();
 
-            let network_manifest = indoc! {r#"
+            let network_manifest = formatdoc! {r#"
                 [network]
                 name = "devnet"
                 deployment_fee_rate = 10
 
                 [accounts.deployer]
-                mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+                mnemonic = "{DEFAULT_DEPLOYER_MNEMONIC}"
                 balance = 100_000_000_000_000
                 sbtc_balance = 1_000_000_000
-            "#}
-            .to_string();
+            "#};
 
             Self {
                 project_manifest,


### PR DESCRIPTION
### Description

Stacked on #2531 — **review and merge that first**, this branch is based on it and the diff here is only the follow-up.

#2531 added a compile-time table of derived keys and a process-wide memo. Two things were left over, both surfaced by review rather than by the original task:

- **The shipped mnemonics and the derivation path were written out in several places**, reconciled only by tests: the `clarinet new` template, `DEFAULT_STACKS_MINER_MNEMONIC` / `DEFAULT_FAUCET_MNEMONIC` / `DEFAULT_STACKER_MNEMONIC`, the precomputed table, and the bench. One of those axes — the derivation path — had no test at all, so changing it would have turned every table lookup into a permanent silent miss. → All of it now has a single home in `clarinet-utils`, next to the table that bakes the keys. `clarinet-files` re-exports the devnet ones so its public API is unchanged, and the `clarinet new` template interpolates the account ones, finishing a pattern the same `formatdoc!` already used for the commented-out miner/faucet/stacker lines. Generated `Devnet.toml` is byte-identical — verified constant by constant against `main`.
- **The generated manifest documents each account's secret key and addresses in comments** that developers copy into tests, but those were literals that nothing verified. With the mnemonics now in another crate, they could drift silently. → The `clarinet-cli` test derives all three and compares.

Two fixes from the Copilot review on #2531 ride along, because both edit code this refactor rewrites:

- **A non-empty BIP39 passphrase would have been retained in plaintext** until process exit. The justification for retaining derived secrets — that `NetworkManifest` already holds the plaintext mnemonic for longer — covers the mnemonic but not a passphrase, which the manifest never holds. Passphrase-bearing derivations now return before either cache, so nothing about them is stored, which also drops the key from `(phrase, password, derivation)` to `(phrase, derivation)`. No hit rate is lost: every caller in the workspace passes `""`.
- **`DerivedKeys` was `pub(crate)` while appearing in the signature of a `pub fn`**, leaving downstream crates unable to name a type in an API they call. Now `pub`.

Net effect on the cache itself: unchanged behaviour, ~150 fewer lines of duplicated constants, and two drift axes that are now structurally impossible instead of test-guarded.

#### Breaking change?

No. `clarinet-files` re-exports every constant it previously defined, under the same names.

### Where the LSP ended up

These measure the two changes already merged — #2531 (this line of work) and #2539 (genesis sBTC) — not this PR's diff, which is a refactor with no perf effect. Recording them here since this is the last PR in the series and the two had only ever been measured apart.

`build_state`, which the LSP runs on every `ContractSaved` / `ManifestSaved`. 1-contract project, medians over 100 samples, Apple silicon:

| wallets | before (`724162e8`) | after (`main`) |
|---------|---------------------|----------------|
| 1       | 75.5 ms             | 74.1 ms        |
| 4       | 80.5 ms             | 74.1 ms        |
| 10      | **89.8 ms**         | **74.3 ms**    |

A default 10-wallet project saves **~15.5 ms on every save**, and the cost is now flat in wallet count — the slope fell from 1.59 ms/wallet to 0.02 ms/wallet, which is noise.

Re-running with `sbtc_balance = 0` separates the two:

| per-wallet cost      | before  | after |
|----------------------|---------|-------|
| key derivation       | 0.77 ms | ~0    |
| sBTC genesis credit  | 0.82 ms | ~0    |
| **total**            | **1.59 ms** | **~0** |

That also confirms two figures that were previously inferred rather than measured: the 0.95 ms/wallet originally attributed to the sBTC deposit shows up here as 0.82 ms measured independently, and the 0.77 ms/wallet derivation slope matches the ~0.8 ms `bip32.rs` reports for one uncached derivation — the LSP was paying full price once per wallet, per save.

What did **not** change is the ~74 ms floor: session setup, boot contract loading and contract analysis. Neither PR touches it, and it now dominates entirely. Anyone chasing LSP latency further should start there.

---

### Checklist

- [x] Tests added in this PR (if applicable)

The two cross-crate drift tests #2531 added become unnecessary — the constants are the same items now — and are replaced by in-crate ones, so `is_precomputed` is no longer public. New coverage: every shipped constant is in the table, the table phrases are canonically spelled (callers look up the *parsed* phrase), passphrase-bearing derivations are not memoized, and the generated manifest's documented addresses match their mnemonics. That last one I checked isn't vacuous by corrupting wallet_2's address and confirming it fails by name.

`cargo tst` 1075/1075, clippy clean on native and `wasm32-unknown-unknown`, `fmt-stacks --check` clean. Bench re-run: cache hits unchanged at ~63 ns (table) and ~70 ns (memo). The racy assertion above was verified specifically under the default parallel harness (`cargo test -p clarinet-utils --lib`), 5 consecutive runs, 19/19 — `cargo tst` uses nextest, which gives each test its own process and would have hidden it.

> [!NOTE]
> **CI does not run on this PR.** `ci.yaml` triggers on `pull_request: branches: [main]`, and this targets the perf branch, so no workflow fires. The verification above is local. CI will run once #2531 merges and GitHub retargets this to `main` — which also needs a rebase, since squash-merge means #2531's commit never lands in `main` by that SHA:
> ```
> git fetch origin
> git rebase --onto origin/main 36988bb5 refactor/shipped-mnemonics-single-home
> git push --force-with-lease origin refactor/shipped-mnemonics-single-home
> ```


